### PR TITLE
P-Extension PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.9] - 2021-12-20
+- Add CGFs for P extensions
+- Add support for P extension test generation
+
 ## [0.5.8] - 2021-10-21
 - Updated and added bitmanip_real_world.py script to generate test with real world patterns.
 

--- a/riscv_ctg/__init__.py
+++ b/riscv_ctg/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'incorebot@gmail.com'
-__version__ = '0.5.8'
+__version__ = '0.5.9'

--- a/riscv_ctg/ctg.py
+++ b/riscv_ctg/ctg.py
@@ -18,6 +18,7 @@ def create_test(usage_str, node,label,base_isa,max_inst):
     global ramdomize
     global out_dir
     global xlen
+
     flen = 0
     if 'opcode' not in node:
         return

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -5350,7 +5350,7 @@ ucmple8:
 # 3.1.7. 16-bit Multiply Instructions
 
 smul16:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -5375,7 +5375,7 @@ smul16:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smulx16:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -5400,7 +5400,7 @@ smulx16:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 umul16:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -5425,7 +5425,7 @@ umul16:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 umulx16:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -5500,7 +5500,7 @@ khmx16:
 # 3.1.8. 8-bit Multiply Instructions
 
 smul8:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -5533,7 +5533,7 @@ smul8:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smulx8:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -5566,7 +5566,7 @@ smulx8:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 umul8:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -5599,7 +5599,7 @@ umul8:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 umulx8:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7463,7 +7463,7 @@ kmsxda:
 # 3.2.5 Signed 16-bit Multiply with 64-bit Add/Subtract Instructions
 
 smal:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7724,7 +7724,7 @@ smaqa.su:
 # 3.3.1 64-bit Addition & Subtraction Instructions
 
 add64:
-  stride: 1
+  stride: 2
   xlen: [32]
   std_op:
   isa: IP
@@ -7744,7 +7744,7 @@ add64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 radd64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7764,7 +7764,7 @@ radd64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 uradd64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7784,7 +7784,7 @@ uradd64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 kadd64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7804,7 +7804,7 @@ kadd64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 ukadd64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7824,7 +7824,7 @@ ukadd64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 sub64:
-  stride: 1
+  stride: 2
   xlen: [32]
   std_op:
   isa: IP
@@ -7844,7 +7844,7 @@ sub64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 rsub64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7864,7 +7864,7 @@ rsub64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 ursub64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7884,7 +7884,7 @@ ursub64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 ksub64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7904,7 +7904,7 @@ ksub64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 uksub64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7926,7 +7926,7 @@ uksub64:
 # 3.2.2 32-bit Multiply with 64-bit Add/Subtract Instructions
 
 smar64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7948,7 +7948,7 @@ smar64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smsr64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7970,7 +7970,7 @@ smsr64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 umar64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -7992,7 +7992,7 @@ umar64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 umsr64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8014,7 +8014,7 @@ umsr64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 kmar64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8036,7 +8036,7 @@ kmar64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 kmsr64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8058,7 +8058,7 @@ kmsr64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 ukmar64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8080,7 +8080,7 @@ ukmar64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 ukmsr64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8105,7 +8105,7 @@ ukmsr64:
 # 3.3.3 Signed 16-bit Multiply with 64-bit Add/Subtract Instructions
 
 smalbb:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8131,7 +8131,7 @@ smalbb:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smalbt:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8157,7 +8157,7 @@ smalbt:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smaltt:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8183,7 +8183,7 @@ smaltt:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smalda:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8209,7 +8209,7 @@ smalda:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smalxda:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8235,7 +8235,7 @@ smalxda:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smalds:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8261,7 +8261,7 @@ smalds:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smaldrs:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8287,7 +8287,7 @@ smaldrs:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smalxds:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8313,7 +8313,7 @@ smalxds:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smslda:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8339,7 +8339,7 @@ smslda:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smslxda:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8941,7 +8941,7 @@ ursubw:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 mulr64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP
@@ -8963,7 +8963,7 @@ mulr64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 mulsr64:
-  stride: 1
+  stride: 2
   xlen: [32,64]
   std_op:
   isa: IP

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -8371,15 +8371,19 @@ kaddh:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
+  bit_width: 16
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -8392,15 +8396,19 @@ ksubh:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
+  bit_width: 16
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -8486,15 +8494,19 @@ ukaddh:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
+  bit_width: 16
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_usign_dataset(32)'
-  rs2_w0_val_data: 'gen_usign_dataset(32)'
-  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  rs1_h0_val_data: 'gen_usign_dataset(16)'
+  rs1_h1_val_data: 'gen_usign_dataset(16)'
+  rs1_h2_val_data: 'gen_usign_dataset(16)'
+  rs1_h3_val_data: 'gen_usign_dataset(16)'
+  rs2_h0_val_data: 'gen_usign_dataset(16)'
+  rs2_h1_val_data: 'gen_usign_dataset(16)'
+  rs2_h2_val_data: 'gen_usign_dataset(16)'
+  rs2_h3_val_data: 'gen_usign_dataset(16)'
   template: |-
 
     // $comment
@@ -8506,15 +8518,19 @@ uksubh:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
+  bit_width: 16
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_usign_dataset(32)'
-  rs2_w0_val_data: 'gen_usign_dataset(32)'
-  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  rs1_h0_val_data: 'gen_usign_dataset(16)'
+  rs1_h1_val_data: 'gen_usign_dataset(16)'
+  rs1_h2_val_data: 'gen_usign_dataset(16)'
+  rs1_h3_val_data: 'gen_usign_dataset(16)'
+  rs2_h0_val_data: 'gen_usign_dataset(16)'
+  rs2_h1_val_data: 'gen_usign_dataset(16)'
+  rs2_h2_val_data: 'gen_usign_dataset(16)'
+  rs2_h3_val_data: 'gen_usign_dataset(16)'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -3373,37 +3373,8 @@ packuw:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
-add8:
-  xlen: [32,64]
-  isa: IP
-  bit_width: 8
-  formattype: 'pbrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)' 
-  rs1_b1_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b2_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b3_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b4_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b5_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b6_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b7_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b1_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b2_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b3_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b4_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b5_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b6_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b7_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
 add16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3426,6 +3397,7 @@ add16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 radd16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3448,6 +3420,7 @@ radd16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 uradd16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3470,6 +3443,7 @@ uradd16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kadd16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3492,6 +3466,7 @@ kadd16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukadd16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3514,6 +3489,7 @@ ukadd16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 sub16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3537,6 +3513,7 @@ sub16:
 
 
 rsub16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3560,6 +3537,7 @@ rsub16:
 
 
 ursub16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3582,6 +3560,7 @@ ursub16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ksub16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3604,6 +3583,7 @@ ksub16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 uksub16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3626,6 +3606,7 @@ uksub16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 cras16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3648,6 +3629,7 @@ cras16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 rcras16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3671,6 +3653,7 @@ rcras16:
 
 
 urcras16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3693,6 +3676,7 @@ urcras16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kcras16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3715,6 +3699,7 @@ kcras16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukcras16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3737,6 +3722,7 @@ ukcras16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 crsa16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3759,6 +3745,7 @@ crsa16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 rcrsa16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3781,6 +3768,7 @@ rcrsa16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 urcrsa16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3803,6 +3791,7 @@ urcrsa16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kcrsa16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3825,6 +3814,7 @@ kcrsa16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukcrsa16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3847,6 +3837,7 @@ ukcrsa16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 stas16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3869,6 +3860,7 @@ stas16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 rstas16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3891,6 +3883,7 @@ rstas16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 urstas16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3913,6 +3906,7 @@ urstas16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kstas16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3935,6 +3929,7 @@ kstas16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukstas16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3957,6 +3952,7 @@ ukstas16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 stsa16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -3979,6 +3975,7 @@ stsa16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 rstsa16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4001,6 +3998,7 @@ rstsa16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 urstsa16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4023,6 +4021,7 @@ urstsa16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kstsa16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4045,6 +4044,7 @@ kstsa16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukstsa16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4066,7 +4066,10 @@ ukstsa16:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# 2.2.2. 8-bit Addition & Subtraction Instructions
+
 add8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4097,6 +4100,7 @@ add8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 radd8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4127,6 +4131,7 @@ radd8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 uradd8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4157,6 +4162,7 @@ uradd8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kadd8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4187,6 +4193,7 @@ kadd8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukadd8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4217,6 +4224,7 @@ ukadd8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 sub8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4247,6 +4255,7 @@ sub8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 rsub8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4276,7 +4285,40 @@ rsub8:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+ursub8:
+  stride: 1
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  rs2_b0_val_data: 'gen_usign_dataset(8)'
+  rs2_b1_val_data: 'gen_usign_dataset(8)'
+  rs2_b2_val_data: 'gen_usign_dataset(8)'
+  rs2_b3_val_data: 'gen_usign_dataset(8)'
+  rs2_b4_val_data: 'gen_usign_dataset(8)'
+  rs2_b5_val_data: 'gen_usign_dataset(8)'
+  rs2_b6_val_data: 'gen_usign_dataset(8)'
+  rs2_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
 usub8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4307,6 +4349,7 @@ usub8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ksub8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4337,6 +4380,7 @@ ksub8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 uksub8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4367,6 +4411,7 @@ uksub8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 sra16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4386,6 +4431,7 @@ sra16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 srai16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4404,6 +4450,7 @@ srai16:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 sra16.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4423,6 +4470,7 @@ sra16.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 srai16.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4441,6 +4489,7 @@ srai16.u:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 srl16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4460,6 +4509,7 @@ srl16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 srli16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4478,6 +4528,7 @@ srli16:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 srl16.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4497,6 +4548,7 @@ srl16.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 srli16.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4515,6 +4567,7 @@ srli16.u:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 sll16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4534,6 +4587,7 @@ sll16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 slli16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4552,6 +4606,7 @@ slli16:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 ksll16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4571,6 +4626,7 @@ ksll16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kslli16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4589,6 +4645,7 @@ kslli16:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 kslra16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4608,6 +4665,7 @@ kslra16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kslra16.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4627,6 +4685,7 @@ kslra16.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 sra8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4650,6 +4709,7 @@ sra8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 srai8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4672,6 +4732,7 @@ srai8:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 sra8.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4695,6 +4756,7 @@ sra8.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 srai8.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4717,6 +4779,7 @@ srai8.u:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 srl8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4740,6 +4803,7 @@ srl8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 srli8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4762,6 +4826,7 @@ srli8:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 srl8.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4784,7 +4849,8 @@ srl8.u:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
-srli8.u:
+srli8.u:  
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4807,6 +4873,7 @@ srli8.u:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 sll8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4830,6 +4897,7 @@ sll8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 slli8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4852,6 +4920,7 @@ slli8:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 ksll8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4875,6 +4944,7 @@ ksll8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kslli8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4897,6 +4967,7 @@ kslli8:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 kslra8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4920,6 +4991,7 @@ kslra8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kslra8.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -4943,6 +5015,7 @@ kslra8.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 cmpeq16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4965,6 +5038,7 @@ cmpeq16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 scmplt16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -4987,6 +5061,7 @@ scmplt16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 scmple16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5009,6 +5084,7 @@ scmple16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ucmplt16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5031,6 +5107,7 @@ ucmplt16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ucmple16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5053,6 +5130,7 @@ ucmple16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 cmpeq8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5083,6 +5161,7 @@ cmpeq8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 scmplt8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5113,6 +5192,7 @@ scmplt8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 scmple8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5143,6 +5223,7 @@ scmple8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ucmplt8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5173,6 +5254,7 @@ ucmplt8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ucmple8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5203,6 +5285,7 @@ ucmple8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smul16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5225,6 +5308,7 @@ smul16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smulx16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5247,6 +5331,7 @@ smulx16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umul16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5269,6 +5354,7 @@ umul16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umulx16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5291,6 +5377,7 @@ umulx16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 khm16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5313,6 +5400,7 @@ khm16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 khmx16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5335,6 +5423,7 @@ khmx16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smul8:
+  stride: 1  
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5365,6 +5454,7 @@ smul8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smulx8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5395,6 +5485,7 @@ smulx8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umul8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5425,6 +5516,7 @@ umul8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umulx8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5455,6 +5547,7 @@ umulx8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 khm8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5485,6 +5578,7 @@ khm8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 khmx8:
+  stride: 1  
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5515,6 +5609,7 @@ khmx8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smin16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5537,6 +5632,7 @@ smin16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umin16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5559,6 +5655,7 @@ umin16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smax16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5581,6 +5678,7 @@ smax16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umax16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5603,6 +5701,7 @@ umax16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 sclip16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5621,6 +5720,7 @@ sclip16:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 uclip16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5639,6 +5739,7 @@ uclip16:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 kabs16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5656,6 +5757,7 @@ kabs16:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clrs16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5673,6 +5775,7 @@ clrs16:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clz16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5690,6 +5793,7 @@ clz16:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clo16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5707,6 +5811,7 @@ clo16:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 swap16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -5724,6 +5829,7 @@ swap16:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 smin8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5754,6 +5860,7 @@ smin8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umin8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5784,6 +5891,7 @@ umin8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smax8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5814,6 +5922,7 @@ smax8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umax8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5844,6 +5953,7 @@ umax8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kabs8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5865,6 +5975,7 @@ kabs8:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 sclip8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5887,6 +5998,7 @@ sclip8:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 uclip8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5909,6 +6021,7 @@ uclip8:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 clrs8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5930,6 +6043,7 @@ clrs8:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clz8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5951,6 +6065,7 @@ clz8:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clo8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5972,6 +6087,7 @@ clo8:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 swap8:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -5993,6 +6109,7 @@ swap8:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 sunpkd810:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -6014,6 +6131,7 @@ sunpkd810:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 sunpkd820:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -6035,6 +6153,7 @@ sunpkd820:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 sunpkd830:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -6056,6 +6175,7 @@ sunpkd830:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 sunpkd831:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -6077,6 +6197,7 @@ sunpkd831:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 sunpkd832:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -6098,6 +6219,7 @@ sunpkd832:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 zunpkd810:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -6119,6 +6241,7 @@ zunpkd810:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 zunpkd820:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -6140,6 +6263,7 @@ zunpkd820:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 zunpkd830:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -6161,6 +6285,7 @@ zunpkd830:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 zunpkd831:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -6182,6 +6307,7 @@ zunpkd831:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 zunpkd832:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -6205,6 +6331,7 @@ zunpkd832:
 # 2.3 Partial-SIMD Data Processing Instructions
 
 pkbb16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6227,6 +6354,7 @@ pkbb16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 pkbt16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6249,6 +6377,7 @@ pkbt16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 pktb16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6271,6 +6400,7 @@ pktb16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 pktt16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6293,6 +6423,7 @@ pktt16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 # 2.3.2 Most Significant Word 32x32 Multiply & Add Instructions
 smmul:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -6311,6 +6442,7 @@ smmul:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smmul.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -6329,6 +6461,7 @@ smmul.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmac:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -6347,6 +6480,7 @@ kmmac:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmac.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -6365,6 +6499,7 @@ kmmac.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmsb:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -6383,6 +6518,7 @@ kmmsb:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmsb.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -6401,6 +6537,7 @@ kmmsb.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kwmmul:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -6419,6 +6556,7 @@ kwmmul:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kwmmul.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -6439,6 +6577,7 @@ kwmmul.u:
 
 # 2.3.3 Most Significant Word 32x32 Multiply & Add Instructions
 smmwb:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6461,6 +6600,7 @@ smmwb:
 
 
 smmwb.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6481,6 +6621,7 @@ smmwb.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smmwt:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6501,6 +6642,7 @@ smmwt:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smmwt.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6522,6 +6664,7 @@ smmwt.u:
 
 
 kmmawb:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6542,6 +6685,7 @@ kmmawb:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmawb.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6562,6 +6706,7 @@ kmmawb.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmawt:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6582,6 +6727,7 @@ kmmawt:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmawt.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6602,6 +6748,7 @@ kmmawt.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmwb2:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6623,6 +6770,7 @@ kmmwb2:
 
 
 kmmwb2.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6643,6 +6791,7 @@ kmmwb2.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmwt2:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6663,6 +6812,7 @@ kmmwt2:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmwt2.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6684,6 +6834,7 @@ kmmwt2.u:
 
 
 kmmawb2:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6704,6 +6855,7 @@ kmmawb2:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmawb2.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6724,6 +6876,7 @@ kmmawb2.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmawt2:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6744,6 +6897,7 @@ kmmawt2:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmmawt2.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32, 16
@@ -6767,6 +6921,7 @@ kmmawt2.u:
 # 2.3.4 Signed 16-bit Multiply with 32-bit Add/Subtract Instructions
 
 smbb16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6789,6 +6944,7 @@ smbb16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smbt16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6811,6 +6967,7 @@ smbt16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smtt16:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6833,6 +6990,7 @@ smtt16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmda:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6855,6 +7013,7 @@ kmda:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmxda:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6877,6 +7036,7 @@ kmxda:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smds:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6900,6 +7060,7 @@ smds:
 
 
 smdrs:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6922,6 +7083,7 @@ smdrs:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smxds:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6944,6 +7106,7 @@ smxds:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmabb:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6966,6 +7129,7 @@ kmabb:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmabt:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -6988,6 +7152,7 @@ kmabt:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmatt:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -7010,6 +7175,7 @@ kmatt:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmada:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -7032,6 +7198,7 @@ kmada:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmaxda:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -7054,6 +7221,7 @@ kmaxda:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmads:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -7076,6 +7244,7 @@ kmads:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmadrs:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -7098,6 +7267,7 @@ kmadrs:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmaxds:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -7120,6 +7290,7 @@ kmaxds:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmsda:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -7142,6 +7313,7 @@ kmsda:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmsxda:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -7166,11 +7338,12 @@ kmsxda:
 # 2.3.5 Signed 16-bit Multiply with 64-bit Add/Subtract Instructions
 
 smal:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
   p64_profile: 'ppn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *all_regs
 
@@ -7188,6 +7361,7 @@ smal:
 # 2.3.6 Miscellaneous Instructions
 
 sclip32:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -7204,6 +7378,7 @@ sclip32:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 uclip32:
+  stride: 1  
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -7220,6 +7395,7 @@ uclip32:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 clrs32:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -7235,6 +7411,7 @@ clrs32:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clz32:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -7250,6 +7427,7 @@ clz32:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clo32:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -7265,6 +7443,7 @@ clo32:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 pbsad:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -7295,6 +7474,7 @@ pbsad:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 pbsada:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -7325,6 +7505,7 @@ pbsada:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smaqa:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -7355,6 +7536,7 @@ smaqa:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umaqa:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -7385,6 +7567,7 @@ umaqa:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smaqa.su:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 8
@@ -7416,11 +7599,31 @@ smaqa.su:
 
 # 2.4.1 64-bit Addition & Subtraction Instructions
 add64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
-  formattype: 'rformat'
+  formattype: 'prrformat'
+  rs1_op_data: *pair_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+
+radd64:
+  stride: 1
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'ppp'
+  formattype: 'prrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
@@ -7434,11 +7637,12 @@ add64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 uradd64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
@@ -7452,11 +7656,12 @@ uradd64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 kadd64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
@@ -7470,11 +7675,12 @@ kadd64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 ukadd64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
@@ -7488,11 +7694,12 @@ ukadd64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 sub64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
@@ -7506,11 +7713,12 @@ sub64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 rsub64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
@@ -7524,11 +7732,12 @@ rsub64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 ursub64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
@@ -7542,11 +7751,12 @@ ursub64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 ksub64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
@@ -7560,11 +7770,12 @@ ksub64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 uksub64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
@@ -7579,11 +7790,12 @@ uksub64:
 
 # 2.4.2 32-bit Multiply with 64-bit Add/Subtract Instructions
 smar64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7597,11 +7809,12 @@ smar64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smsr64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7615,11 +7828,12 @@ smsr64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umar64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7633,11 +7847,12 @@ umar64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umsr64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7651,11 +7866,12 @@ umsr64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmar64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7669,11 +7885,12 @@ kmar64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmsr64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7687,11 +7904,12 @@ kmsr64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukmar64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7705,11 +7923,12 @@ ukmar64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukmsr64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7725,11 +7944,12 @@ ukmsr64:
 
 # 2.4.3 Signed 16-bit Multiply with 64-bit Add/Subtract Instructions
 smalbb:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7743,11 +7963,12 @@ smalbb:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smalbt:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7761,11 +7982,12 @@ smalbt:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smaltt:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7779,11 +8001,12 @@ smaltt:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smalda:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7797,11 +8020,12 @@ smalda:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smalxda:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7815,11 +8039,12 @@ smalxda:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smalds:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7833,11 +8058,12 @@ smalds:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smaldrs:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7851,11 +8077,12 @@ smaldrs:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smalxds:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7869,11 +8096,12 @@ smalxds:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smslda:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7887,11 +8115,12 @@ smslda:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smslxda:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -7907,6 +8136,7 @@ smslxda:
 # 2.5. Non-SIMD Instructions
 
 kaddh:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -7926,6 +8156,7 @@ kaddh:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ksubh:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -7945,6 +8176,7 @@ ksubh:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 khmbb:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -7968,6 +8200,7 @@ khmbb:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 khmbt:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -7990,6 +8223,7 @@ khmbt:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 khmtt:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -8012,6 +8246,7 @@ khmtt:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukaddh:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8030,6 +8265,7 @@ ukaddh:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 uksubh:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8047,7 +8283,9 @@ uksubh:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# 2.5.2 Q31 saturation Instructions
 kaddw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8066,6 +8304,7 @@ kaddw:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukaddw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8084,6 +8323,7 @@ ukaddw:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ksubw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8101,7 +8341,8 @@ ksubw:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
-usubw:
+uksubw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8120,6 +8361,7 @@ usubw:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kdmbb:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -8142,6 +8384,7 @@ kdmbb:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kdmbt:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -8164,6 +8407,7 @@ kdmbt:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kdmtt:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -8186,6 +8430,7 @@ kdmtt:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kslraw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8204,6 +8449,7 @@ kslraw:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kslraw.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8222,6 +8468,7 @@ kslraw.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ksllw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8239,6 +8486,7 @@ ksllw:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kslliw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8256,6 +8504,7 @@ kslliw:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 kdmabb:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -8278,6 +8527,7 @@ kdmabb:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kdmabt:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -8300,6 +8550,7 @@ kdmabt:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kdmatt:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 16
@@ -8322,6 +8573,7 @@ kdmatt:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kabsw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8339,6 +8591,7 @@ kabsw:
 # 2.5.3. 32-bit Computation Instructions
 
 raddw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8355,6 +8608,7 @@ raddw:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 uraddw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8371,6 +8625,7 @@ uraddw:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 rsubw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8387,6 +8642,7 @@ rsubw:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ursubw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8403,6 +8659,7 @@ ursubw:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 maxw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8419,6 +8676,7 @@ maxw:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 minw:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8435,6 +8693,7 @@ minw:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 msubr32:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8451,17 +8710,18 @@ msubr32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 mulr64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
   rs1_val_data: 'gen_sign_dataset(xlen)'
   rs2_val_data: 'gen_sign_dataset(xlen)'
-  
+
   template: |-
 
     // $comment
@@ -8469,11 +8729,12 @@ mulr64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 mulsr64:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
   p64_profile: 'pnn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
@@ -8486,11 +8747,39 @@ mulsr64:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# 2.5.4
+rdov:
+  stride: 1
+  rd_op_data: *all_regs
+  xlen: [32,64]
+  isa: IP
+  formattype: 'uformat'
+  imm_val_data: 'gen_usign_dataset(2)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; dest:$rd
+    TEST_CASE($testreg, $rd, $correctval, $swreg, $offset, $inst $rd)
+
+clrov:
+  stride: 1
+  rd_op_data: *all_regs
+  xlen: [32,64]
+  isa: IP
+  formattype: 'uformat'
+  imm_val_data: 'gen_usign_dataset(2)'
+  template: |-
+
+    // $comment
+    // opcode: $inst
+    TEST_CASE($testreg, $correctval, $swreg, $offset, $inst)
+
 
 
 # 2.5.5. Miscellaneous Instructions
 
 ave:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8503,10 +8792,11 @@ ave:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 sra.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8519,18 +8809,20 @@ sra.u:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 srai.u:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
   formattype: 'iformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  rs1_val_data: 'gen_sign_dataset(xlen)'
   imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
+
   template: |-
 
     // $comment
@@ -8538,6 +8830,7 @@ srai.u:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 bitrev:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8550,17 +8843,18 @@ bitrev:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 bitrevi:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
   formattype: 'iformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  rs1_val_data: 'gen_sign_dataset(xlen)'
   imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
   template: |-
 
@@ -8570,11 +8864,12 @@ bitrevi:
 
 
 wext:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
   p64_profile: 'npn'
-  formattype: 'rformat'
+  formattype: 'prrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
@@ -8588,6 +8883,7 @@ wext:
     TEST_P64_NPN_OP($inst, $rd, $rs1, $rs1_hi, $rs2, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $swreg, $offset, $testreg)
 
 wexti:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 64
@@ -8607,6 +8903,7 @@ wexti:
 
 
 bpick:
+  stride: 1
   xlen: [32,64]
   isa: IP
   formattype: 'prrrformat'
@@ -8624,10 +8921,11 @@ bpick:
     TEST_RRR_OP($inst, $rd, $rs1, $rs2, $rs3, $correctval, $rs1_val, $rs2_val, $rs3_val, $swreg, $offset, $testreg)
 
 insb:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
-  formattype: 'pwriformat'
+  formattype: 'iformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_val_data: 'gen_sign_dataset(xlen)'
@@ -8640,6 +8938,7 @@ insb:
 
 
 maddr32:
+  stride: 1
   xlen: [32,64]
   isa: IP
   bit_width: 32
@@ -8656,32 +8955,10 @@ maddr32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 
-# 2.5.4
-rdov:
-  rd_op_data: *all_regs
-  xlen: [32,64]
-  isa: IP
-  formattype: 'uformat'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; dest:$rd
-    TEST_CASE($testreg, $rd, $correctval, $swreg, $offset, $inst $rd)
-
-clrov:
-  rd_op_data: *all_regs
-  xlen: [32,64]
-  isa: IP
-  formattype: 'uformat'
-  template: |-
-
-    // $comment
-    // opcode: $inst
-    TEST_CASE($testreg, $correctval, $swreg, $offset, $inst)
-
 # 2.6. RV64 Only Instructions
 
 add32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8700,6 +8977,7 @@ add32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 radd32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8718,6 +8996,7 @@ radd32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 uradd32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8736,6 +9015,7 @@ uradd32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kadd32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8754,6 +9034,7 @@ kadd32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukadd32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8772,6 +9053,7 @@ ukadd32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 sub32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8790,6 +9072,7 @@ sub32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmda32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8808,6 +9091,7 @@ kmda32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmxda32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8826,6 +9110,7 @@ kmxda32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmada32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8844,6 +9129,7 @@ kmada32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmaxda32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8862,6 +9148,7 @@ kmaxda32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmads32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8880,6 +9167,7 @@ kmads32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmadrs32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8898,6 +9186,7 @@ kmadrs32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmaxds32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8916,6 +9205,7 @@ kmaxds32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmsda32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8934,6 +9224,7 @@ kmsda32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmsxda32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8952,6 +9243,7 @@ kmsxda32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smds32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8970,6 +9262,7 @@ smds32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smdrs32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -8988,6 +9281,7 @@ smdrs32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smxds32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9006,6 +9300,7 @@ smxds32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 sraiw.u:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9023,6 +9318,7 @@ sraiw.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 pkbb32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9041,6 +9337,7 @@ pkbb32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 pkbt32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9059,6 +9356,7 @@ pkbt32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 pktb32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9078,6 +9376,7 @@ pktb32:
 
 
 pktt32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9097,6 +9396,7 @@ pktt32:
 
 
 rsub32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9116,6 +9416,7 @@ rsub32:
 
 
 ursub32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9134,6 +9435,7 @@ ursub32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ksub32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9152,6 +9454,7 @@ ksub32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 uksub32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9170,6 +9473,7 @@ uksub32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 cras32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9188,6 +9492,7 @@ cras32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 rcras32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9207,6 +9512,7 @@ rcras32:
 
 
 urcras32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9225,6 +9531,7 @@ urcras32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kcras32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9243,6 +9550,7 @@ kcras32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukcras32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9261,6 +9569,7 @@ ukcras32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 crsa32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9279,6 +9588,7 @@ crsa32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 rcrsa32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9297,6 +9607,7 @@ rcrsa32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 urcrsa32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9315,6 +9626,7 @@ urcrsa32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kcrsa32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9333,6 +9645,7 @@ kcrsa32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukcrsa32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9351,6 +9664,7 @@ ukcrsa32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 stas32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9369,6 +9683,7 @@ stas32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 rstas32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9387,6 +9702,7 @@ rstas32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 urstas32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9405,6 +9721,7 @@ urstas32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kstas32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9423,6 +9740,7 @@ kstas32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukstas32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9441,6 +9759,7 @@ ukstas32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 stsa32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9459,6 +9778,7 @@ stsa32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 rstsa32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9477,6 +9797,7 @@ rstsa32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 urstsa32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9495,6 +9816,7 @@ urstsa32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kstsa32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9513,6 +9835,7 @@ kstsa32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukstsa32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9531,6 +9854,7 @@ ukstsa32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 sra32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9548,6 +9872,7 @@ sra32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 srai32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9564,6 +9889,7 @@ srai32:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 sra32.u:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9581,6 +9907,7 @@ sra32.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 srai32.u:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9597,6 +9924,7 @@ srai32.u:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 srl32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9614,6 +9942,7 @@ srl32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 srli32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9630,6 +9959,7 @@ srli32:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 srl32.u:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9647,6 +9977,7 @@ srl32.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 srli32.u:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9663,6 +9994,7 @@ srli32.u:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 sll32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9680,6 +10012,7 @@ sll32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 slli32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9696,6 +10029,7 @@ slli32:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 ksll32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9713,6 +10047,7 @@ ksll32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kslli32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9729,6 +10064,7 @@ kslli32:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 kslra32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9746,6 +10082,7 @@ kslra32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kslra32.u:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9763,6 +10100,7 @@ kslra32.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smin32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9781,6 +10119,7 @@ smin32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umin32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9799,6 +10138,7 @@ umin32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smax32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9817,6 +10157,7 @@ smax32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umax32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9835,6 +10176,7 @@ umax32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kabs32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -9850,6 +10192,7 @@ kabs32:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 khmbb16:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 16
@@ -9872,6 +10215,7 @@ khmbb16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 khmbt16:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 16
@@ -9894,6 +10238,7 @@ khmbt16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 khmtt16:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 16
@@ -9916,6 +10261,7 @@ khmtt16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kdmbb16:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 16
@@ -9938,6 +10284,7 @@ kdmbb16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kdmbt16:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 16
@@ -9960,6 +10307,7 @@ kdmbt16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kdmtt16:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 16
@@ -9982,6 +10330,7 @@ kdmtt16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kdmabb16:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 16
@@ -10004,6 +10353,7 @@ kdmabb16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kdmabt16:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 16
@@ -10026,6 +10376,7 @@ kdmabt16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kdmatt16:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 16
@@ -10048,6 +10399,7 @@ kdmatt16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smbb32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -10066,6 +10418,7 @@ smbb32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smbt32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -10084,6 +10437,7 @@ smbt32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smtt32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -10102,6 +10456,7 @@ smtt32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmabb32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -10120,6 +10475,7 @@ kmabb32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmabt32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32
@@ -10138,6 +10494,7 @@ kmabt32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmatt32:
+  stride: 1
   xlen: [64]
   isa: IP
   bit_width: 32

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -4361,38 +4361,6 @@ ursub8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 
-usub8:
-  stride: 1
-  xlen: [32,64]
-  std_op:
-  isa: IP
-  bit_width: 8
-  formattype: 'pbrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)'
-  rs1_b1_val_data: 'gen_usign_dataset(8)'
-  rs1_b2_val_data: 'gen_usign_dataset(8)'
-  rs1_b3_val_data: 'gen_usign_dataset(8)'
-  rs1_b4_val_data: 'gen_usign_dataset(8)'
-  rs1_b5_val_data: 'gen_usign_dataset(8)'
-  rs1_b6_val_data: 'gen_usign_dataset(8)'
-  rs1_b7_val_data: 'gen_usign_dataset(8)'
-  rs2_b0_val_data: 'gen_usign_dataset(8)'
-  rs2_b1_val_data: 'gen_usign_dataset(8)'
-  rs2_b2_val_data: 'gen_usign_dataset(8)'
-  rs2_b3_val_data: 'gen_usign_dataset(8)'
-  rs2_b4_val_data: 'gen_usign_dataset(8)'
-  rs2_b5_val_data: 'gen_usign_dataset(8)'
-  rs2_b6_val_data: 'gen_usign_dataset(8)'
-  rs2_b7_val_data: 'gen_usign_dataset(8)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
 ksub8:
   stride: 1
   xlen: [32,64]
@@ -7527,13 +7495,16 @@ smal:
   isa: IP
   bit_width: 16
   p64_profile: 'ppn'
-  formattype: 'prrformat'
+  formattype: 'pphrrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *all_regs
 
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(64)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -7803,8 +7774,8 @@ add64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(64)'
+  rs2_val_data: 'gen_sign_dataset(64)'
 
   template: |-
 
@@ -7823,8 +7794,8 @@ radd64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(64)'
+  rs2_val_data: 'gen_sign_dataset(64)'
 
   template: |-
 
@@ -7843,8 +7814,8 @@ uradd64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_usign_dataset(xlen)'
-  rs2_val_data: 'gen_usign_dataset(xlen)'
+  rs1_val_data: 'gen_usign_dataset(64)'
+  rs2_val_data: 'gen_usign_dataset(64)'
 
   template: |-
 
@@ -7863,8 +7834,8 @@ kadd64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(64)'
+  rs2_val_data: 'gen_sign_dataset(64)'
 
   template: |-
 
@@ -7883,8 +7854,8 @@ ukadd64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_usign_dataset(xlen)'
-  rs2_val_data: 'gen_usign_dataset(xlen)'
+  rs1_val_data: 'gen_usign_dataset(64)'
+  rs2_val_data: 'gen_usign_dataset(64)'
 
   template: |-
 
@@ -7903,8 +7874,8 @@ sub64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(64)'
+  rs2_val_data: 'gen_sign_dataset(64)'
 
   template: |-
 
@@ -7923,8 +7894,8 @@ rsub64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(64)'
+  rs2_val_data: 'gen_sign_dataset(64)'
 
   template: |-
 
@@ -7943,8 +7914,8 @@ ursub64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_usign_dataset(xlen)'
-  rs2_val_data: 'gen_usign_dataset(xlen)'
+  rs1_val_data: 'gen_usign_dataset(64)'
+  rs2_val_data: 'gen_usign_dataset(64)'
 
   template: |-
 
@@ -7963,8 +7934,8 @@ ksub64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(64)'
+  rs2_val_data: 'gen_sign_dataset(64)'
 
   template: |-
 
@@ -7983,8 +7954,8 @@ uksub64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_usign_dataset(xlen)'
-  rs2_val_data: 'gen_usign_dataset(xlen)'
+  rs1_val_data: 'gen_usign_dataset(64)'
+  rs2_val_data: 'gen_usign_dataset(64)'
 
   template: |-
 
@@ -7998,14 +7969,16 @@ smar64:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 32
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'pwrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
 
   template: |-
 
@@ -8018,14 +7991,16 @@ smsr64:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 32
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'pwrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
 
   template: |-
 
@@ -8038,14 +8013,16 @@ umar64:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 32
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'pwrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_usign_dataset(xlen)'
-  rs2_val_data: 'gen_usign_dataset(xlen)'
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
 
   template: |-
 
@@ -8058,14 +8035,16 @@ umsr64:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 32
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'pwrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_usign_dataset(xlen)'
-  rs2_val_data: 'gen_usign_dataset(xlen)'
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
 
   template: |-
 
@@ -8078,14 +8057,16 @@ kmar64:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 32
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'pwrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
 
   template: |-
 
@@ -8098,14 +8079,16 @@ kmsr64:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 32
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'pwrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
 
   template: |-
 
@@ -8118,14 +8101,16 @@ ukmar64:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 32
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'pwrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_usign_dataset(xlen)'
-  rs2_val_data: 'gen_usign_dataset(xlen)'
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
 
   template: |-
 
@@ -8138,14 +8123,16 @@ ukmsr64:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 32
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'pwrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_usign_dataset(xlen)'
-  rs2_val_data: 'gen_usign_dataset(xlen)'
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
 
   template: |-
 
@@ -8160,14 +8147,20 @@ smalbb:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 16
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -8180,14 +8173,20 @@ smalbt:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 16
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -8200,14 +8199,20 @@ smaltt:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 16
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -8220,14 +8225,20 @@ smalda:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 16
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -8240,14 +8251,20 @@ smalxda:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 16
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -8260,14 +8277,20 @@ smalds:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 16
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -8280,14 +8303,20 @@ smaldrs:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 16
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -8300,14 +8329,20 @@ smalxds:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 16
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -8320,14 +8355,20 @@ smslda:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 16
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -8340,14 +8381,20 @@ smslxda:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 16
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
 
   template: |-
 
@@ -8845,7 +8892,9 @@ raddw:
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
   rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
   template: |-
 
     // $comment
@@ -8863,7 +8912,9 @@ uraddw:
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
   rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
   template: |-
 
     // $comment
@@ -8881,7 +8932,9 @@ rsubw:
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
   rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
   template: |-
 
     // $comment
@@ -8899,43 +8952,9 @@ ursubw:
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
   rs2_w0_val_data: 'gen_usign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-maxw:
-  stride: 1
-  xlen: [32,64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-minw:
-  stride: 1
-  xlen: [32,64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
   template: |-
 
     // $comment
@@ -8953,7 +8972,9 @@ msubr32:
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
   rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
   template: |-
 
     // $comment
@@ -8967,12 +8988,14 @@ mulr64:
   isa: IP
   bit_width: 32
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'pwrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
 
   template: |-
 
@@ -8987,12 +9010,14 @@ mulsr64:
   isa: IP
   bit_width: 32
   p64_profile: 'pnn'
-  formattype: 'prrformat'
+  formattype: 'pwrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
 
   template: |-
 
@@ -9128,14 +9153,21 @@ wext:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 64
+  bit_width: 64, 8
   p64_profile: 'npn'
-  formattype: 'prrformat'
+  formattype: 'ppbrrformat'
   rs1_op_data: *pair_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(64)'
+  rs2_b0_val_data: 'gen_usign_dataset(8)'
+  rs2_b1_val_data: 'gen_usign_dataset(8)'
+  rs2_b2_val_data: 'gen_usign_dataset(8)'
+  rs2_b3_val_data: 'gen_usign_dataset(8)'
+  rs2_b4_val_data: 'gen_usign_dataset(8)'
+  rs2_b5_val_data: 'gen_usign_dataset(8)'
+  rs2_b6_val_data: 'gen_usign_dataset(8)'
+  rs2_b7_val_data: 'gen_usign_dataset(8)'
 
   template: |-
 
@@ -9153,7 +9185,7 @@ wexti:
   formattype: 'iformat'
   rs1_op_data: *pair_regs
   rd_op_data: *all_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(64)'
   imm_val_data: 'gen_imm_dataset(ceil(log(32,2)))'
 
   template: |-
@@ -9164,31 +9196,11 @@ wexti:
 
 
 
-bpick:
-  stride: 1
-  xlen: [32,64]
-  std_op:
-  isa: IP
-  formattype: 'prrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rs3_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
-  rs3_val_data: 'gen_sign_dataset(xlen)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; op3:$rs3; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val op3val:$rs3_val
-    TEST_RRR_OP($inst, $rd, $rs1, $rs2, $rs3, $correctval, $rs1_val, $rs2_val, $rs3_val, $swreg, $offset, $testreg)
-
 insb:
   stride: 1
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 32
   formattype: 'iformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
@@ -9212,7 +9224,9 @@ maddr32:
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
   rs2_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -6429,3 +6429,292 @@ uksubh:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+kaddw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ukaddw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ksubw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+usubw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kdmbb:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kdmbt:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kdmtt:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kslraw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kslraw.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ksllw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pswrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_val_data: 'gen_usign_dataset(ceil(log(32,2)))'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kslliw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwriformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  imm_val_data: 'gen_imm_dataset(5)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+kdmabb:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kdmabt:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kdmatt:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kabsw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -7467,7 +7467,7 @@ smal:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 16
+  bit_width: 64,16
   p64_profile: 'ppn'
   formattype: 'pphrrformat'
   rs1_op_data: *pair_regs

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -7782,3 +7782,57 @@ kdmatt16:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+smbb32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smbt32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smtt32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -6291,6 +6291,8 @@ pktt16:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# 2.5. Non-SIMD Instructions
+
 kaddh:
   xlen: [32,64]
   isa: IP
@@ -6718,3 +6720,547 @@ kabsw:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
+# 2.6. RV64 Only Instructions
+
+add32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+radd32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+uradd32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kadd32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ukadd32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+sub32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+rsub32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+ursub32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ksub32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+uksub32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+cras32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+rcras32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+urcras32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kcras32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ukcras32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+crsa32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+rcrsa32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+urcrsa32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kcrsa32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ukcrsa32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+stas32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+rstas32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+urstas32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kstas32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ukstas32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+stsa32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+rstsa32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+urstsa32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kstsa32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ukstsa32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -6252,3 +6252,141 @@ pktt16:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+kaddh:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ksubh:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+khmbb:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+khmbt:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+khmtt:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ukaddh:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+uksubh:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -5685,6 +5685,147 @@ swap16:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
+smin8:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  rs2_b0_val_data: 'gen_sign_dataset(8)'
+  rs2_b1_val_data: 'gen_sign_dataset(8)'
+  rs2_b2_val_data: 'gen_sign_dataset(8)'
+  rs2_b3_val_data: 'gen_sign_dataset(8)'
+  rs2_b4_val_data: 'gen_sign_dataset(8)'
+  rs2_b5_val_data: 'gen_sign_dataset(8)'
+  rs2_b6_val_data: 'gen_sign_dataset(8)'
+  rs2_b7_val_data: 'gen_sign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+umin8:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  rs2_b0_val_data: 'gen_usign_dataset(8)'
+  rs2_b1_val_data: 'gen_usign_dataset(8)'
+  rs2_b2_val_data: 'gen_usign_dataset(8)'
+  rs2_b3_val_data: 'gen_usign_dataset(8)'
+  rs2_b4_val_data: 'gen_usign_dataset(8)'
+  rs2_b5_val_data: 'gen_usign_dataset(8)'
+  rs2_b6_val_data: 'gen_usign_dataset(8)'
+  rs2_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smax8:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  rs2_b0_val_data: 'gen_sign_dataset(8)'
+  rs2_b1_val_data: 'gen_sign_dataset(8)'
+  rs2_b2_val_data: 'gen_sign_dataset(8)'
+  rs2_b3_val_data: 'gen_sign_dataset(8)'
+  rs2_b4_val_data: 'gen_sign_dataset(8)'
+  rs2_b5_val_data: 'gen_sign_dataset(8)'
+  rs2_b6_val_data: 'gen_sign_dataset(8)'
+  rs2_b7_val_data: 'gen_sign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+umax8:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  rs2_b0_val_data: 'gen_usign_dataset(8)'
+  rs2_b1_val_data: 'gen_usign_dataset(8)'
+  rs2_b2_val_data: 'gen_usign_dataset(8)'
+  rs2_b3_val_data: 'gen_usign_dataset(8)'
+  rs2_b4_val_data: 'gen_usign_dataset(8)'
+  rs2_b5_val_data: 'gen_usign_dataset(8)'
+  rs2_b6_val_data: 'gen_usign_dataset(8)'
+  rs2_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kabs8:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
 sclip8:
   xlen: [32,64]
   isa: IP
@@ -5706,4 +5847,110 @@ sclip8:
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+uclip8:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbriformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  imm_val_data: 'gen_imm_dataset(3)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+clrs8:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+clz8:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+clo8:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+swap8:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -3379,6 +3379,8 @@ packuw:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# 3.1.1. 16-bit Addition & Subtraction Instructions
+
 add16:
   stride: 1
   xlen: [32,64]
@@ -4102,7 +4104,7 @@ ukstsa16:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
-# 2.2.2. 8-bit Addition & Subtraction Instructions
+# 3.1.2. 8-bit Addition & Subtraction Instructions
 
 add8:
   stride: 1
@@ -4425,6 +4427,8 @@ uksub8:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# 3.1.3. 16-bit Shift Instructions
+
 sra16:
   stride: 1
   xlen: [32,64]
@@ -4712,6 +4716,8 @@ kslra16.u:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+# 3.1.4. 8-bit Shift Instructions
 
 sra8:
   stride: 1
@@ -5057,6 +5063,8 @@ kslra8.u:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# 3.1.5. 16-bit Compare Instructions
+
 cmpeq16:
   stride: 1
   xlen: [32,64]
@@ -5176,6 +5184,8 @@ ucmple16:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+# 3.1.6. 8-bit Compare Instructions
 
 cmpeq8:
   stride: 1
@@ -5337,6 +5347,8 @@ ucmple8:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# 3.1.7. 16-bit Multiply Instructions
+
 smul16:
   stride: 1
   xlen: [32,64]
@@ -5484,6 +5496,8 @@ khmx16:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+# 3.1.8. 8-bit Multiply Instructions
 
 smul8:
   stride: 1
@@ -5681,6 +5695,8 @@ khmx8:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# 3.1.9. 16-bit Misc Instructions
+
 smin16:
   stride: 1
   xlen: [32,64]
@@ -5874,25 +5890,6 @@ clz16:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
-clo16:
-  stride: 1
-  xlen: [32,64]
-  std_op:
-  isa: IP
-  bit_width: 16
-  formattype: 'phrformat'
-  rs1_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_h0_val_data: 'gen_usign_dataset(16)'
-  rs1_h1_val_data: 'gen_usign_dataset(16)'
-  rs1_h2_val_data: 'gen_usign_dataset(16)'
-  rs1_h3_val_data: 'gen_usign_dataset(16)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
-
 swap16:
   stride: 1
   xlen: [32,64]
@@ -5911,6 +5908,8 @@ swap16:
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+# 3.1.10. 8-bit Misc Instructions
 
 smin8:
   stride: 1
@@ -6157,29 +6156,6 @@ clz8:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
-clo8:
-  stride: 1
-  xlen: [32,64]
-  std_op:
-  isa: IP
-  bit_width: 8
-  formattype: 'pbrformat'
-  rs1_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)'
-  rs1_b1_val_data: 'gen_usign_dataset(8)'
-  rs1_b2_val_data: 'gen_usign_dataset(8)'
-  rs1_b3_val_data: 'gen_usign_dataset(8)'
-  rs1_b4_val_data: 'gen_usign_dataset(8)'
-  rs1_b5_val_data: 'gen_usign_dataset(8)'
-  rs1_b6_val_data: 'gen_usign_dataset(8)'
-  rs1_b7_val_data: 'gen_usign_dataset(8)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
-
 swap8:
   stride: 1
   xlen: [32,64]
@@ -6202,6 +6178,8 @@ swap8:
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+# 3.1.11. 8-bit Unpacking Instructions
 
 sunpkd810:
   stride: 1
@@ -6433,7 +6411,7 @@ zunpkd832:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
-# 2.3 Partial-SIMD Data Processing Instructions
+# 3.2 Partial-SIMD Data Processing Instructions
 
 pkbb16:
   stride: 1
@@ -6530,7 +6508,7 @@ pktt16:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-# 2.3.2 Most Significant Word 32x32 Multiply & Add Instructions
+# 3.2.2 Most Significant Word 32x32 Multiply & Add Instructions
 smmul:
   stride: 1
   xlen: [32,64]
@@ -6692,7 +6670,7 @@ kwmmul.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 
-# 2.3.3 Most Significant Word 32x32 Multiply & Add Instructions
+# 3.2.3 Most Significant Word 32x16 Multiply & Add Instructions
 smmwb:
   stride: 1
   xlen: [32,64]
@@ -6714,8 +6692,6 @@ smmwb:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-
 
 smmwb.u:
   stride: 1
@@ -6782,7 +6758,6 @@ smmwt.u:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
 
 kmmawb:
   stride: 1
@@ -7051,7 +7026,7 @@ kmmawt2.u:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 
-# 2.3.4 Signed 16-bit Multiply with 32-bit Add/Subtract Instructions
+# 3.2.4 Signed 16-bit Multiply with 32-bit Add/Subtract Instructions
 
 smbb16:
   stride: 1
@@ -7196,7 +7171,6 @@ smds:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
 
 smdrs:
   stride: 1
@@ -7486,7 +7460,7 @@ kmsxda:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
-# 2.3.5 Signed 16-bit Multiply with 64-bit Add/Subtract Instructions
+# 3.2.5 Signed 16-bit Multiply with 64-bit Add/Subtract Instructions
 
 smal:
   stride: 1
@@ -7513,7 +7487,7 @@ smal:
     TEST_P64_PPN_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 
-# 2.3.6 Miscellaneous Instructions
+# 3.2.6 Miscellaneous Instructions
 
 sclip32:
   stride: 1
@@ -7569,23 +7543,6 @@ clrs32:
     TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clz32:
-  stride: 1
-  xlen: [32,64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrformat'
-  rs1_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_usign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
-
-clo32:
   stride: 1
   xlen: [32,64]
   std_op:
@@ -7665,6 +7622,8 @@ pbsada:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+# 3.2.7. 8-bit Multiply with 32-bit Add Instructions
 
 smaqa:
   stride: 1
@@ -7762,7 +7721,8 @@ smaqa.su:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
-# 2.4.1 64-bit Addition & Subtraction Instructions
+# 3.3.1 64-bit Addition & Subtraction Instructions
+
 add64:
   stride: 1
   xlen: [32,64]
@@ -7963,7 +7923,8 @@ uksub64:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
-# 2.4.2 32-bit Multiply with 64-bit Add/Subtract Instructions
+# 3.2.2 32-bit Multiply with 64-bit Add/Subtract Instructions
+
 smar64:
   stride: 1
   xlen: [32,64]
@@ -8141,7 +8102,8 @@ ukmsr64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 
-# 2.4.3 Signed 16-bit Multiply with 64-bit Add/Subtract Instructions
+# 3.3.3 Signed 16-bit Multiply with 64-bit Add/Subtract Instructions
+
 smalbb:
   stride: 1
   xlen: [32,64]
@@ -8402,7 +8364,7 @@ smslxda:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
-# 2.5. Non-SIMD Instructions
+# 3.4.1 Q15 Saturation Instructions
 
 kaddh:
   stride: 1
@@ -8559,7 +8521,8 @@ uksubh:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
-# 2.5.2 Q31 saturation Instructions
+# 3.4.2 Q31 Saturation Instructions
+
 kaddw:
   stride: 1
   xlen: [32,64]
@@ -8879,7 +8842,7 @@ kabsw:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
-# 2.5.3. 32-bit Computation Instructions
+# 3.4.3. 32-bit Computation Instructions
 
 raddw:
   stride: 1
@@ -8961,26 +8924,6 @@ ursubw:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
-msubr32:
-  stride: 1
-  xlen: [32,64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
 mulr64:
   stride: 1
   xlen: [32,64]
@@ -9025,7 +8968,48 @@ mulsr64:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
-# 2.5.4
+maddr32:
+  stride: 1
+  xlen: [32,64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+msubr32:
+  stride: 1
+  xlen: [32,64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+# 3.4.4 Overflow/Saturation Status Manipulation Instructions
+
 rdov:
   stride: 1
   rd_op_data: *all_regs
@@ -9054,9 +9038,7 @@ clrov:
     // opcode: $inst
     TEST_CASE($testreg, x0, $correctval, $swreg, $offset, $inst)
 
-
-
-# 2.5.5. Miscellaneous Instructions
+# 3.4.5. Miscellaneous Instructions
 
 ave:
   stride: 1
@@ -9147,7 +9129,6 @@ bitrevi:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
-
 wext:
   stride: 1
   xlen: [32,64]
@@ -9195,7 +9176,6 @@ wexti:
     TEST_P64_NP_OP($inst, $rd, $rs1, $rs1_hi, $correctval, $rs1_val, $rs1_val_hi, $imm_val, $swreg, $offset, $testreg)
 
 
-
 insb:
   stride: 1
   xlen: [32,64]
@@ -9212,29 +9192,8 @@ insb:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
-
-maddr32:
-  stride: 1
-  xlen: [32,64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
-  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
-  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
-  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-
-# 2.6. RV64 Only Instructions
+# 8. RV64 Only Instructions
+# Table 27. (RV64 Only) SIMD 32-bit Add/Subtract Instructions
 
 add32:
   stride: 1
@@ -9356,347 +9315,6 @@ sub32:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
-kmda32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-kmxda32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-kmada32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-kmaxda32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-kmads32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-kmadrs32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-kmaxds32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-kmsda32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-kmsxda32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-smds32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-smdrs32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-smxds32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-sraiw.u:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwriformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  imm_val_data: 'gen_imm_dataset(5)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-pkbb32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_usign_dataset(32)'
-  rs2_w0_val_data: 'gen_usign_dataset(32)'
-  rs2_w1_val_data: 'gen_usign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-pkbt32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_usign_dataset(32)'
-  rs2_w0_val_data: 'gen_usign_dataset(32)'
-  rs2_w1_val_data: 'gen_usign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-pktb32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_usign_dataset(32)'
-  rs2_w0_val_data: 'gen_usign_dataset(32)'
-  rs2_w1_val_data: 'gen_usign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-
-pktt32:
-  stride: 1
-  xlen: [64]
-  std_op:
-  isa: IP
-  bit_width: 32
-  formattype: 'pwrrformat'
-  rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_usign_dataset(32)'
-  rs2_w0_val_data: 'gen_usign_dataset(32)'
-  rs2_w1_val_data: 'gen_usign_dataset(32)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
-
 rsub32:
   stride: 1
   xlen: [64]
@@ -9716,7 +9334,6 @@ rsub32:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
 
 ursub32:
   stride: 1
@@ -9817,7 +9434,6 @@ rcras32:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
-
 
 urcras32:
   stride: 1
@@ -10179,6 +9795,8 @@ ukstsa32:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# Table 28. (RV64 Only) SIMD 32-bit Shift Instructions
+
 sra32:
   stride: 1
   xlen: [64]
@@ -10439,6 +10057,8 @@ kslra32.u:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# Table 29. (RV64 Only) SIMD 32-bit Miscellaneous Instructions
+
 smin32:
   stride: 1
   xlen: [64]
@@ -10535,6 +10155,8 @@ kabs32:
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+# Table 30. (RV64 Only) SIMD Q15 saturating Multiply Instructions
 
 khmbb16:
   stride: 1
@@ -10752,6 +10374,8 @@ kdmatt16:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# Table 31. (RV64 Only) 32-bit Multiply Instructions
+
 smbb32:
   stride: 1
   xlen: [64]
@@ -10780,6 +10404,7 @@ smbt32:
   bit_width: 32
   formattype: 'pwrrformat'
   rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_w0_val_data: 'gen_sign_dataset(32)'
   rs1_w1_val_data: 'gen_sign_dataset(32)'
@@ -10788,8 +10413,8 @@ smbt32:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smtt32:
   stride: 1
@@ -10810,6 +10435,8 @@ smtt32:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+# Table 32. (RV64 Only) 32-bit Multiply & Add Instructions
 
 kmabb32:
   stride: 1
@@ -10871,4 +10498,346 @@ kmatt32:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# Table 33. (RV64 Only) 32-bit Parallel Multiply & Add Instructions
 
+kmda32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmxda32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmada32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmaxda32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmads32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmadrs32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmaxds32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmsda32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmsxda32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smds32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smdrs32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smxds32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+# Table 34. (RV64 Only) Non-SIMD 32-bit Shift Instructions
+
+sraiw.u:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwriformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  imm_val_data: 'gen_imm_dataset(5)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+# Table 35. (RV64 Only) 32-bit Packing Instructions
+
+pkbb32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+pkbt32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+pktb32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+pktt32:
+  stride: 1
+  xlen: [64]
+  std_op:
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -4381,6 +4381,7 @@ sra16:
   rs1_h3_val_data: 'gen_sign_dataset(16)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(16,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4398,6 +4399,7 @@ srai16:
   rs1_h3_val_data: 'gen_sign_dataset(16)'
   imm_val_data: 'gen_imm_dataset(4)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -4416,6 +4418,7 @@ sra16.u:
   rs1_h3_val_data: 'gen_sign_dataset(16)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(16,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4433,6 +4436,7 @@ srai16.u:
   rs1_h3_val_data: 'gen_sign_dataset(16)'
   imm_val_data: 'gen_imm_dataset(4)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -4451,6 +4455,7 @@ srl16:
   rs1_h3_val_data: 'gen_usign_dataset(16)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(16,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4468,6 +4473,7 @@ srli16:
   rs1_h3_val_data: 'gen_usign_dataset(16)'
   imm_val_data: 'gen_imm_dataset(4)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -4486,6 +4492,7 @@ srl16.u:
   rs1_h3_val_data: 'gen_usign_dataset(16)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(16,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4503,6 +4510,7 @@ srli16.u:
   rs1_h3_val_data: 'gen_usign_dataset(16)'
   imm_val_data: 'gen_imm_dataset(4)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -4521,6 +4529,7 @@ sll16:
   rs1_h3_val_data: 'gen_usign_dataset(16)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(16,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4538,6 +4547,7 @@ slli16:
   rs1_h3_val_data: 'gen_usign_dataset(16)'
   imm_val_data: 'gen_imm_dataset(4)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -4556,6 +4566,7 @@ ksll16:
   rs1_h3_val_data: 'gen_sign_dataset(16)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(16,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4573,6 +4584,7 @@ kslli16:
   rs1_h3_val_data: 'gen_sign_dataset(16)'
   imm_val_data: 'gen_imm_dataset(4)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -4591,6 +4603,7 @@ kslra16:
   rs1_h3_val_data: 'gen_sign_dataset(16)'
   rs2_val_data: 'gen_sign_dataset(ceil(log(16,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4609,6 +4622,7 @@ kslra16.u:
   rs1_h3_val_data: 'gen_sign_dataset(16)'
   rs2_val_data: 'gen_sign_dataset(ceil(log(16,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4631,6 +4645,7 @@ sra8:
   rs1_b7_val_data: 'gen_sign_dataset(8)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(8,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4652,6 +4667,7 @@ srai8:
   rs1_b7_val_data: 'gen_sign_dataset(8)'
   imm_val_data: 'gen_imm_dataset(3)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -4674,6 +4690,7 @@ sra8.u:
   rs1_b7_val_data: 'gen_sign_dataset(8)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(8,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4695,6 +4712,7 @@ srai8.u:
   rs1_b7_val_data: 'gen_sign_dataset(8)'
   imm_val_data: 'gen_imm_dataset(3)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -4717,6 +4735,7 @@ srl8:
   rs1_b7_val_data: 'gen_usign_dataset(8)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(8,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4738,6 +4757,7 @@ srli8:
   rs1_b7_val_data: 'gen_usign_dataset(8)'
   imm_val_data: 'gen_imm_dataset(3)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -4760,6 +4780,7 @@ srl8.u:
   rs1_b7_val_data: 'gen_usign_dataset(8)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(8,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4781,6 +4802,7 @@ srli8.u:
   rs1_b7_val_data: 'gen_usign_dataset(8)'
   imm_val_data: 'gen_imm_dataset(3)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -4803,6 +4825,7 @@ sll8:
   rs1_b7_val_data: 'gen_usign_dataset(8)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(8,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4824,6 +4847,7 @@ slli8:
   rs1_b7_val_data: 'gen_usign_dataset(8)'
   imm_val_data: 'gen_imm_dataset(3)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -4846,6 +4870,7 @@ ksll8:
   rs1_b7_val_data: 'gen_sign_dataset(8)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(8,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4867,6 +4892,7 @@ kslli8:
   rs1_b7_val_data: 'gen_sign_dataset(8)'
   imm_val_data: 'gen_imm_dataset(3)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -4889,6 +4915,7 @@ kslra8:
   rs1_b7_val_data: 'gen_sign_dataset(8)'
   rs2_val_data: 'gen_sign_dataset(ceil(log(8,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -4911,6 +4938,7 @@ kslra8.u:
   rs1_b7_val_data: 'gen_sign_dataset(8)'
   rs2_val_data: 'gen_sign_dataset(ceil(log(8,2)))'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -5504,6 +5532,7 @@ smin16:
   rs2_h2_val_data: 'gen_sign_dataset(16)'
   rs2_h3_val_data: 'gen_sign_dataset(16)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -5525,6 +5554,7 @@ umin16:
   rs2_h2_val_data: 'gen_usign_dataset(16)'
   rs2_h3_val_data: 'gen_usign_dataset(16)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -5546,6 +5576,7 @@ smax16:
   rs2_h2_val_data: 'gen_sign_dataset(16)'
   rs2_h3_val_data: 'gen_sign_dataset(16)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -5567,6 +5598,7 @@ umax16:
   rs2_h2_val_data: 'gen_usign_dataset(16)'
   rs2_h3_val_data: 'gen_usign_dataset(16)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -5584,6 +5616,7 @@ sclip16:
   rs1_h3_val_data: 'gen_sign_dataset(16)'
   imm_val_data: 'gen_imm_dataset(4)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -5601,6 +5634,7 @@ uclip16:
   rs1_h3_val_data: 'gen_usign_dataset(16)'
   imm_val_data: 'gen_imm_dataset(4)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -5617,6 +5651,7 @@ kabs16:
   rs1_h2_val_data: 'gen_sign_dataset(16)'
   rs1_h3_val_data: 'gen_sign_dataset(16)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
@@ -5633,6 +5668,7 @@ clrs16:
   rs1_h2_val_data: 'gen_sign_dataset(16)'
   rs1_h3_val_data: 'gen_sign_dataset(16)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
@@ -5649,6 +5685,7 @@ clz16:
   rs1_h2_val_data: 'gen_usign_dataset(16)'
   rs1_h3_val_data: 'gen_usign_dataset(16)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
@@ -5665,6 +5702,7 @@ clo16:
   rs1_h2_val_data: 'gen_usign_dataset(16)'
   rs1_h3_val_data: 'gen_usign_dataset(16)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
@@ -5681,6 +5719,7 @@ swap16:
   rs1_h2_val_data: 'gen_usign_dataset(16)'
   rs1_h3_val_data: 'gen_usign_dataset(16)'
   template: |-
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -5858,7 +5858,7 @@ kabs16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clrs16:
   stride: 1
@@ -5877,7 +5877,7 @@ clrs16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clz16:
   stride: 1
@@ -5896,7 +5896,7 @@ clz16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clo16:
   stride: 1
@@ -5915,7 +5915,7 @@ clo16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 swap16:
   stride: 1
@@ -5934,7 +5934,7 @@ swap16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 smin8:
   stride: 1
@@ -6085,7 +6085,7 @@ kabs8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 sclip8:
   stride: 1
@@ -6156,7 +6156,7 @@ clrs8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clz8:
   stride: 1
@@ -6179,7 +6179,7 @@ clz8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clo8:
   stride: 1
@@ -6202,7 +6202,7 @@ clo8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 swap8:
   stride: 1
@@ -6225,7 +6225,7 @@ swap8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 sunpkd810:
   stride: 1
@@ -6248,7 +6248,7 @@ sunpkd810:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 sunpkd820:
   stride: 1
@@ -6271,7 +6271,7 @@ sunpkd820:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 sunpkd830:
   stride: 1
@@ -6294,7 +6294,7 @@ sunpkd830:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 sunpkd831:
   stride: 1
@@ -6317,7 +6317,7 @@ sunpkd831:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 sunpkd832:
   stride: 1
@@ -6340,7 +6340,7 @@ sunpkd832:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 zunpkd810:
   stride: 1
@@ -6363,7 +6363,7 @@ zunpkd810:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 zunpkd820:
   stride: 1
@@ -6386,7 +6386,7 @@ zunpkd820:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 zunpkd830:
   stride: 1
@@ -6409,7 +6409,7 @@ zunpkd830:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 zunpkd831:
   stride: 1
@@ -6432,7 +6432,7 @@ zunpkd831:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 zunpkd832:
   stride: 1
@@ -6455,7 +6455,7 @@ zunpkd832:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 # 2.3 Partial-SIMD Data Processing Instructions
 
@@ -7587,7 +7587,7 @@ clrs32:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clz32:
   stride: 1
@@ -7604,7 +7604,7 @@ clz32:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 clo32:
   stride: 1
@@ -7621,7 +7621,7 @@ clo32:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 pbsad:
   stride: 1
@@ -8822,7 +8822,7 @@ kabsw:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 # 2.5.3. 32-bit Computation Instructions
 
@@ -10512,7 +10512,7 @@ kabs32:
 
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
-    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+    TEST_R_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
 khmbb16:
   stride: 1

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -6831,6 +6831,96 @@ pbsada:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+smaqa:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  rs2_b0_val_data: 'gen_sign_dataset(8)'
+  rs2_b1_val_data: 'gen_sign_dataset(8)'
+  rs2_b2_val_data: 'gen_sign_dataset(8)'
+  rs2_b3_val_data: 'gen_sign_dataset(8)'
+  rs2_b4_val_data: 'gen_sign_dataset(8)'
+  rs2_b5_val_data: 'gen_sign_dataset(8)'
+  rs2_b6_val_data: 'gen_sign_dataset(8)'
+  rs2_b7_val_data: 'gen_sign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+umaqa:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  rs2_b0_val_data: 'gen_usign_dataset(8)'
+  rs2_b1_val_data: 'gen_usign_dataset(8)'
+  rs2_b2_val_data: 'gen_usign_dataset(8)'
+  rs2_b3_val_data: 'gen_usign_dataset(8)'
+  rs2_b4_val_data: 'gen_usign_dataset(8)'
+  rs2_b5_val_data: 'gen_usign_dataset(8)'
+  rs2_b6_val_data: 'gen_usign_dataset(8)'
+  rs2_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smaqa.su:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  rs2_b0_val_data: 'gen_sign_dataset(8)'
+  rs2_b1_val_data: 'gen_sign_dataset(8)'
+  rs2_b2_val_data: 'gen_sign_dataset(8)'
+  rs2_b3_val_data: 'gen_sign_dataset(8)'
+  rs2_b4_val_data: 'gen_sign_dataset(8)'
+  rs2_b5_val_data: 'gen_sign_dataset(8)'
+  rs2_b6_val_data: 'gen_sign_dataset(8)'
+  rs2_b7_val_data: 'gen_sign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
 # 2.5. Non-SIMD Instructions
 
 kaddh:

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -5375,10 +5375,11 @@ smul16:
   std_op:
   isa: IP
   bit_width: 16
+  p64_profile: 'pnn'
   formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
-  rd_op_data: *all_regs
+  rd_op_data: *pair_regs
   rs1_h0_val_data: 'gen_sign_dataset(16)'
   rs1_h1_val_data: 'gen_sign_dataset(16)'
   rs1_h2_val_data: 'gen_sign_dataset(16)'
@@ -5391,7 +5392,7 @@ smul16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smulx16:
   stride: 1
@@ -5399,10 +5400,11 @@ smulx16:
   std_op:
   isa: IP
   bit_width: 16
+  p64_profile: 'pnn'
   formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
-  rd_op_data: *all_regs
+  rd_op_data: *pair_regs
   rs1_h0_val_data: 'gen_sign_dataset(16)'
   rs1_h1_val_data: 'gen_sign_dataset(16)'
   rs1_h2_val_data: 'gen_sign_dataset(16)'
@@ -5415,7 +5417,7 @@ smulx16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 umul16:
   stride: 1
@@ -5423,10 +5425,11 @@ umul16:
   std_op:
   isa: IP
   bit_width: 16
+  p64_profile: 'pnn'
   formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
-  rd_op_data: *all_regs
+  rd_op_data: *pair_regs
   rs1_h0_val_data: 'gen_usign_dataset(16)'
   rs1_h1_val_data: 'gen_usign_dataset(16)'
   rs1_h2_val_data: 'gen_usign_dataset(16)'
@@ -5439,7 +5442,7 @@ umul16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 umulx16:
   stride: 1
@@ -5447,10 +5450,11 @@ umulx16:
   std_op:
   isa: IP
   bit_width: 16
+  p64_profile: 'pnn'
   formattype: 'phrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
-  rd_op_data: *all_regs
+  rd_op_data: *pair_regs
   rs1_h0_val_data: 'gen_usign_dataset(16)'
   rs1_h1_val_data: 'gen_usign_dataset(16)'
   rs1_h2_val_data: 'gen_usign_dataset(16)'
@@ -5463,7 +5467,7 @@ umulx16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 khm16:
   stride: 1
@@ -5519,10 +5523,11 @@ smul8:
   std_op:
   isa: IP
   bit_width: 8
+  p64_profile: 'pnn'
   formattype: 'pbrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
-  rd_op_data: *all_regs
+  rd_op_data: *pair_regs
   rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
@@ -5543,7 +5548,7 @@ smul8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smulx8:
   stride: 1
@@ -5551,10 +5556,11 @@ smulx8:
   std_op:
   isa: IP
   bit_width: 8
+  p64_profile: 'pnn'
   formattype: 'pbrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
-  rd_op_data: *all_regs
+  rd_op_data: *pair_regs
   rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
@@ -5575,7 +5581,7 @@ smulx8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 umul8:
   stride: 1
@@ -5583,10 +5589,11 @@ umul8:
   std_op:
   isa: IP
   bit_width: 8
+  p64_profile: 'pnn'
   formattype: 'pbrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
-  rd_op_data: *all_regs
+  rd_op_data: *pair_regs
   rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
@@ -5607,7 +5614,7 @@ umul8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 umulx8:
   stride: 1
@@ -5615,10 +5622,11 @@ umulx8:
   std_op:
   isa: IP
   bit_width: 8
+  p64_profile: 'pnn'
   formattype: 'pbrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
-  rd_op_data: *all_regs
+  rd_op_data: *pair_regs
   rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
@@ -5639,7 +5647,7 @@ umulx8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 khm8:
   stride: 1

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -6692,6 +6692,145 @@ kmsxda:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# 2.3.6 Miscellaneous Instructions
+
+sclip32:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwriformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  imm_val_data: 'gen_imm_dataset(5)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+uclip32:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwriformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  imm_val_data: 'gen_imm_dataset(5)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+clrs32:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+clz32:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+clo32:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+pbsad:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  rs2_b0_val_data: 'gen_usign_dataset(8)'
+  rs2_b1_val_data: 'gen_usign_dataset(8)'
+  rs2_b2_val_data: 'gen_usign_dataset(8)'
+  rs2_b3_val_data: 'gen_usign_dataset(8)'
+  rs2_b4_val_data: 'gen_usign_dataset(8)'
+  rs2_b5_val_data: 'gen_usign_dataset(8)'
+  rs2_b6_val_data: 'gen_usign_dataset(8)'
+  rs2_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+pbsada:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  rs2_b0_val_data: 'gen_usign_dataset(8)'
+  rs2_b1_val_data: 'gen_usign_dataset(8)'
+  rs2_b2_val_data: 'gen_usign_dataset(8)'
+  rs2_b3_val_data: 'gen_usign_dataset(8)'
+  rs2_b4_val_data: 'gen_usign_dataset(8)'
+  rs2_b5_val_data: 'gen_usign_dataset(8)'
+  rs2_b6_val_data: 'gen_usign_dataset(8)'
+  rs2_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
 # 2.5. Non-SIMD Instructions
 
 kaddh:

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -9046,7 +9046,6 @@ ave:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 32
   formattype: 'rformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
@@ -9064,7 +9063,6 @@ sra.u:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 32
   formattype: 'rformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
@@ -9082,7 +9080,6 @@ srai.u:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 32
   formattype: 'iformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
@@ -9100,7 +9097,6 @@ bitrev:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 32
   formattype: 'rformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
@@ -9118,7 +9114,6 @@ bitrevi:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 32
   formattype: 'iformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -7264,3 +7264,235 @@ ukstsa32:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+sra32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pswrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_val_data: 'gen_usign_dataset(ceil(log(32,2)))'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+srai32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwriformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  imm_val_data: 'gen_imm_dataset(5)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+sra32.u:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pswrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_val_data: 'gen_usign_dataset(ceil(log(32,2)))'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+srai32.u:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwriformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  imm_val_data: 'gen_imm_dataset(5)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+srl32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pswrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_val_data: 'gen_usign_dataset(ceil(log(32,2)))'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+srli32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwriformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  imm_val_data: 'gen_imm_dataset(5)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+srl32.u:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pswrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_val_data: 'gen_usign_dataset(ceil(log(32,2)))'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+srli32.u:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwriformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  imm_val_data: 'gen_imm_dataset(5)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+sll32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pswrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_val_data: 'gen_usign_dataset(ceil(log(32,2)))'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+slli32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwriformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  imm_val_data: 'gen_imm_dataset(5)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+ksll32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pswrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_val_data: 'gen_usign_dataset(ceil(log(32,2)))'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kslli32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwriformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  imm_val_data: 'gen_imm_dataset(5)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+kslra32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pswrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_val_data: 'gen_sign_dataset(ceil(log(32,2)))'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kslra32.u:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pswrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_val_data: 'gen_sign_dataset(ceil(log(32,2)))'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -3391,14 +3391,14 @@ add16:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
   template: |-
 
     // $comment
@@ -3511,14 +3511,14 @@ sub16:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
   template: |-
 
     // $comment
@@ -3633,14 +3633,14 @@ cras16:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
   template: |-
 
     // $comment
@@ -3754,14 +3754,14 @@ crsa16:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
   template: |-
 
     // $comment
@@ -3874,14 +3874,14 @@ stas16:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
   template: |-
 
     // $comment
@@ -3994,14 +3994,14 @@ stsa16:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
   template: |-
 
     // $comment
@@ -4116,22 +4116,22 @@ add8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b1_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b2_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b3_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b4_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b5_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b6_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b7_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b1_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b2_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b3_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b4_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b5_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b6_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b7_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  rs2_b0_val_data: 'gen_sign_dataset(8)'
+  rs2_b1_val_data: 'gen_sign_dataset(8)'
+  rs2_b2_val_data: 'gen_sign_dataset(8)'
+  rs2_b3_val_data: 'gen_sign_dataset(8)'
+  rs2_b4_val_data: 'gen_sign_dataset(8)'
+  rs2_b5_val_data: 'gen_sign_dataset(8)'
+  rs2_b6_val_data: 'gen_sign_dataset(8)'
+  rs2_b7_val_data: 'gen_sign_dataset(8)'
   template: |-
 
     // $comment
@@ -4276,22 +4276,22 @@ sub8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b1_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b2_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b3_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b4_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b5_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b6_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b7_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b1_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b2_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b3_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b4_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b5_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b6_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b7_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  rs2_b0_val_data: 'gen_sign_dataset(8)'
+  rs2_b1_val_data: 'gen_sign_dataset(8)'
+  rs2_b2_val_data: 'gen_sign_dataset(8)'
+  rs2_b3_val_data: 'gen_sign_dataset(8)'
+  rs2_b4_val_data: 'gen_sign_dataset(8)'
+  rs2_b5_val_data: 'gen_sign_dataset(8)'
+  rs2_b6_val_data: 'gen_sign_dataset(8)'
+  rs2_b7_val_data: 'gen_sign_dataset(8)'
   template: |-
 
     // $comment
@@ -5075,14 +5075,14 @@ cmpeq16:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs1_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h0_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h1_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h2_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
-  rs2_h3_val_data: 'gen_sign_dataset(16) + gen_usign_dataset(16)'
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
   template: |-
 
     // $comment
@@ -5197,22 +5197,22 @@ cmpeq8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b1_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b2_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b3_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b4_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b5_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b6_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs1_b7_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b1_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b2_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b3_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b4_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b5_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b6_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
-  rs2_b7_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  rs2_b0_val_data: 'gen_sign_dataset(8)'
+  rs2_b1_val_data: 'gen_sign_dataset(8)'
+  rs2_b2_val_data: 'gen_sign_dataset(8)'
+  rs2_b3_val_data: 'gen_sign_dataset(8)'
+  rs2_b4_val_data: 'gen_sign_dataset(8)'
+  rs2_b5_val_data: 'gen_sign_dataset(8)'
+  rs2_b6_val_data: 'gen_sign_dataset(8)'
+  rs2_b7_val_data: 'gen_sign_dataset(8)'
   template: |-
 
     // $comment
@@ -9206,10 +9206,10 @@ add32:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
   template: |-
 
     // $comment
@@ -9306,10 +9306,10 @@ sub32:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
   template: |-
 
     // $comment
@@ -9406,10 +9406,10 @@ cras32:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
   template: |-
 
     // $comment
@@ -9506,10 +9506,10 @@ crsa32:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
   template: |-
 
     // $comment
@@ -9606,10 +9606,10 @@ stas32:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
   template: |-
 
     // $comment
@@ -9706,10 +9706,10 @@ stsa32:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
-  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_usign_dataset(32)'
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -9009,34 +9009,35 @@ msubr32:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 # 3.4.4 Overflow/Saturation Status Manipulation Instructions
+# alias for CSRR Rd, vxsat 
+# rdov:
+#   stride: 1
+#   rd_op_data: *all_regs
+#   xlen: [32,64]
+#   std_op:
+#   isa: IP
+#   formattype: 'uformat'
+#   imm_val_data: 'gen_usign_dataset(2)'
+#   template: |-
+# 
+#     // $comment
+#     // opcode: $inst ; dest:$rd
+#     TEST_CASE($testreg, $rd, $correctval, $swreg, $offset, $inst $rd)
 
-rdov:
-  stride: 1
-  rd_op_data: *all_regs
-  xlen: [32,64]
-  std_op:
-  isa: IP
-  formattype: 'uformat'
-  imm_val_data: 'gen_usign_dataset(2)'
-  template: |-
-
-    // $comment
-    // opcode: $inst ; dest:$rd
-    TEST_CASE($testreg, $rd, $correctval, $swreg, $offset, $inst $rd)
-
-clrov:
-  stride: 1
-  rd_op_data: *all_regs
-  xlen: [32,64]
-  std_op:
-  isa: IP
-  formattype: 'uformat'
-  imm_val_data: 'gen_usign_dataset(2)'
-  template: |-
-
-    // $comment
-    // opcode: $inst
-    TEST_CASE($testreg, x0, $correctval, $swreg, $offset, $inst)
+# alias for CSRRCI x0, vxsat, 1
+# clrov:
+#   stride: 1
+#   rd_op_data: *all_regs
+#   xlen: [32,64]
+#   std_op:
+#   isa: IP
+#   formattype: 'uformat'
+#   imm_val_data: 'gen_usign_dataset(2)'
+#   template: |-
+# 
+#     // $comment
+#     // opcode: $inst
+#     TEST_CASE($testreg, x0, $correctval, $swreg, $offset, $inst)
 
 # 3.4.5. Miscellaneous Instructions
 

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -4680,7 +4680,7 @@ kslra16:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 16
+  bit_width: 16,xlen
   formattype: 'pshrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
@@ -4701,7 +4701,7 @@ kslra16.u:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 16
+  bit_width: 16,xlen
   formattype: 'pshrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
@@ -5018,7 +5018,7 @@ kslra8:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 8
+  bit_width: 8,xlen
   formattype: 'psbrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
@@ -5043,7 +5043,7 @@ kslra8.u:
   xlen: [32,64]
   std_op:
   isa: IP
-  bit_width: 8
+  bit_width: 8,xlen
   formattype: 'psbrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
@@ -10036,7 +10036,7 @@ kslra32:
   xlen: [64]
   std_op:
   isa: IP
-  bit_width: 32
+  bit_width: 32,xlen
   formattype: 'pswrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
@@ -10055,7 +10055,7 @@ kslra32.u:
   xlen: [64]
   std_op:
   isa: IP
-  bit_width: 32
+  bit_width: 32,xlen
   formattype: 'pswrrformat'
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -9027,7 +9027,7 @@ clrov:
 
     // $comment
     // opcode: $inst
-    TEST_CASE($testreg, $correctval, $swreg, $offset, $inst)
+    TEST_CASE($testreg, x0, $correctval, $swreg, $offset, $inst)
 
 
 

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -5372,7 +5372,7 @@ smul16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smulx16:
   stride: 2
@@ -5397,7 +5397,7 @@ smulx16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umul16:
   stride: 2
@@ -5422,7 +5422,7 @@ umul16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umulx16:
   stride: 2
@@ -5447,7 +5447,7 @@ umulx16:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 khm16:
   stride: 1
@@ -5530,7 +5530,7 @@ smul8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smulx8:
   stride: 2
@@ -5563,7 +5563,7 @@ smulx8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umul8:
   stride: 2
@@ -5596,7 +5596,7 @@ umul8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umulx8:
   stride: 2
@@ -5629,7 +5629,7 @@ umulx8:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 khm8:
   stride: 1
@@ -7484,7 +7484,7 @@ smal:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64; op2val:$rs2_val;
-    TEST_P64_PPN_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PPN_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $swreg, $offset, $testreg)
 
 
 # 3.2.6 Miscellaneous Instructions
@@ -7741,7 +7741,7 @@ add64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64 op2val:$rs2_val64
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 radd64:
   stride: 2
@@ -7761,7 +7761,7 @@ radd64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 uradd64:
   stride: 2
@@ -7781,7 +7781,7 @@ uradd64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 kadd64:
   stride: 2
@@ -7801,7 +7801,7 @@ kadd64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 ukadd64:
   stride: 2
@@ -7821,7 +7821,7 @@ ukadd64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 sub64:
   stride: 2
@@ -7841,7 +7841,7 @@ sub64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 rsub64:
   stride: 2
@@ -7861,7 +7861,7 @@ rsub64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 ursub64:
   stride: 2
@@ -7881,7 +7881,7 @@ ursub64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 ksub64:
   stride: 2
@@ -7901,7 +7901,7 @@ ksub64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 uksub64:
   stride: 2
@@ -7921,7 +7921,7 @@ uksub64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 # 3.2.2 32-bit Multiply with 64-bit Add/Subtract Instructions
 
@@ -7945,7 +7945,7 @@ smar64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smsr64:
   stride: 2
@@ -7967,7 +7967,7 @@ smsr64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umar64:
   stride: 2
@@ -7989,7 +7989,7 @@ umar64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 umsr64:
   stride: 2
@@ -8011,7 +8011,7 @@ umsr64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmar64:
   stride: 2
@@ -8033,7 +8033,7 @@ kmar64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmsr64:
   stride: 2
@@ -8055,7 +8055,7 @@ kmsr64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukmar64:
   stride: 2
@@ -8077,7 +8077,7 @@ ukmar64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 ukmsr64:
   stride: 2
@@ -8099,7 +8099,7 @@ ukmsr64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 
 # 3.3.3 Signed 16-bit Multiply with 64-bit Add/Subtract Instructions
@@ -8128,7 +8128,7 @@ smalbb:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smalbt:
   stride: 2
@@ -8154,7 +8154,7 @@ smalbt:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smaltt:
   stride: 2
@@ -8180,7 +8180,7 @@ smaltt:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smalda:
   stride: 2
@@ -8206,7 +8206,7 @@ smalda:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smalxda:
   stride: 2
@@ -8232,7 +8232,7 @@ smalxda:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smalds:
   stride: 2
@@ -8258,7 +8258,7 @@ smalds:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smaldrs:
   stride: 2
@@ -8284,7 +8284,7 @@ smaldrs:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smalxds:
   stride: 2
@@ -8310,7 +8310,7 @@ smalxds:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smslda:
   stride: 2
@@ -8336,7 +8336,7 @@ smslda:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smslxda:
   stride: 2
@@ -8362,7 +8362,7 @@ smslxda:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 # 3.4.1 Q15 Saturation Instructions
 
@@ -8960,7 +8960,7 @@ mulr64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val;
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 mulsr64:
   stride: 2
@@ -8982,7 +8982,7 @@ mulsr64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 maddr32:
   stride: 1

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -7046,6 +7046,96 @@ smxds32:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+sraiw.u:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwriformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  imm_val_data: 'gen_imm_dataset(5)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+pkbb32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+pkbt32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+pktb32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+pktt32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
 
 rsub32:
   xlen: [64]

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -7836,3 +7836,58 @@ smtt32:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+kmabb32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmabt32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmatt32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -3405,6 +3405,7 @@ add16:
 radd16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3428,6 +3429,7 @@ radd16:
 uradd16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3451,6 +3453,7 @@ uradd16:
 kadd16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3474,6 +3477,7 @@ kadd16:
 ukadd16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3497,6 +3501,7 @@ ukadd16:
 sub16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3521,6 +3526,7 @@ sub16:
 rsub16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3545,6 +3551,7 @@ rsub16:
 ursub16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3568,6 +3575,7 @@ ursub16:
 ksub16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3591,6 +3599,7 @@ ksub16:
 uksub16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3614,6 +3623,7 @@ uksub16:
 cras16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3637,6 +3647,7 @@ cras16:
 rcras16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3661,6 +3672,7 @@ rcras16:
 urcras16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3684,6 +3696,7 @@ urcras16:
 kcras16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3707,6 +3720,7 @@ kcras16:
 ukcras16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3730,6 +3744,7 @@ ukcras16:
 crsa16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3753,6 +3768,7 @@ crsa16:
 rcrsa16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3776,6 +3792,7 @@ rcrsa16:
 urcrsa16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3799,6 +3816,7 @@ urcrsa16:
 kcrsa16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3822,6 +3840,7 @@ kcrsa16:
 ukcrsa16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3845,6 +3864,7 @@ ukcrsa16:
 stas16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3868,6 +3888,7 @@ stas16:
 rstas16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3891,6 +3912,7 @@ rstas16:
 urstas16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3914,6 +3936,7 @@ urstas16:
 kstas16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3937,6 +3960,7 @@ kstas16:
 ukstas16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3960,6 +3984,7 @@ ukstas16:
 stsa16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -3983,6 +4008,7 @@ stsa16:
 rstsa16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -4006,6 +4032,7 @@ rstsa16:
 urstsa16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -4029,6 +4056,7 @@ urstsa16:
 kstsa16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -4052,6 +4080,7 @@ kstsa16:
 ukstsa16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -4077,6 +4106,7 @@ ukstsa16:
 add8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -4108,6 +4138,7 @@ add8:
 radd8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -4139,6 +4170,7 @@ radd8:
 uradd8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -4170,6 +4202,7 @@ uradd8:
 kadd8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -4201,6 +4234,7 @@ kadd8:
 ukadd8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -4232,6 +4266,7 @@ ukadd8:
 sub8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -4263,6 +4298,7 @@ sub8:
 rsub8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -4294,6 +4330,7 @@ rsub8:
 ursub8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -4326,6 +4363,7 @@ ursub8:
 usub8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -4357,6 +4395,7 @@ usub8:
 ksub8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -4388,6 +4427,7 @@ ksub8:
 uksub8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -4419,6 +4459,7 @@ uksub8:
 sra16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'pshrrformat'
@@ -4439,6 +4480,7 @@ sra16:
 srai16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phriformat'
@@ -4458,6 +4500,7 @@ srai16:
 sra16.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'pshrrformat'
@@ -4478,6 +4521,7 @@ sra16.u:
 srai16.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phriformat'
@@ -4497,6 +4541,7 @@ srai16.u:
 srl16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'pshrrformat'
@@ -4517,6 +4562,7 @@ srl16:
 srli16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phriformat'
@@ -4536,6 +4582,7 @@ srli16:
 srl16.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'pshrrformat'
@@ -4556,6 +4603,7 @@ srl16.u:
 srli16.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phriformat'
@@ -4575,6 +4623,7 @@ srli16.u:
 sll16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'pshrrformat'
@@ -4595,6 +4644,7 @@ sll16:
 slli16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phriformat'
@@ -4614,6 +4664,7 @@ slli16:
 ksll16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'pshrrformat'
@@ -4634,6 +4685,7 @@ ksll16:
 kslli16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phriformat'
@@ -4653,6 +4705,7 @@ kslli16:
 kslra16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'pshrrformat'
@@ -4673,6 +4726,7 @@ kslra16:
 kslra16.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'pshrrformat'
@@ -4693,6 +4747,7 @@ kslra16.u:
 sra8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'psbrrformat'
@@ -4717,6 +4772,7 @@ sra8:
 srai8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbriformat'
@@ -4740,6 +4796,7 @@ srai8:
 sra8.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'psbrrformat'
@@ -4764,6 +4821,7 @@ sra8.u:
 srai8.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbriformat'
@@ -4787,6 +4845,7 @@ srai8.u:
 srl8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'psbrrformat'
@@ -4811,6 +4870,7 @@ srl8:
 srli8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbriformat'
@@ -4834,6 +4894,7 @@ srli8:
 srl8.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'psbrrformat'
@@ -4855,9 +4916,10 @@ srl8.u:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
-srli8.u:  
+srli8.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbriformat'
@@ -4881,6 +4943,7 @@ srli8.u:
 sll8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'psbrrformat'
@@ -4905,6 +4968,7 @@ sll8:
 slli8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbriformat'
@@ -4928,6 +4992,7 @@ slli8:
 ksll8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'psbrrformat'
@@ -4952,6 +5017,7 @@ ksll8:
 kslli8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbriformat'
@@ -4975,6 +5041,7 @@ kslli8:
 kslra8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'psbrrformat'
@@ -4999,6 +5066,7 @@ kslra8:
 kslra8.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'psbrrformat'
@@ -5023,6 +5091,7 @@ kslra8.u:
 cmpeq16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5046,6 +5115,7 @@ cmpeq16:
 scmplt16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5069,6 +5139,7 @@ scmplt16:
 scmple16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5092,6 +5163,7 @@ scmple16:
 ucmplt16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5115,6 +5187,7 @@ ucmplt16:
 ucmple16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5138,6 +5211,7 @@ ucmple16:
 cmpeq8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5169,6 +5243,7 @@ cmpeq8:
 scmplt8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5200,6 +5275,7 @@ scmplt8:
 scmple8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5231,6 +5307,7 @@ scmple8:
 ucmplt8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5262,6 +5339,7 @@ ucmplt8:
 ucmple8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5293,6 +5371,7 @@ ucmple8:
 smul16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5316,6 +5395,7 @@ smul16:
 smulx16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5339,6 +5419,7 @@ smulx16:
 umul16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5362,6 +5443,7 @@ umul16:
 umulx16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5385,6 +5467,7 @@ umulx16:
 khm16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5408,6 +5491,7 @@ khm16:
 khmx16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5429,8 +5513,9 @@ khmx16:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 smul8:
-  stride: 1  
+  stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5462,6 +5547,7 @@ smul8:
 smulx8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5493,6 +5579,7 @@ smulx8:
 umul8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5524,6 +5611,7 @@ umul8:
 umulx8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5555,6 +5643,7 @@ umulx8:
 khm8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5584,8 +5673,9 @@ khm8:
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 khmx8:
-  stride: 1  
+  stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5617,6 +5707,7 @@ khmx8:
 smin16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5640,6 +5731,7 @@ smin16:
 umin16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5663,6 +5755,7 @@ umin16:
 smax16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5686,6 +5779,7 @@ smax16:
 umax16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -5709,6 +5803,7 @@ umax16:
 sclip16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phriformat'
@@ -5728,6 +5823,7 @@ sclip16:
 uclip16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phriformat'
@@ -5747,6 +5843,7 @@ uclip16:
 kabs16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrformat'
@@ -5765,6 +5862,7 @@ kabs16:
 clrs16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrformat'
@@ -5783,6 +5881,7 @@ clrs16:
 clz16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrformat'
@@ -5801,6 +5900,7 @@ clz16:
 clo16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrformat'
@@ -5819,6 +5919,7 @@ clo16:
 swap16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrformat'
@@ -5837,6 +5938,7 @@ swap16:
 smin8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5868,6 +5970,7 @@ smin8:
 umin8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5899,6 +6002,7 @@ umin8:
 smax8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5930,6 +6034,7 @@ smax8:
 umax8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -5961,6 +6066,7 @@ umax8:
 kabs8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -5983,6 +6089,7 @@ kabs8:
 sclip8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbriformat'
@@ -6006,6 +6113,7 @@ sclip8:
 uclip8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbriformat'
@@ -6029,6 +6137,7 @@ uclip8:
 clrs8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6051,6 +6160,7 @@ clrs8:
 clz8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6073,6 +6183,7 @@ clz8:
 clo8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6095,6 +6206,7 @@ clo8:
 swap8:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6117,6 +6229,7 @@ swap8:
 sunpkd810:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6139,6 +6252,7 @@ sunpkd810:
 sunpkd820:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6161,6 +6275,7 @@ sunpkd820:
 sunpkd830:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6183,6 +6298,7 @@ sunpkd830:
 sunpkd831:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6205,6 +6321,7 @@ sunpkd831:
 sunpkd832:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6227,6 +6344,7 @@ sunpkd832:
 zunpkd810:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6249,6 +6367,7 @@ zunpkd810:
 zunpkd820:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6271,6 +6390,7 @@ zunpkd820:
 zunpkd830:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6293,6 +6413,7 @@ zunpkd830:
 zunpkd831:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6315,6 +6436,7 @@ zunpkd831:
 zunpkd832:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrformat'
@@ -6339,6 +6461,7 @@ zunpkd832:
 pkbb16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -6362,6 +6485,7 @@ pkbb16:
 pkbt16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -6385,6 +6509,7 @@ pkbt16:
 pktb16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -6408,6 +6533,7 @@ pktb16:
 pktt16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -6431,6 +6557,7 @@ pktt16:
 smmul:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -6450,6 +6577,7 @@ smmul:
 smmul.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -6469,6 +6597,7 @@ smmul.u:
 kmmac:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -6488,6 +6617,7 @@ kmmac:
 kmmac.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -6507,6 +6637,7 @@ kmmac.u:
 kmmsb:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -6526,6 +6657,7 @@ kmmsb:
 kmmsb.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -6545,6 +6677,7 @@ kmmsb.u:
 kwmmul:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -6564,6 +6697,7 @@ kwmmul:
 kwmmul.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -6585,6 +6719,7 @@ kwmmul.u:
 smmwb:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6608,6 +6743,7 @@ smmwb:
 smmwb.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6629,6 +6765,7 @@ smmwb.u:
 smmwt:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6650,6 +6787,7 @@ smmwt:
 smmwt.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6672,6 +6810,7 @@ smmwt.u:
 kmmawb:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6693,6 +6832,7 @@ kmmawb:
 kmmawb.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6714,6 +6854,7 @@ kmmawb.u:
 kmmawt:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6735,6 +6876,7 @@ kmmawt:
 kmmawt.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6756,6 +6898,7 @@ kmmawt.u:
 kmmwb2:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6778,6 +6921,7 @@ kmmwb2:
 kmmwb2.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6799,6 +6943,7 @@ kmmwb2.u:
 kmmwt2:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6820,6 +6965,7 @@ kmmwt2:
 kmmwt2.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6842,6 +6988,7 @@ kmmwt2.u:
 kmmawb2:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6863,6 +7010,7 @@ kmmawb2:
 kmmawb2.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6884,6 +7032,7 @@ kmmawb2.u:
 kmmawt2:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6905,6 +7054,7 @@ kmmawt2:
 kmmawt2.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32, 16
   formattype: 'pwhrrformat'
@@ -6929,6 +7079,7 @@ kmmawt2.u:
 smbb16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -6952,6 +7103,7 @@ smbb16:
 smbt16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -6975,6 +7127,7 @@ smbt16:
 smtt16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -6998,6 +7151,7 @@ smtt16:
 kmda:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7021,6 +7175,7 @@ kmda:
 kmxda:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7044,6 +7199,7 @@ kmxda:
 smds:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7068,6 +7224,7 @@ smds:
 smdrs:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7091,6 +7248,7 @@ smdrs:
 smxds:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7114,6 +7272,7 @@ smxds:
 kmabb:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7137,6 +7296,7 @@ kmabb:
 kmabt:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7160,6 +7320,7 @@ kmabt:
 kmatt:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7183,6 +7344,7 @@ kmatt:
 kmada:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7206,6 +7368,7 @@ kmada:
 kmaxda:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7229,6 +7392,7 @@ kmaxda:
 kmads:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7252,6 +7416,7 @@ kmads:
 kmadrs:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7275,6 +7440,7 @@ kmadrs:
 kmaxds:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7298,6 +7464,7 @@ kmaxds:
 kmsda:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7321,6 +7488,7 @@ kmsda:
 kmsxda:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -7346,6 +7514,7 @@ kmsxda:
 smal:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   p64_profile: 'ppn'
@@ -7369,6 +7538,7 @@ smal:
 sclip32:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwriformat'
@@ -7384,8 +7554,9 @@ sclip32:
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 uclip32:
-  stride: 1  
+  stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwriformat'
@@ -7403,6 +7574,7 @@ uclip32:
 clrs32:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrformat'
@@ -7419,6 +7591,7 @@ clrs32:
 clz32:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrformat'
@@ -7435,6 +7608,7 @@ clz32:
 clo32:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrformat'
@@ -7451,6 +7625,7 @@ clo32:
 pbsad:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -7482,6 +7657,7 @@ pbsad:
 pbsada:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -7513,6 +7689,7 @@ pbsada:
 smaqa:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -7544,6 +7721,7 @@ smaqa:
 umaqa:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -7575,6 +7753,7 @@ umaqa:
 smaqa.su:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 8
   formattype: 'pbrrformat'
@@ -7607,6 +7786,7 @@ smaqa.su:
 add64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
@@ -7626,6 +7806,7 @@ add64:
 radd64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
@@ -7645,6 +7826,7 @@ radd64:
 uradd64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
@@ -7664,6 +7846,7 @@ uradd64:
 kadd64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
@@ -7683,6 +7866,7 @@ kadd64:
 ukadd64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
@@ -7702,6 +7886,7 @@ ukadd64:
 sub64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
@@ -7721,6 +7906,7 @@ sub64:
 rsub64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
@@ -7740,6 +7926,7 @@ rsub64:
 ursub64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
@@ -7759,6 +7946,7 @@ ursub64:
 ksub64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
@@ -7778,6 +7966,7 @@ ksub64:
 uksub64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'ppp'
@@ -7798,6 +7987,7 @@ uksub64:
 smar64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -7817,6 +8007,7 @@ smar64:
 smsr64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -7836,6 +8027,7 @@ smsr64:
 umar64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -7855,6 +8047,7 @@ umar64:
 umsr64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -7874,6 +8067,7 @@ umsr64:
 kmar64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -7893,6 +8087,7 @@ kmar64:
 kmsr64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -7912,6 +8107,7 @@ kmsr64:
 ukmar64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -7931,6 +8127,7 @@ ukmar64:
 ukmsr64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -7952,6 +8149,7 @@ ukmsr64:
 smalbb:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -7971,6 +8169,7 @@ smalbb:
 smalbt:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -7990,6 +8189,7 @@ smalbt:
 smaltt:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -8009,6 +8209,7 @@ smaltt:
 smalda:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -8028,6 +8229,7 @@ smalda:
 smalxda:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -8047,6 +8249,7 @@ smalxda:
 smalds:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -8066,6 +8269,7 @@ smalds:
 smaldrs:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -8085,6 +8289,7 @@ smaldrs:
 smalxds:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -8104,6 +8309,7 @@ smalxds:
 smslda:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -8123,6 +8329,7 @@ smslda:
 smslxda:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'pnn'
@@ -8144,6 +8351,7 @@ smslxda:
 kaddh:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8164,6 +8372,7 @@ kaddh:
 ksubh:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8184,6 +8393,7 @@ ksubh:
 khmbb:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -8208,6 +8418,7 @@ khmbb:
 khmbt:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -8231,6 +8442,7 @@ khmbt:
 khmtt:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -8254,6 +8466,7 @@ khmtt:
 ukaddh:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8273,6 +8486,7 @@ ukaddh:
 uksubh:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8293,6 +8507,7 @@ uksubh:
 kaddw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8312,6 +8527,7 @@ kaddw:
 ukaddw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8331,6 +8547,7 @@ ukaddw:
 ksubw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8350,6 +8567,7 @@ ksubw:
 uksubw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8369,6 +8587,7 @@ uksubw:
 kdmbb:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -8392,6 +8611,7 @@ kdmbb:
 kdmbt:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -8415,6 +8635,7 @@ kdmbt:
 kdmtt:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -8438,6 +8659,7 @@ kdmtt:
 kslraw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8457,6 +8679,7 @@ kslraw:
 kslraw.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8476,6 +8699,7 @@ kslraw.u:
 ksllw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pswrrformat'
@@ -8494,6 +8718,7 @@ ksllw:
 kslliw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwriformat'
@@ -8512,6 +8737,7 @@ kslliw:
 kdmabb:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -8535,6 +8761,7 @@ kdmabb:
 kdmabt:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -8558,6 +8785,7 @@ kdmabt:
 kdmatt:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -8581,6 +8809,7 @@ kdmatt:
 kabsw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrformat'
@@ -8599,6 +8828,7 @@ kabsw:
 raddw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8616,6 +8846,7 @@ raddw:
 uraddw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8633,6 +8864,7 @@ uraddw:
 rsubw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8650,6 +8882,7 @@ rsubw:
 ursubw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8667,6 +8900,7 @@ ursubw:
 maxw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8684,6 +8918,7 @@ maxw:
 minw:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8701,6 +8936,7 @@ minw:
 msubr32:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8718,6 +8954,7 @@ msubr32:
 mulr64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   p64_profile: 'pnn'
@@ -8737,6 +8974,7 @@ mulr64:
 mulsr64:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   p64_profile: 'pnn'
@@ -8758,6 +8996,7 @@ rdov:
   stride: 1
   rd_op_data: *all_regs
   xlen: [32,64]
+  std_op:
   isa: IP
   formattype: 'uformat'
   imm_val_data: 'gen_usign_dataset(2)'
@@ -8771,6 +9010,7 @@ clrov:
   stride: 1
   rd_op_data: *all_regs
   xlen: [32,64]
+  std_op:
   isa: IP
   formattype: 'uformat'
   imm_val_data: 'gen_usign_dataset(2)'
@@ -8787,6 +9027,7 @@ clrov:
 ave:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'rformat'
@@ -8804,6 +9045,7 @@ ave:
 sra.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'rformat'
@@ -8821,6 +9063,7 @@ sra.u:
 srai.u:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'iformat'
@@ -8838,6 +9081,7 @@ srai.u:
 bitrev:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'rformat'
@@ -8855,6 +9099,7 @@ bitrev:
 bitrevi:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'iformat'
@@ -8872,6 +9117,7 @@ bitrevi:
 wext:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'npn'
@@ -8891,6 +9137,7 @@ wext:
 wexti:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 64
   p64_profile: 'np '
@@ -8911,6 +9158,7 @@ wexti:
 bpick:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   formattype: 'prrrformat'
   rs1_op_data: *all_regs
@@ -8929,6 +9177,7 @@ bpick:
 insb:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'iformat'
@@ -8946,6 +9195,7 @@ insb:
 maddr32:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8966,6 +9216,7 @@ maddr32:
 add32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -8985,6 +9236,7 @@ add32:
 radd32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9004,6 +9256,7 @@ radd32:
 uradd32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9023,6 +9276,7 @@ uradd32:
 kadd32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9042,6 +9296,7 @@ kadd32:
 ukadd32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9061,6 +9316,7 @@ ukadd32:
 sub32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9080,6 +9336,7 @@ sub32:
 kmda32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9099,6 +9356,7 @@ kmda32:
 kmxda32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9118,6 +9376,7 @@ kmxda32:
 kmada32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9137,6 +9396,7 @@ kmada32:
 kmaxda32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9156,6 +9416,7 @@ kmaxda32:
 kmads32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9175,6 +9436,7 @@ kmads32:
 kmadrs32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9194,6 +9456,7 @@ kmadrs32:
 kmaxds32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9213,6 +9476,7 @@ kmaxds32:
 kmsda32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9232,6 +9496,7 @@ kmsda32:
 kmsxda32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9251,6 +9516,7 @@ kmsxda32:
 smds32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9270,6 +9536,7 @@ smds32:
 smdrs32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9289,6 +9556,7 @@ smdrs32:
 smxds32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9308,6 +9576,7 @@ smxds32:
 sraiw.u:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwriformat'
@@ -9326,6 +9595,7 @@ sraiw.u:
 pkbb32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9345,6 +9615,7 @@ pkbb32:
 pkbt32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9364,6 +9635,7 @@ pkbt32:
 pktb32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9384,6 +9656,7 @@ pktb32:
 pktt32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9404,6 +9677,7 @@ pktt32:
 rsub32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9424,6 +9698,7 @@ rsub32:
 ursub32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9443,6 +9718,7 @@ ursub32:
 ksub32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9462,6 +9738,7 @@ ksub32:
 uksub32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9481,6 +9758,7 @@ uksub32:
 cras32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9500,6 +9778,7 @@ cras32:
 rcras32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9520,6 +9799,7 @@ rcras32:
 urcras32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9539,6 +9819,7 @@ urcras32:
 kcras32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9558,6 +9839,7 @@ kcras32:
 ukcras32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9577,6 +9859,7 @@ ukcras32:
 crsa32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9596,6 +9879,7 @@ crsa32:
 rcrsa32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9615,6 +9899,7 @@ rcrsa32:
 urcrsa32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9634,6 +9919,7 @@ urcrsa32:
 kcrsa32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9653,6 +9939,7 @@ kcrsa32:
 ukcrsa32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9672,6 +9959,7 @@ ukcrsa32:
 stas32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9691,6 +9979,7 @@ stas32:
 rstas32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9710,6 +9999,7 @@ rstas32:
 urstas32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9729,6 +10019,7 @@ urstas32:
 kstas32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9748,6 +10039,7 @@ kstas32:
 ukstas32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9767,6 +10059,7 @@ ukstas32:
 stsa32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9786,6 +10079,7 @@ stsa32:
 rstsa32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9805,6 +10099,7 @@ rstsa32:
 urstsa32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9824,6 +10119,7 @@ urstsa32:
 kstsa32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9843,6 +10139,7 @@ kstsa32:
 ukstsa32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -9862,6 +10159,7 @@ ukstsa32:
 sra32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pswrrformat'
@@ -9880,6 +10178,7 @@ sra32:
 srai32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwriformat'
@@ -9897,6 +10196,7 @@ srai32:
 sra32.u:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pswrrformat'
@@ -9915,6 +10215,7 @@ sra32.u:
 srai32.u:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwriformat'
@@ -9932,6 +10233,7 @@ srai32.u:
 srl32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pswrrformat'
@@ -9950,6 +10252,7 @@ srl32:
 srli32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwriformat'
@@ -9967,6 +10270,7 @@ srli32:
 srl32.u:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pswrrformat'
@@ -9985,6 +10289,7 @@ srl32.u:
 srli32.u:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwriformat'
@@ -10002,6 +10307,7 @@ srli32.u:
 sll32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pswrrformat'
@@ -10020,6 +10326,7 @@ sll32:
 slli32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwriformat'
@@ -10037,6 +10344,7 @@ slli32:
 ksll32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pswrrformat'
@@ -10055,6 +10363,7 @@ ksll32:
 kslli32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwriformat'
@@ -10072,6 +10381,7 @@ kslli32:
 kslra32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pswrrformat'
@@ -10090,6 +10400,7 @@ kslra32:
 kslra32.u:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pswrrformat'
@@ -10108,6 +10419,7 @@ kslra32.u:
 smin32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -10127,6 +10439,7 @@ smin32:
 umin32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -10146,6 +10459,7 @@ umin32:
 smax32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -10165,6 +10479,7 @@ smax32:
 umax32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -10184,6 +10499,7 @@ umax32:
 kabs32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrformat'
@@ -10200,6 +10516,7 @@ kabs32:
 khmbb16:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -10223,6 +10540,7 @@ khmbb16:
 khmbt16:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -10246,6 +10564,7 @@ khmbt16:
 khmtt16:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -10269,6 +10588,7 @@ khmtt16:
 kdmbb16:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -10292,6 +10612,7 @@ kdmbb16:
 kdmbt16:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -10315,6 +10636,7 @@ kdmbt16:
 kdmtt16:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -10338,6 +10660,7 @@ kdmtt16:
 kdmabb16:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -10361,6 +10684,7 @@ kdmabb16:
 kdmabt16:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -10384,6 +10708,7 @@ kdmabt16:
 kdmatt16:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'
@@ -10407,6 +10732,7 @@ kdmatt16:
 smbb32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -10426,6 +10752,7 @@ smbb32:
 smbt32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -10445,6 +10772,7 @@ smbt32:
 smtt32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -10464,6 +10792,7 @@ smtt32:
 kmabb32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -10483,6 +10812,7 @@ kmabb32:
 kmabt32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'
@@ -10502,6 +10832,7 @@ kmabt32:
 kmatt32:
   stride: 1
   xlen: [64]
+  std_op:
   isa: IP
   bit_width: 32
   formattype: 'pwrrformat'

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -439,8 +439,8 @@ srai:
   isa: I
   operation: 'hex(rs1_val >> (imm_val))'
   formattype: 'iformat'
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  imm_val_data: 'gen_sign_dataset(ceil(log(xlen,2)))'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
+  imm_val_data: 'gen_usign_dataset(ceil(log(xlen,2)))'
   template: |-
 
     // $comment
@@ -3326,6 +3326,12 @@ roriw:
   formattype: 'iformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
 rev8.w:
   stride: 1
   xlen: [64]

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -10766,7 +10766,6 @@ smbt32:
   bit_width: 32
   formattype: 'pwrrformat'
   rs1_op_data: *all_regs
-  rs2_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_w0_val_data: 'gen_sign_dataset(32)'
   rs1_w1_val_data: 'gen_sign_dataset(32)'
@@ -10775,8 +10774,8 @@ smbt32:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
 
 smtt32:
   stride: 1

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -7496,3 +7496,91 @@ kslra32.u:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smin32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+umin32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smax32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+umax32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w1_val_data: 'gen_usign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kabs32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -6164,3 +6164,91 @@ zunpkd832:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
+pkbb16:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_usign_dataset(16)'
+  rs1_h1_val_data: 'gen_usign_dataset(16)'
+  rs1_h2_val_data: 'gen_usign_dataset(16)'
+  rs1_h3_val_data: 'gen_usign_dataset(16)'
+  rs2_h0_val_data: 'gen_usign_dataset(16)'
+  rs2_h1_val_data: 'gen_usign_dataset(16)'
+  rs2_h2_val_data: 'gen_usign_dataset(16)'
+  rs2_h3_val_data: 'gen_usign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+pkbt16:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_usign_dataset(16)'
+  rs1_h1_val_data: 'gen_usign_dataset(16)'
+  rs1_h2_val_data: 'gen_usign_dataset(16)'
+  rs1_h3_val_data: 'gen_usign_dataset(16)'
+  rs2_h0_val_data: 'gen_usign_dataset(16)'
+  rs2_h1_val_data: 'gen_usign_dataset(16)'
+  rs2_h2_val_data: 'gen_usign_dataset(16)'
+  rs2_h3_val_data: 'gen_usign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+pktb16:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_usign_dataset(16)'
+  rs1_h1_val_data: 'gen_usign_dataset(16)'
+  rs1_h2_val_data: 'gen_usign_dataset(16)'
+  rs1_h3_val_data: 'gen_usign_dataset(16)'
+  rs2_h0_val_data: 'gen_usign_dataset(16)'
+  rs2_h1_val_data: 'gen_usign_dataset(16)'
+  rs2_h2_val_data: 'gen_usign_dataset(16)'
+  rs2_h3_val_data: 'gen_usign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+pktt16:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_usign_dataset(16)'
+  rs1_h1_val_data: 'gen_usign_dataset(16)'
+  rs1_h2_val_data: 'gen_usign_dataset(16)'
+  rs1_h3_val_data: 'gen_usign_dataset(16)'
+  rs2_h0_val_data: 'gen_usign_dataset(16)'
+  rs2_h1_val_data: 'gen_usign_dataset(16)'
+  rs2_h2_val_data: 'gen_usign_dataset(16)'
+  rs2_h3_val_data: 'gen_usign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -6203,6 +6203,8 @@ zunpkd832:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
+# 2.3 Partial-SIMD Data Processing Instructions
+
 pkbb16:
   xlen: [32,64]
   isa: IP
@@ -6285,6 +6287,405 @@ pktt16:
   rs2_h1_val_data: 'gen_usign_dataset(16)'
   rs2_h2_val_data: 'gen_usign_dataset(16)'
   rs2_h3_val_data: 'gen_usign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+# 2.3.4 Signed 16-bit Multiply with 32-bit Add/Subtract Instructions
+
+smbb16:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smbt16:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smtt16:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmda:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmxda:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smds:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+smdrs:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smxds:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmabb:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmabt:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmatt:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmada:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmaxda:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmads:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmadrs:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmaxds:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmsda:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmsxda:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -5954,3 +5954,213 @@ swap8:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
+sunpkd810:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+sunpkd820:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+sunpkd830:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+sunpkd831:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+sunpkd832:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
+  rs1_b1_val_data: 'gen_sign_dataset(8)'
+  rs1_b2_val_data: 'gen_sign_dataset(8)'
+  rs1_b3_val_data: 'gen_sign_dataset(8)'
+  rs1_b4_val_data: 'gen_sign_dataset(8)'
+  rs1_b5_val_data: 'gen_sign_dataset(8)'
+  rs1_b6_val_data: 'gen_sign_dataset(8)'
+  rs1_b7_val_data: 'gen_sign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+zunpkd810:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+zunpkd820:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+zunpkd830:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+zunpkd831:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+zunpkd832:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 8
+  formattype: 'pbrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -4,7 +4,7 @@ metadata:
   all_fregs: &all_fregs "['f'+str(x) for x in range(0,32 if 'e' not in base_isa else 16)]"
   all_regs_mx0: &all_regs_mx0 "['x'+str(x) for x in range(1,32 if 'e' not in base_isa else 16)]"
   c_regs: &c_regs "['x'+str(x) for x in range(8,16)]"
-  pair_regs: &pair_regs "['x'+str(x) for x in range(2,32 if 'e' not in base_isa else 16, 2)]"
+  pair_regs: &pair_regs "['x'+str(x) for x in range(2,32 if 'e' not in base_isa else 16, 2 if xlen == 32 else 1)]"
 
 add:
   stride: 1
@@ -23,7 +23,6 @@ add:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
- 
 
 sub:
   stride: 1
@@ -38,7 +37,7 @@ sub:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -57,7 +56,7 @@ addw:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -75,7 +74,7 @@ subw:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -93,7 +92,7 @@ and:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -111,7 +110,7 @@ or:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -129,7 +128,7 @@ slt:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -147,7 +146,7 @@ sltu:
   rs1_val_data: 'gen_usign_dataset(xlen) + gen_sp_dataset(xlen,False)'
   rs2_val_data: 'gen_usign_dataset(xlen) + gen_sp_dataset(xlen,False)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -165,7 +164,7 @@ xor:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -183,7 +182,7 @@ sllw:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_usign_dataset(5)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -201,7 +200,7 @@ srlw:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_usign_dataset(5)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -219,7 +218,7 @@ sraw:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_usign_dataset(5)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -237,7 +236,7 @@ sll:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(xlen,2)))'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -255,7 +254,7 @@ srl:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(xlen,2)))'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -273,7 +272,7 @@ sra:
   rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_usign_dataset(ceil(log(xlen,2)))'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
@@ -290,7 +289,7 @@ addi:
   imm_val_data: 'gen_sign_dataset(12)+ gen_sp_dataset(12)'
   formattype: 'iformat'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -307,7 +306,7 @@ addiw:
   imm_val_data: 'gen_sign_dataset(12)+ gen_sp_dataset(12,True)'
   formattype: 'iformat'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -324,7 +323,7 @@ slti:
   imm_val_data: 'gen_sign_dataset(12)+ gen_sp_dataset(12,True)'
   formattype: 'iformat'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -341,7 +340,7 @@ sltiu:
   imm_val_data: 'gen_usign_dataset(12)+ gen_sp_dataset(12,False)'
   formattype: 'iformat'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -358,7 +357,7 @@ andi:
   imm_val_data: 'gen_sign_dataset(12)+ gen_sp_dataset(12)'
   formattype: 'iformat'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -375,7 +374,7 @@ ori:
   imm_val_data: 'gen_sign_dataset(12)+ gen_sp_dataset(12)'
   formattype: 'iformat'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -392,7 +391,7 @@ xori:
   imm_val_data: 'gen_sign_dataset(12)+ gen_sp_dataset(12)'
   formattype: 'iformat'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -409,7 +408,7 @@ slli:
   rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   imm_val_data: 'gen_usign_dataset(ceil(log(xlen,2)))'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -426,7 +425,7 @@ srli:
   rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   imm_val_data: 'gen_usign_dataset(ceil(log(xlen,2)))'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -440,10 +439,10 @@ srai:
   isa: I
   operation: 'hex(rs1_val >> (imm_val))'
   formattype: 'iformat'
-  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
-  imm_val_data: 'gen_usign_dataset(ceil(log(xlen,2)))'
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  imm_val_data: 'gen_sign_dataset(ceil(log(xlen,2)))'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -460,7 +459,7 @@ slliw:
   rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   imm_val_data: 'gen_usign_dataset(5)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -477,7 +476,7 @@ srliw:
   rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   imm_val_data: 'gen_usign_dataset(5)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -494,7 +493,7 @@ sraiw:
   rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   imm_val_data: 'gen_usign_dataset(5)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
@@ -509,7 +508,7 @@ lui:
   formattype: 'uformat'
   imm_val_data: 'gen_usign_dataset(20)+ gen_sp_dataset(20,False)'
   template: |-
-    
+
     // $comment
     // opcode: $inst ; dest:$rd; immval:$imm_val
     TEST_CASE($testreg, $rd, $correctval, $swreg, $offset, $inst $rd,$imm_val)
@@ -846,7 +845,7 @@ jalr:
   template: |-
 
     // $comment
-    // opcode: jalr; op1:$rs1; dest:$rd; immval:$imm_val; align:$ea_align 
+    // opcode: jalr; op1:$rs1; dest:$rd; immval:$imm_val; align:$ea_align
     TEST_JALR_OP($testreg, $rd, $rs1, $imm_val, $swreg, $offset,$ea_align)
 
 mul:
@@ -4075,7 +4074,7 @@ add8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
@@ -4105,7 +4104,7 @@ radd8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -4135,7 +4134,7 @@ uradd8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -4165,7 +4164,7 @@ kadd8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -4195,7 +4194,7 @@ ukadd8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -4225,7 +4224,7 @@ sub8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
@@ -4255,7 +4254,7 @@ rsub8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -4285,7 +4284,7 @@ usub8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -4315,7 +4314,7 @@ ksub8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -4345,7 +4344,7 @@ uksub8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -4635,7 +4634,7 @@ sra8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -4657,7 +4656,7 @@ srai8:
   formattype: 'pbriformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -4680,7 +4679,7 @@ sra8.u:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -4702,7 +4701,7 @@ srai8.u:
   formattype: 'pbriformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -4725,7 +4724,7 @@ srl8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -4747,7 +4746,7 @@ srli8:
   formattype: 'pbriformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -4770,7 +4769,7 @@ srl8.u:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -4792,7 +4791,7 @@ srli8.u:
   formattype: 'pbriformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -4815,7 +4814,7 @@ sll8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -4837,7 +4836,7 @@ slli8:
   formattype: 'pbriformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -4860,7 +4859,7 @@ ksll8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -4882,7 +4881,7 @@ kslli8:
   formattype: 'pbriformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -4905,7 +4904,7 @@ kslra8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -4928,7 +4927,7 @@ kslra8.u:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -5061,7 +5060,7 @@ cmpeq8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8) + gen_usign_dataset(8)'
@@ -5091,7 +5090,7 @@ scmplt8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -5121,7 +5120,7 @@ scmple8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -5151,7 +5150,7 @@ ucmplt8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -5181,7 +5180,7 @@ ucmple8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -5343,7 +5342,7 @@ smul8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -5373,7 +5372,7 @@ smulx8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -5403,7 +5402,7 @@ umul8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -5433,7 +5432,7 @@ umulx8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -5463,7 +5462,7 @@ khm8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -5493,7 +5492,7 @@ khmx8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -5732,7 +5731,7 @@ smin8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -5762,7 +5761,7 @@ umin8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -5792,7 +5791,7 @@ smax8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)' 
+  rs1_b0_val_data: 'gen_sign_dataset(8)'
   rs1_b1_val_data: 'gen_sign_dataset(8)'
   rs1_b2_val_data: 'gen_sign_dataset(8)'
   rs1_b3_val_data: 'gen_sign_dataset(8)'
@@ -5822,7 +5821,7 @@ umax8:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_usign_dataset(8)' 
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
   rs1_b1_val_data: 'gen_usign_dataset(8)'
   rs1_b2_val_data: 'gen_usign_dataset(8)'
   rs1_b3_val_data: 'gen_usign_dataset(8)'
@@ -6292,6 +6291,478 @@ pktt16:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+# 2.3.2 Most Significant Word 32x32 Multiply & Add Instructions
+smmul:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smmul.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmac:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmac.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmsb:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmsb.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kwmmul:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kwmmul.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs1_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w1_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+# 2.3.3 Most Significant Word 32x32 Multiply & Add Instructions
+smmwb:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+
+smmwb.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smmwt:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smmwt.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+kmmawb:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmawb.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmawt:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmawt.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmwb2:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+kmmwb2.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmwt2:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmwt2.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+kmmawb2:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmawb2.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmawt2:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmmawt2.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32, 16
+  formattype: 'pwhrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
 
 # 2.3.4 Signed 16-bit Multiply with 32-bit Add/Subtract Instructions
 
@@ -6692,6 +7163,28 @@ kmsxda:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# 2.3.5 Signed 16-bit Multiply with 64-bit Add/Subtract Instructions
+
+smal:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 16
+  p64_profile: 'ppn'
+  formattype: 'rformat'
+  rs1_op_data: *pair_regs
+  rs2_op_data: *all_regs
+
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs1_hi_val op3val:$rs2_val;  op4val:$rs2_hi_val
+    TEST_P64_PPN_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $swreg, $offset, $testreg)
+
+
 # 2.3.6 Miscellaneous Instructions
 
 sclip32:
@@ -6921,6 +7414,496 @@ smaqa.su:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+# 2.4.1 64-bit Addition & Subtraction Instructions
+add64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'ppp'
+  formattype: 'rformat'
+  rs1_op_data: *pair_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+
+uradd64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'ppp'
+  formattype: 'rformat'
+  rs1_op_data: *pair_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+
+kadd64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'ppp'
+  formattype: 'rformat'
+  rs1_op_data: *pair_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+
+ukadd64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'ppp'
+  formattype: 'rformat'
+  rs1_op_data: *pair_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+
+sub64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'ppp'
+  formattype: 'rformat'
+  rs1_op_data: *pair_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+
+rsub64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'ppp'
+  formattype: 'rformat'
+  rs1_op_data: *pair_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+
+ursub64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'ppp'
+  formattype: 'rformat'
+  rs1_op_data: *pair_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+
+ksub64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'ppp'
+  formattype: 'rformat'
+  rs1_op_data: *pair_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+
+uksub64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'ppp'
+  formattype: 'rformat'
+  rs1_op_data: *pair_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+
+# 2.4.2 32-bit Multiply with 64-bit Add/Subtract Instructions
+smar64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smsr64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+umar64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+umsr64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmar64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmsr64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ukmar64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ukmsr64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+# 2.4.3 Signed 16-bit Multiply with 64-bit Add/Subtract Instructions
+smalbb:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smalbt:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smaltt:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smalda:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smalxda:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smalds:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smaldrs:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smalxds:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smslda:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smslxda:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
 # 2.5. Non-SIMD Instructions
 
 kaddh:
@@ -6935,6 +7918,7 @@ kaddh:
   rs1_w1_val_data: 'gen_sign_dataset(32)'
   rs2_w0_val_data: 'gen_sign_dataset(32)'
   rs2_w1_val_data: 'gen_sign_dataset(32)'
+
   template: |-
 
     // $comment
@@ -6953,6 +7937,7 @@ ksubh:
   rs1_w1_val_data: 'gen_sign_dataset(32)'
   rs2_w0_val_data: 'gen_sign_dataset(32)'
   rs2_w1_val_data: 'gen_sign_dataset(32)'
+
   template: |-
 
     // $comment
@@ -6975,6 +7960,7 @@ khmbb:
   rs2_h1_val_data: 'gen_sign_dataset(16)'
   rs2_h2_val_data: 'gen_sign_dataset(16)'
   rs2_h3_val_data: 'gen_sign_dataset(16)'
+
   template: |-
 
     // $comment
@@ -7349,6 +8335,349 @@ kabsw:
     // $comment
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
+
+# 2.5.3. 32-bit Computation Instructions
+
+raddw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+uraddw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+rsubw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+ursubw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+maxw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+minw:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+msubr32:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+mulr64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+  
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val;
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+mulsr64:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  p64_profile: 'pnn'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *pair_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+
+# 2.5.5. Miscellaneous Instructions
+
+ave:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+sra.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+srai.u:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'iformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+bitrev:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+bitrevi:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'iformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+
+wext:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'npn'
+  formattype: 'rformat'
+  rs1_op_data: *pair_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val
+    TEST_P64_NPN_OP($inst, $rd, $rs1, $rs1_hi, $rs2, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $swreg, $offset, $testreg)
+
+wexti:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 64
+  p64_profile: 'np '
+  formattype: 'iformat'
+  rs1_op_data: *pair_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(32,2)))'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi; immval:$imm_val
+    TEST_P64_NP_OP($inst, $rd, $rs1, $rs1_hi, $correctval, $rs1_val, $rs1_val_hi, $imm_val, $swreg, $offset, $testreg)
+
+
+
+bpick:
+  xlen: [32,64]
+  isa: IP
+  formattype: 'prrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rs3_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs3_val_data: 'gen_sign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; op3:$rs3; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val op3val:$rs3_val
+    TEST_RRR_OP($inst, $rd, $rs1, $rs2, $rs3, $correctval, $rs1_val, $rs2_val, $rs3_val, $swreg, $offset, $testreg)
+
+insb:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwriformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2))-3)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $imm_val, $swreg, $offset, $testreg)
+
+
+maddr32:
+  xlen: [32,64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  rs2_w0_val_data: 'gen_sign_dataset(32) + gen_sp_dataset(32,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;  immval:$imm_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+
+# 2.5.4
+rdov:
+  rd_op_data: *all_regs
+  xlen: [32,64]
+  isa: IP
+  formattype: 'uformat'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; dest:$rd
+    TEST_CASE($testreg, $rd, $correctval, $swreg, $offset, $inst $rd)
+
+clrov:
+  rd_op_data: *all_regs
+  xlen: [32,64]
+  isa: IP
+  formattype: 'uformat'
+  template: |-
+
+    // $comment
+    // opcode: $inst
+    TEST_CASE($testreg, $correctval, $swreg, $offset, $inst)
 
 # 2.6. RV64 Only Instructions
 

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -7530,8 +7530,8 @@ smal:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs1_hi_val op3val:$rs2_val;  op4val:$rs2_hi_val
-    TEST_P64_PPN_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64; op2val:$rs2_val;
+    TEST_P64_PPN_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 
 # 2.3.6 Miscellaneous Instructions
@@ -7801,8 +7801,8 @@ add64:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64 op2val:$rs2_val64
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 radd64:
   stride: 1
@@ -7821,8 +7821,8 @@ radd64:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 uradd64:
   stride: 1
@@ -7841,8 +7841,8 @@ uradd64:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 kadd64:
   stride: 1
@@ -7861,8 +7861,8 @@ kadd64:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 ukadd64:
   stride: 1
@@ -7881,8 +7881,8 @@ ukadd64:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 sub64:
   stride: 1
@@ -7901,8 +7901,8 @@ sub64:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 rsub64:
   stride: 1
@@ -7921,8 +7921,8 @@ rsub64:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 ursub64:
   stride: 1
@@ -7941,8 +7941,8 @@ ursub64:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 ksub64:
   stride: 1
@@ -7961,8 +7961,8 @@ ksub64:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 uksub64:
   stride: 1
@@ -7981,8 +7981,8 @@ uksub64:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; op4:$rs2_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val;  op4val:$rs2_val_hi
-    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64;  op2val:$rs2_val64;
+    TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $offset_hi, $testreg)
 
 # 2.4.2 32-bit Multiply with 64-bit Add/Subtract Instructions
 smar64:
@@ -8003,7 +8003,7 @@ smar64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smsr64:
   stride: 1
@@ -8023,7 +8023,7 @@ smsr64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 umar64:
   stride: 1
@@ -8043,7 +8043,7 @@ umar64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 umsr64:
   stride: 1
@@ -8063,7 +8063,7 @@ umsr64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 kmar64:
   stride: 1
@@ -8083,7 +8083,7 @@ kmar64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 kmsr64:
   stride: 1
@@ -8103,7 +8103,7 @@ kmsr64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 ukmar64:
   stride: 1
@@ -8123,7 +8123,7 @@ ukmar64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 ukmsr64:
   stride: 1
@@ -8143,7 +8143,7 @@ ukmsr64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 
 # 2.4.3 Signed 16-bit Multiply with 64-bit Add/Subtract Instructions
@@ -8165,7 +8165,7 @@ smalbb:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smalbt:
   stride: 1
@@ -8185,7 +8185,7 @@ smalbt:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smaltt:
   stride: 1
@@ -8205,7 +8205,7 @@ smaltt:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smalda:
   stride: 1
@@ -8225,7 +8225,7 @@ smalda:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smalxda:
   stride: 1
@@ -8245,7 +8245,7 @@ smalxda:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smalds:
   stride: 1
@@ -8265,7 +8265,7 @@ smalds:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smaldrs:
   stride: 1
@@ -8285,7 +8285,7 @@ smaldrs:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smalxds:
   stride: 1
@@ -8305,7 +8305,7 @@ smalxds:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smslda:
   stride: 1
@@ -8325,7 +8325,7 @@ smslda:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 smslxda:
   stride: 1
@@ -8345,7 +8345,7 @@ smslxda:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 # 2.5. Non-SIMD Instructions
 
@@ -8970,7 +8970,7 @@ mulr64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val;
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 mulsr64:
   stride: 1
@@ -8990,7 +8990,7 @@ mulsr64:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $offset_hi, $testreg)
 
 # 2.5.4
 rdov:
@@ -9132,7 +9132,7 @@ wext:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; op3:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi op3val:$rs2_val
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val64; op2val:$rs2_val
     TEST_P64_NPN_OP($inst, $rd, $rs1, $rs1_hi, $rs2, $correctval, $rs1_val, $rs1_val_hi, $rs2_val, $swreg, $offset, $testreg)
 
 wexti:
@@ -9141,7 +9141,7 @@ wexti:
   std_op:
   isa: IP
   bit_width: 64
-  p64_profile: 'np '
+  p64_profile: 'npi'
   formattype: 'iformat'
   rs1_op_data: *pair_regs
   rd_op_data: *all_regs
@@ -9151,7 +9151,7 @@ wexti:
   template: |-
 
     // $comment
-    // opcode: $inst ; op1:$rs1; op2:$rs1_hi; dest:$rd; op1val:$rs1_val;  op2val:$rs1_val_hi; immval:$imm_val
+    // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val64; immval:$imm_val
     TEST_P64_NP_OP($inst, $rd, $rs1, $rs1_hi, $correctval, $rs1_val, $rs1_val_hi, $imm_val, $swreg, $offset, $testreg)
 
 

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -6830,6 +6830,222 @@ sub32:
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
+kmda32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmxda32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmada32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmaxda32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmads32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmadrs32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmaxds32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmsda32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kmsxda32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smds32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smdrs32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+smxds32:
+  xlen: [64]
+  isa: IP
+  bit_width: 32
+  formattype: 'pwrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs2_w1_val_data: 'gen_sign_dataset(32)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
 
 rsub32:
   xlen: [64]

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -7725,7 +7725,7 @@ smaqa.su:
 
 add64:
   stride: 1
-  xlen: [32,64]
+  xlen: [32]
   std_op:
   isa: IP
   bit_width: 64
@@ -7825,7 +7825,7 @@ ukadd64:
 
 sub64:
   stride: 1
-  xlen: [32,64]
+  xlen: [32]
   std_op:
   isa: IP
   bit_width: 64

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -7843,8 +7843,8 @@ uradd64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_usign_dataset(xlen)'
 
   template: |-
 
@@ -7883,8 +7883,8 @@ ukadd64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_usign_dataset(xlen)'
 
   template: |-
 
@@ -7943,8 +7943,8 @@ ursub64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_usign_dataset(xlen)'
 
   template: |-
 
@@ -7983,8 +7983,8 @@ uksub64:
   rs1_op_data: *pair_regs
   rs2_op_data: *pair_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_usign_dataset(xlen)'
 
   template: |-
 
@@ -8044,8 +8044,8 @@ umar64:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_usign_dataset(xlen)'
 
   template: |-
 
@@ -8064,8 +8064,8 @@ umsr64:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_usign_dataset(xlen)'
 
   template: |-
 
@@ -8124,8 +8124,8 @@ ukmar64:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_usign_dataset(xlen)'
 
   template: |-
 
@@ -8144,8 +8144,8 @@ ukmsr64:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *pair_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_usign_dataset(xlen)'
 
   template: |-
 
@@ -8862,8 +8862,8 @@ uraddw:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
   template: |-
 
     // $comment
@@ -8898,8 +8898,8 @@ ursubw:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs2_w0_val_data: 'gen_sign_dataset(32)'
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs2_w0_val_data: 'gen_usign_dataset(32)'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -4689,7 +4689,7 @@ kslra16:
   rs1_h1_val_data: 'gen_sign_dataset(16)'
   rs1_h2_val_data: 'gen_sign_dataset(16)'
   rs1_h3_val_data: 'gen_sign_dataset(16)'
-  rs2_val_data: 'gen_sign_dataset(ceil(log(16,2)))'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
   template: |-
 
     // $comment
@@ -4706,11 +4706,11 @@ kslra16.u:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_h0_val_data: 'gen_sign_dataset(16)'
-  rs1_h1_val_data: 'gen_sign_dataset(16)'
-  rs1_h2_val_data: 'gen_sign_dataset(16)'
-  rs1_h3_val_data: 'gen_sign_dataset(16)'
-  rs2_val_data: 'gen_sign_dataset(ceil(log(16,2)))'
+  rs1_h0_val_data: 'gen_usign_dataset(16)'
+  rs1_h1_val_data: 'gen_usign_dataset(16)'
+  rs1_h2_val_data: 'gen_usign_dataset(16)'
+  rs1_h3_val_data: 'gen_usign_dataset(16)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
   template: |-
 
     // $comment
@@ -5031,7 +5031,7 @@ kslra8:
   rs1_b5_val_data: 'gen_sign_dataset(8)'
   rs1_b6_val_data: 'gen_sign_dataset(8)'
   rs1_b7_val_data: 'gen_sign_dataset(8)'
-  rs2_val_data: 'gen_sign_dataset(ceil(log(8,2)))'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
   template: |-
 
     // $comment
@@ -5048,15 +5048,15 @@ kslra8.u:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_b0_val_data: 'gen_sign_dataset(8)'
-  rs1_b1_val_data: 'gen_sign_dataset(8)'
-  rs1_b2_val_data: 'gen_sign_dataset(8)'
-  rs1_b3_val_data: 'gen_sign_dataset(8)'
-  rs1_b4_val_data: 'gen_sign_dataset(8)'
-  rs1_b5_val_data: 'gen_sign_dataset(8)'
-  rs1_b6_val_data: 'gen_sign_dataset(8)'
-  rs1_b7_val_data: 'gen_sign_dataset(8)'
-  rs2_val_data: 'gen_sign_dataset(ceil(log(8,2)))'
+  rs1_b0_val_data: 'gen_usign_dataset(8)'
+  rs1_b1_val_data: 'gen_usign_dataset(8)'
+  rs1_b2_val_data: 'gen_usign_dataset(8)'
+  rs1_b3_val_data: 'gen_usign_dataset(8)'
+  rs1_b4_val_data: 'gen_usign_dataset(8)'
+  rs1_b5_val_data: 'gen_usign_dataset(8)'
+  rs1_b6_val_data: 'gen_usign_dataset(8)'
+  rs1_b7_val_data: 'gen_usign_dataset(8)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
   template: |-
 
     // $comment
@@ -8721,8 +8721,8 @@ kslraw.u:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
   rs2_w0_val_data: 'gen_sign_dataset(32)'
   rs2_w1_val_data: 'gen_sign_dataset(32)'
   template: |-
@@ -10043,7 +10043,7 @@ kslra32:
   rd_op_data: *all_regs
   rs1_w0_val_data: 'gen_sign_dataset(32)'
   rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_val_data: 'gen_sign_dataset(ceil(log(32,2)))'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
   template: |-
 
     // $comment
@@ -10060,9 +10060,9 @@ kslra32.u:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_w0_val_data: 'gen_sign_dataset(32)'
-  rs1_w1_val_data: 'gen_sign_dataset(32)'
-  rs2_val_data: 'gen_sign_dataset(ceil(log(32,2)))'
+  rs1_w0_val_data: 'gen_usign_dataset(32)'
+  rs1_w1_val_data: 'gen_usign_dataset(32)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -7584,3 +7584,201 @@ kabs32:
     // opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val;
     TEST_IMM_OP( $inst, $rd, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
 
+khmbb16:
+  xlen: [64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+khmbt16:
+  xlen: [64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+khmtt16:
+  xlen: [64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kdmbb16:
+  xlen: [64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kdmbt16:
+  xlen: [64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kdmtt16:
+  xlen: [64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kdmabb16:
+  xlen: [64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kdmabt16:
+  xlen: [64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+kdmatt16:
+  xlen: [64]
+  isa: IP
+  bit_width: 16
+  formattype: 'phrrformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_h0_val_data: 'gen_sign_dataset(16)'
+  rs1_h1_val_data: 'gen_sign_dataset(16)'
+  rs1_h2_val_data: 'gen_sign_dataset(16)'
+  rs1_h3_val_data: 'gen_sign_dataset(16)'
+  rs2_h0_val_data: 'gen_sign_dataset(16)'
+  rs2_h1_val_data: 'gen_sign_dataset(16)'
+  rs2_h2_val_data: 'gen_sign_dataset(16)'
+  rs2_h3_val_data: 'gen_sign_dataset(16)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -3382,6 +3382,7 @@ packuw:
 add16:
   stride: 1
   xlen: [32,64]
+  std_op:
   isa: IP
   bit_width: 16
   formattype: 'phrrformat'

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -225,9 +225,9 @@ def gen_pair_reg_data(instr_dict, xlen, _bit_width, p64_profile):
         bit_width1, bit_width2 = map(int, _bit_width.split(','))
     else:
         bit_width1, bit_width2 = _bit_width, _bit_width
-    rs1_is_paired = len(p64_profile) >= 3 and p64_profile[1]=='p'
-    rs2_is_paired = len(p64_profile) >= 3 and p64_profile[2]=='p'
-    rd_is_paired  = len(p64_profile) >= 3 and p64_profile[0]=='p'
+    rs1_is_paired = xlen == 32 and len(p64_profile) >= 3 and p64_profile[1]=='p'
+    rs2_is_paired = xlen == 32 and len(p64_profile) >= 3 and p64_profile[2]=='p'
+    rd_is_paired  = xlen == 32 and len(p64_profile) >= 3 and p64_profile[0]=='p'
 
     for instr in instr_dict:
         if 'rs1' in instr:

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -12,6 +12,7 @@ OPS_RVP = {
     'pwrformat': ['rs1', 'rd'],
     'pswrrformat': ['rs1', 'rs2', 'rd'],
     'pwhrrformat': ['rs1', 'rs2', 'rd'],
+    'prrformat': ['rs1', 'rs2', 'rd'],
     'prrrformat': ['rs1', 'rs2', 'rs3', 'rd']
 
 }
@@ -31,6 +32,7 @@ VALS_RVP = {
     'pwrformat': 'simd_val_vars("rs1", xlen, 32)',
     'pswrrformat': 'simd_val_vars("rs1", xlen, 32) + ["rs2_val"]',
     'pwhrrformat': 'simd_val_vars("rs1", xlen, 32) + simd_val_vars("rs2", xlen, 16)',
+    'prrformat': "['rs1_val', 'rs2_val']",
     'prrrformat': "['rs1_val', 'rs2_val' , 'rs3_val']"
 
 }

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -225,9 +225,13 @@ def gen_pair_reg_data(instr_dict, xlen, _bit_width, p64_profile):
 
     '''
     if type(_bit_width)==str:
-        bit_width1, bit_width2 = map(int, _bit_width.split(','))
+        _bit_width = eval(_bit_width)
+
+    if type(_bit_width)==tuple:
+        bit_width1, bit_width2 = _bit_width
     else:
         bit_width1, bit_width2 = _bit_width, _bit_width
+
     rs1_is_paired = xlen == 32 and len(p64_profile) >= 3 and p64_profile[1]=='p'
     rs2_is_paired = xlen == 32 and len(p64_profile) >= 3 and p64_profile[2]=='p'
     rd_is_paired  = xlen == 32 and len(p64_profile) >= 3 and p64_profile[0]=='p'

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -6,7 +6,11 @@ OPS_RVP = {
     'pbriformat': ['rs1', 'rd'],
     'phriformat': ['rs1', 'rd'],
     'psbrrformat': ['rs1', 'rs2', 'rd'],
-    'pshrrformat': ['rs1', 'rs2', 'rd']
+    'pshrrformat': ['rs1', 'rs2', 'rd'],
+    'pwrrformat': ['rs1', 'rs2', 'rd'],
+    'pwriformat': ['rs1', 'rd'],
+    'pwrformat': ['rs1', 'rd'],
+    'pswrrformat': ['rs1', 'rs2', 'rd']
 }
 ''' Dictionary mapping RVP instruction formats to operands used by those formats '''
 
@@ -18,7 +22,11 @@ VALS_RVP = {
     'pbriformat': 'simd_val_vars("rs1", xlen, 8) + ["imm_val"]',
     'phriformat': 'simd_val_vars("rs1", xlen, 16) + ["imm_val"]',
     'psbrrformat': 'simd_val_vars("rs1", xlen, 8) + ["rs2_val"]',
-    'pshrrformat': 'simd_val_vars("rs1", xlen, 16) + ["rs2_val"]'
+    'pshrrformat': 'simd_val_vars("rs1", xlen, 16) + ["rs2_val"]',
+    'pwrrformat': 'simd_val_vars("rs1", xlen, 32) + simd_val_vars("rs2", xlen, 32)',
+    'pwriformat': 'simd_val_vars("rs1", xlen, 32) + ["imm_val"]',
+    'pwrformat': 'simd_val_vars("rs1", xlen, 32)',
+    'pswrrformat': 'simd_val_vars("rs1", xlen, 32) + ["rs2_val"]'
 }
 ''' Dictionary mapping RVP instruction formats to operand value variables used by those formats '''
 

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -217,13 +217,13 @@ def gen_pair_reg_data(instr_dict, xlen, bit_width, p64_profile):
     :type p64_profile: string
 
     '''
-    rs1_is_pair = len(p64_profile) >= 3 and p64_profile[1]=='p'
-    rs2_is_pair = len(p64_profile) >= 3 and p64_profile[2]=='p'
-    rd_is_pair  = len(p64_profile) >= 3 and p64_profile[0]=='p'
+    rs1_is_paired = len(p64_profile) >= 3 and p64_profile[1]=='p'
+    rs2_is_paired = len(p64_profile) >= 3 and p64_profile[2]=='p'
+    rd_is_paired  = len(p64_profile) >= 3 and p64_profile[0]=='p'
 
     for instr in instr_dict:
         if 'rs1' in instr:
-            op_width = 64 if rs1_is_pair else xlen
+            op_width = 64 if rs1_is_paired else xlen
             twocompl_offset = 1<<bit_width
             fmt, sz= get_fmt_sz(bit_width)
 
@@ -239,7 +239,7 @@ def gen_pair_reg_data(instr_dict, xlen, bit_width, p64_profile):
                     if val < 0:
                         val = val + twocompl_offset
                     rs1_val += val << (i*bit_width)
-            if xlen == 32 and rs1_is_pair:
+            if xlen == 32 and rs1_is_paired:
                 instr['rs1_val'] = format(0xffffffff & rs1_val, f"#0{2+xlen//4}x")
                 instr['rs1_val_hi'] = format(0xffffffff & (rs1_val>>32), f"#0{2+xlen//4}x")
                 instr['rs1_hi'] = incr_reg_num(instr['rs1'])
@@ -250,7 +250,7 @@ def gen_pair_reg_data(instr_dict, xlen, bit_width, p64_profile):
             instr['rs1_val64'] = format(rs1_val, f"#018x")
 
         if 'rs2' in instr:
-            op_width = 64 if rs2_is_pair else xlen
+            op_width = 64 if rs2_is_paired else xlen
             twocompl_offset = 1<<bit_width
             fmt, sz= get_fmt_sz(bit_width)
 
@@ -276,7 +276,7 @@ def gen_pair_reg_data(instr_dict, xlen, bit_width, p64_profile):
                 instr['rs2_hi'] = ''
             instr['rs2_val64'] = format(rs2_val, f"#018x")
 
-        if 'rd' in instr and rd_is_pair:
+        if 'rd' in instr and rd_is_paired:
             if xlen == 32:
                 instr['rd_hi'] = incr_reg_num(instr['rd'])
             else:

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -153,7 +153,10 @@ def concat_simd_data(instr_dict, xlen, _bit_width):
     :type bit_width: int
     '''
     if type(_bit_width)==str:
-        bit_width1, bit_width2 = map(int, _bit_width.split(','))
+        _bit_width = eval(_bit_width)
+
+    if type(_bit_width)==tuple:
+        bit_width1, bit_width2 = _bit_width
     else:
         bit_width1, bit_width2 = _bit_width, _bit_width
 

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -222,7 +222,8 @@ def gen_pair_reg_data(instr_dict, xlen, bit_width, p64_profile):
     rd_is_pair  = len(p64_profile) >= 3 and p64_profile[0]=='p'
 
     for instr in instr_dict:
-        if 'rs1' in instr and rs1_is_pair:
+        if 'rs1' in instr:
+            op_width = 64 if rs1_is_pair else xlen
             twocompl_offset = 1<<bit_width
             fmt, sz= get_fmt_sz(bit_width)
 
@@ -232,23 +233,24 @@ def gen_pair_reg_data(instr_dict, xlen, bit_width, p64_profile):
                     rs1_val = rs1_val + twocompl_offset
             else:
                 rs1_val = 0
-                for i in range(xlen//bit_width):
+                for i in range(op_width//bit_width):
                     val_var = f"rs1_{sz}{i}_val"
                     val = int(instr[val_var])
                     if val < 0:
                         val = val + twocompl_offset
                     rs1_val += val << (i*bit_width)
-            if xlen == 32:
-                instr['rs1_val'] = format(0xffffffff & rs1_val, f"#0{xlen//4}x")
-                instr['rs1_val_hi'] = format(0xffffffff & (rs1_val>>32), f"#0{xlen//4}x")
+            if xlen == 32 and rs1_is_pair:
+                instr['rs1_val'] = format(0xffffffff & rs1_val, f"#0{2+xlen//4}x")
+                instr['rs1_val_hi'] = format(0xffffffff & (rs1_val>>32), f"#0{2+xlen//4}x")
                 instr['rs1_hi'] = incr_reg_num(instr['rs1'])
             else:
-                instr['rs1_val'] = format(rs1_val, f"#0{xlen//4}x")
+                instr['rs1_val'] = format(rs1_val, f"#0{2+xlen//4}x")
                 instr['rs1_val_hi'] = '0x0'
                 instr['rs1_hi'] = ''
-            instr['rs1_val64'] = format(rs1_val, f"#016x")
+            instr['rs1_val64'] = format(rs1_val, f"#018x")
 
-        if 'rs2' in instr and rs2_is_pair:
+        if 'rs2' in instr:
+            op_width = 64 if rs2_is_pair else xlen
             twocompl_offset = 1<<bit_width
             fmt, sz= get_fmt_sz(bit_width)
 
@@ -258,21 +260,21 @@ def gen_pair_reg_data(instr_dict, xlen, bit_width, p64_profile):
                     rs2_val = rs2_val + twocompl_offset
             else: # concatenates all element of a SIMD register into a single value
                 rs2_val = 0
-                for i in range(xlen//bit_width):
+                for i in range(op_width//bit_width):
                     val_var = f"rs2_{sz}{i}_val"
                     val = int(instr[val_var])
                     if val < 0:
                         val = val + twocompl_offset
                     rs2_val += val << (i*bit_width)
             if xlen == 32:
-                instr['rs2_val'] = format(0xffffffff & rs2_val, f"#0{xlen//4}x")
-                instr['rs2_val_hi'] = format(0xffffffff & (rs2_val>>32), f"#0{xlen//4}x")
+                instr['rs2_val'] = format(0xffffffff & rs2_val, f"#0{2+xlen//4}x")
+                instr['rs2_val_hi'] = format(0xffffffff & (rs2_val>>32), f"#0{2+xlen//4}x")
                 instr['rs2_hi'] = incr_reg_num(instr['rs2'])
             else:
-                instr['rs2_val'] = format(rs2_val, f"#0{xlen//4}x")
+                instr['rs2_val'] = format(rs2_val, f"#0{2+xlen//4}x")
                 instr['rs2_val_hi'] = '0x0'
                 instr['rs2_hi'] = ''
-            instr['rs2_val64'] = format(rs2_val, f"#016x")
+            instr['rs2_val64'] = format(rs2_val, f"#018x")
 
         if 'rd' in instr and rd_is_pair:
             if xlen == 32:

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -12,6 +12,8 @@ OPS_RVP = {
     'pwrformat': ['rs1', 'rd'],
     'pswrrformat': ['rs1', 'rs2', 'rd'],
     'pwhrrformat': ['rs1', 'rs2', 'rd'],
+    'pphrrformat': ['rs1', 'rs2', 'rd'],
+    'ppbrrformat': ['rs1', 'rs2', 'rd'],
     'prrformat': ['rs1', 'rs2', 'rd'],
     'prrrformat': ['rs1', 'rs2', 'rs3', 'rd']
 
@@ -32,7 +34,9 @@ VALS_RVP = {
     'pwrformat': 'simd_val_vars("rs1", xlen, 32)',
     'pswrrformat': 'simd_val_vars("rs1", xlen, 32) + ["rs2_val"]',
     'pwhrrformat': 'simd_val_vars("rs1", xlen, 32) + simd_val_vars("rs2", xlen, 16)',
-    'prrformat': "['rs1_val', 'rs2_val']",
+    'pphrrformat': '["rs1_val"] + simd_val_vars("rs2", xlen, 16)',
+    'ppbrrformat': '["rs1_val"] + simd_val_vars("rs2", xlen, 8)',
+    'prrformat': '["rs1_val", "rs2_val"]',
     'prrrformat': "['rs1_val', 'rs2_val' , 'rs3_val']"
 
 }

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -1,47 +1,3 @@
-OPS_RVP = {
-    'pbrrformat': ['rs1', 'rs2', 'rd'],
-    'phrrformat': ['rs1', 'rs2', 'rd'],
-    'pbrformat': ['rs1', 'rd'],
-    'phrformat': ['rs1', 'rd'],
-    'pbriformat': ['rs1', 'rd'],
-    'phriformat': ['rs1', 'rd'],
-    'psbrrformat': ['rs1', 'rs2', 'rd'],
-    'pshrrformat': ['rs1', 'rs2', 'rd'],
-    'pwrrformat': ['rs1', 'rs2', 'rd'],
-    'pwriformat': ['rs1', 'rd'],
-    'pwrformat': ['rs1', 'rd'],
-    'pswrrformat': ['rs1', 'rs2', 'rd'],
-    'pwhrrformat': ['rs1', 'rs2', 'rd'],
-    'pphrrformat': ['rs1', 'rs2', 'rd'],
-    'ppbrrformat': ['rs1', 'rs2', 'rd'],
-    'prrformat': ['rs1', 'rs2', 'rd'],
-    'prrrformat': ['rs1', 'rs2', 'rs3', 'rd']
-
-}
-''' Dictionary mapping RVP instruction formats to operands used by those formats '''
-
-VALS_RVP = {
-    'pbrrformat': 'simd_val_vars("rs1", xlen, 8) + simd_val_vars("rs2", xlen, 8)',
-    'phrrformat': 'simd_val_vars("rs1", xlen, 16) + simd_val_vars("rs2", xlen, 16)',
-    'pbrformat': 'simd_val_vars("rs1", xlen, 8)',
-    'phrformat': 'simd_val_vars("rs1", xlen, 16)',
-    'pbriformat': 'simd_val_vars("rs1", xlen, 8) + ["imm_val"]',
-    'phriformat': 'simd_val_vars("rs1", xlen, 16) + ["imm_val"]',
-    'psbrrformat': 'simd_val_vars("rs1", xlen, 8) + ["rs2_val"]',
-    'pshrrformat': 'simd_val_vars("rs1", xlen, 16) + ["rs2_val"]',
-    'pwrrformat': 'simd_val_vars("rs1", xlen, 32) + simd_val_vars("rs2", xlen, 32)',
-    'pwriformat': 'simd_val_vars("rs1", xlen, 32) + ["imm_val"]',
-    'pwrformat': 'simd_val_vars("rs1", xlen, 32)',
-    'pswrrformat': 'simd_val_vars("rs1", xlen, 32) + ["rs2_val"]',
-    'pwhrrformat': 'simd_val_vars("rs1", xlen, 32) + simd_val_vars("rs2", xlen, 16)',
-    'pphrrformat': '["rs1_val"] + simd_val_vars("rs2", xlen, 16)',
-    'ppbrrformat': '["rs1_val"] + simd_val_vars("rs2", xlen, 8)',
-    'prrformat': '["rs1_val", "rs2_val"]',
-    'prrrformat': "['rs1_val', 'rs2_val' , 'rs3_val']"
-
-}
-''' Dictionary mapping RVP instruction formats to operand value variables used by those formats '''
-
 def simd_val_vars(operand, xlen, bit_width):
     '''
     This function generates the operand value variables for SIMD elements of the given operand.
@@ -68,19 +24,6 @@ def simd_val_vars(operand, xlen, bit_width):
     for i in range(nelms):
         val_list += [f"{operand}_{sz}{i}_val"]
     return val_list
-
-def init_rvp_ops_vals(OPS, VALS):
-    '''
-    This function updates the OPS and VALS dictionaries (the dictionaries for operands and operand value variables) with the RVP counter parts.
-
-    :param OPS: the dict mapping instruction formats to operands used by those formats.
-    :param VALS: the dict mapping instruction formats to operand value variables used by those formats.
-
-    :type OPS: dict
-    :type VALS: dict
-    '''
-    OPS.update(OPS_RVP)
-    VALS.update(VALS_RVP)
 
 def get_fmt_sz(bit_width):
     if bit_width == 8:

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -245,8 +245,6 @@ def gen_pair_reg_data(instr_dict, xlen, bit_width, p64_profile):
                 instr['rs1_hi'] = incr_reg_num(instr['rs1'])
             else:
                 instr['rs1_val'] = format(rs1_val, f"#0{2+xlen//4}x")
-                instr['rs1_val_hi'] = '0x0'
-                instr['rs1_hi'] = ''
             instr['rs1_val64'] = format(rs1_val, f"#018x")
 
         if 'rs2' in instr:
@@ -272,15 +270,11 @@ def gen_pair_reg_data(instr_dict, xlen, bit_width, p64_profile):
                 instr['rs2_hi'] = incr_reg_num(instr['rs2'])
             else:
                 instr['rs2_val'] = format(rs2_val, f"#0{2+xlen//4}x")
-                instr['rs2_val_hi'] = '0x0'
-                instr['rs2_hi'] = ''
             instr['rs2_val64'] = format(rs2_val, f"#018x")
 
         if 'rd' in instr and rd_is_paired:
             if xlen == 32:
                 instr['rd_hi'] = incr_reg_num(instr['rd'])
-            else:
-                instr['rd_hi'] = ''
 
         if 'imm_val' in instr:
             imm_val = int(instr['imm_val'])

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -239,11 +239,14 @@ def gen_pair_reg_data(instr_dict, xlen, bit_width, p64_profile):
                         val = val + twocompl_offset
                     rs1_val += val << (i*bit_width)
             if xlen == 32:
-                instr['rs1_val'] = format(0xffffffff & rs1_val, f"#08x")
-                instr['rs1_val_hi'] = format(0xffffffff & (rs1_val>>32), f"#08x")
+                instr['rs1_val'] = format(0xffffffff & rs1_val, f"#0{xlen//4}x")
+                instr['rs1_val_hi'] = format(0xffffffff & (rs1_val>>32), f"#0{xlen//4}x")
                 instr['rs1_hi'] = incr_reg_num(instr['rs1'])
             else:
                 instr['rs1_val'] = format(rs1_val, f"#0{xlen//4}x")
+                instr['rs1_val_hi'] = '0x0'
+                instr['rs1_hi'] = ''
+            instr['rs1_val64'] = format(rs1_val, f"#016x")
 
         if 'rs2' in instr and rs2_is_pair:
             twocompl_offset = 1<<bit_width
@@ -262,17 +265,20 @@ def gen_pair_reg_data(instr_dict, xlen, bit_width, p64_profile):
                         val = val + twocompl_offset
                     rs2_val += val << (i*bit_width)
             if xlen == 32:
-                instr['rs2_val'] = format(0xffffffff & rs2_val, f"#08x")
-                instr['rs2_val_hi'] = format(0xffffffff & (rs2_val>>32), f"#08x")
+                instr['rs2_val'] = format(0xffffffff & rs2_val, f"#0{xlen//4}x")
+                instr['rs2_val_hi'] = format(0xffffffff & (rs2_val>>32), f"#0{xlen//4}x")
                 instr['rs2_hi'] = incr_reg_num(instr['rs2'])
             else:
                 instr['rs2_val'] = format(rs2_val, f"#0{xlen//4}x")
+                instr['rs2_val_hi'] = '0x0'
+                instr['rs2_hi'] = ''
+            instr['rs2_val64'] = format(rs2_val, f"#016x")
 
         if 'rd' in instr and rd_is_pair:
             if xlen == 32:
                 instr['rd_hi'] = incr_reg_num(instr['rd'])
             else:
-                instr['rd_hi'] = instr['rd']
+                instr['rd_hi'] = ''
 
         if 'imm_val' in instr:
             imm_val = int(instr['imm_val'])

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -10,7 +10,10 @@ OPS_RVP = {
     'pwrrformat': ['rs1', 'rs2', 'rd'],
     'pwriformat': ['rs1', 'rd'],
     'pwrformat': ['rs1', 'rd'],
-    'pswrrformat': ['rs1', 'rs2', 'rd']
+    'pswrrformat': ['rs1', 'rs2', 'rd'],
+    'pwhrrformat': ['rs1', 'rs2', 'rd'],
+    'prrrformat': ['rs1', 'rs2', 'rs3', 'rd']
+
 }
 ''' Dictionary mapping RVP instruction formats to operands used by those formats '''
 
@@ -26,7 +29,10 @@ VALS_RVP = {
     'pwrrformat': 'simd_val_vars("rs1", xlen, 32) + simd_val_vars("rs2", xlen, 32)',
     'pwriformat': 'simd_val_vars("rs1", xlen, 32) + ["imm_val"]',
     'pwrformat': 'simd_val_vars("rs1", xlen, 32)',
-    'pswrrformat': 'simd_val_vars("rs1", xlen, 32) + ["rs2_val"]'
+    'pswrrformat': 'simd_val_vars("rs1", xlen, 32) + ["rs2_val"]',
+    'pwhrrformat': 'simd_val_vars("rs1", xlen, 32) + simd_val_vars("rs2", xlen, 16)',
+    'prrrformat': "['rs1_val', 'rs2_val' , 'rs3_val']"
+
 }
 ''' Dictionary mapping RVP instruction formats to operand value variables used by those formats '''
 
@@ -69,20 +75,8 @@ def init_rvp_ops_vals(OPS, VALS):
     '''
     OPS.update(OPS_RVP)
     VALS.update(VALS_RVP)
-    
-def concat_simd_data(instr_dict, xlen, bit_width):
-    '''
-    This function concatenates all element of a SIMD register into a single value in the hex format.
 
-    :param instr_dict: a dict holding metadata and operand data for the current instruction. 
-    :param xlen: an integer indicating the XLEN value to be used.
-    :param bit_width: an integer indicating the element bit width of the current RVP instruction.
-
-    :type instr_dict: dict
-    :type xlen: int
-    :type bit_width: int
-    '''
-    twocompl_offset = 1<<bit_width
+def get_fmt_sz(bit_width):
     if bit_width == 8:
         fmt = f"#02x"
     elif bit_width == 16:
@@ -99,8 +93,68 @@ def concat_simd_data(instr_dict, xlen, bit_width):
         sz = "w"
     else:
         sz = "d"
+
+    return fmt, sz
+
+def gen_fmt(bit_width):
+    '''
+    This function generate fmt string by bit_width.
+
+    :param bit_width: an integer indicating the element bit width of the current RVP instruction.
+
+    :type bit_width: int
+    '''
+
+    if bit_width == 8:
+        fmt = f"#02x"
+    elif bit_width == 16:
+        fmt = f"#04x"
+    elif bit_width == 32:
+        fmt = f"#08x"
+    else:
+        fmt = f"#016x"
+    return fmt
+
+def gen_sz(bit_width):
+    '''
+    This function generate size string by bit_width.
+
+    :param bit_width: an integer indicating the element bit width of the current RVP instruction.
+
+    :type bit_width: int
+    '''
+
+    if bit_width == 8:
+        sz = "b"
+    elif bit_width == 16:
+        sz = "h"
+    elif bit_width == 32:
+        sz = "w"
+    else:
+        sz = "d"
+    return sz
+
+def concat_simd_data(instr_dict, xlen, _bit_width):
+    '''
+    This function concatenates all element of a SIMD register into a single value in the hex format.
+
+    :param instr_dict: a dict holding metadata and operand data for the current instruction.
+    :param xlen: an integer indicating the XLEN value to be used.
+    :param bit_width: an integer indicating the element bit width of the current RVP instruction.
+
+    :type instr_dict: dict
+    :type xlen: int
+    :type bit_width: int
+    '''
+    if type(_bit_width)==tuple:
+        bit_width1, bit_width2 = _bit_width
+    else:
+        bit_width1, bit_width2 = _bit_width, _bit_width
+
     for instr in instr_dict:
         if 'rs1' in instr:
+            twocompl_offset = 1<<bit_width1
+            fmt, sz= get_fmt_sz(bit_width1)
             if 'rs1_val' in instr:  # single element value
                 rs1_val = int(instr['rs1_val'])
                 if rs1_val < 0:
@@ -108,14 +162,19 @@ def concat_simd_data(instr_dict, xlen, bit_width):
                 instr['rs1_val'] = format(rs1_val, f"#0x")
             else:   # concatenates all element of a SIMD register into a single value
                 rs1_val = 0
-                for i in range(xlen//bit_width):
+                for i in range(xlen//bit_width1):
                     val_var = f"rs1_{sz}{i}_val"
                     val = int(instr[val_var])
                     if val < 0:
                         val = val + twocompl_offset
-                    rs1_val += val << (i*bit_width)
+                    rs1_val += val << (i*bit_width1)
                 instr['rs1_val'] = format(rs1_val, f"#0{xlen//4}x")
         if 'rs2' in instr:
+            # bit_width1 == bit_width2 except for instructions with pwhrrformat.
+            # but even for pwhrrformat, the values are aligned to bit_width1 instead of bit_width2.
+            twocompl_offset = 1<<bit_width2
+            fmt, sz= get_fmt_sz(bit_width2)
+
             if 'rs2_val' in instr:  # single element value
                 rs2_val = int(instr['rs2_val'])
                 if rs2_val < 0:
@@ -123,13 +182,96 @@ def concat_simd_data(instr_dict, xlen, bit_width):
                 instr['rs2_val'] = format(rs2_val, f"#0x")
             else:   # concatenates all element of a SIMD register into a single value
                 rs2_val = 0
+                for i in range(xlen//bit_width2):
+                    val_var = f"rs2_{sz}{i}_val"
+                    val = int(instr[val_var])
+                    if val < 0:
+                        val = val + twocompl_offset
+                    rs2_val += val << (i*bit_width2)
+                instr['rs2_val'] = format(rs2_val, f"#0{xlen//4}x")
+        if 'imm_val' in instr:
+            imm_val = int(instr['imm_val'])
+            instr['imm_val'] = format(imm_val, f"#0x")
+
+def incr_reg_num(reg):
+    name = reg[0]
+    num = int(reg[1:])
+    num = num + 1
+    return name + str(num)
+
+def gen_pair_reg_data(instr_dict, xlen, bit_width, p64_profile):
+    '''
+    This function generate high registers for paired register operands, rs1_hi, rs2_hi and rd_hi depending on the specification of the p64_profile string.
+    It also generate the corresponding values rs1_val_hi, rs2_val_hi.
+
+    :param instr_dict: a dict holding metadata and operand data for the current instruction.
+    :param xlen: an integer indicating the XLEN value to be used.
+    :param bit_width: an integer indicating the element bit width of the current RVP instruction.
+    :param p64_profile: a string of 3 chars indicating the type of operands (pair/non-pair) of the current RVP instruction. (rd, rs1 and rs2)
+
+    :type instr_dict: dict
+    :type xlen: int
+    :type bit_width: int
+    :type p64_profile: string
+
+    '''
+    rs1_is_pair = len(p64_profile) >= 3 and p64_profile[1]=='p'
+    rs2_is_pair = len(p64_profile) >= 3 and p64_profile[2]=='p'
+    rd_is_pair  = len(p64_profile) >= 3 and p64_profile[0]=='p'
+
+    for instr in instr_dict:
+        if 'rs1' in instr and rs1_is_pair:
+            twocompl_offset = 1<<bit_width
+            fmt, sz= get_fmt_sz(bit_width)
+
+            if 'rs1_val' in instr:
+                rs1_val = int(instr['rs1_val'])
+                if rs1_val < 0:
+                    rs1_val = rs1_val + twocompl_offset
+            else:
+                rs1_val = 0
+                for i in range(xlen//bit_width):
+                    val_var = f"rs1_{sz}{i}_val"
+                    val = int(instr[val_var])
+                    if val < 0:
+                        val = val + twocompl_offset
+                    rs1_val += val << (i*bit_width)
+            if xlen == 32:
+                instr['rs1_val'] = format(0xffffffff & rs1_val, f"#08x")
+                instr['rs1_val_hi'] = format(0xffffffff & (rs1_val>>32), f"#08x")
+                instr['rs1_hi'] = incr_reg_num(instr['rs1'])
+            else:
+                instr['rs1_val'] = format(rs1_val, f"#0{xlen//4}x")
+
+        if 'rs2' in instr and rs2_is_pair:
+            twocompl_offset = 1<<bit_width
+            fmt, sz= get_fmt_sz(bit_width)
+
+            if 'rs2_val' in instr:  # single element value
+                rs2_val = int(instr['rs2_val'])
+                if rs2_val < 0:
+                    rs2_val = rs2_val + twocompl_offset
+            else: # concatenates all element of a SIMD register into a single value
+                rs2_val = 0
                 for i in range(xlen//bit_width):
                     val_var = f"rs2_{sz}{i}_val"
                     val = int(instr[val_var])
                     if val < 0:
                         val = val + twocompl_offset
                     rs2_val += val << (i*bit_width)
+            if xlen == 32:
+                instr['rs2_val'] = format(0xffffffff & rs2_val, f"#08x")
+                instr['rs2_val_hi'] = format(0xffffffff & (rs2_val>>32), f"#08x")
+                instr['rs2_hi'] = incr_reg_num(instr['rs2'])
+            else:
                 instr['rs2_val'] = format(rs2_val, f"#0{xlen//4}x")
+
+        if 'rd' in instr and rd_is_pair:
+            if xlen == 32:
+                instr['rd_hi'] = incr_reg_num(instr['rd'])
+            else:
+                instr['rd_hi'] = instr['rd']
+
         if 'imm_val' in instr:
             imm_val = int(instr['imm_val'])
             instr['imm_val'] = format(imm_val, f"#0x")

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -943,6 +943,50 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
       inst imm_val; \
       )
 
+#define TEST_RRR_OP(inst, destreg, reg1, reg2, reg3, correctval, val1, val2, swreg, offset, testreg) \
+    TEST_CASE(testreg, destreg, correctval, swreg, offset, \
+      LI(reg1, MASK_XLEN(val1)); \
+      LI(reg2, MASK_XLEN(val2)); \
+      inst destreg, reg1, reg2; \
+    )
+
+#if __riscv_xlen == 32
+
+//Tests for a instructions with pair register rd, pair register rs1 and pair register rs2
+#define TEST_P64_PPP_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, testreg) \
+    TEST_P64_PPP_OP_32(inst, rd, rd_hi, rs1, rs1_hi, rs2,, rs2_hi correctval, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, testreg)
+//Tests for a instructions with pair register rd, pair register rs1 and normal register rs2
+#define TEST_P64_PPN_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
+    TEST_P64_PPN_OP_32(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg)
+//Tests for a instructions with pair register rd, normal register rs1 and normal register rs2
+#define TEST_P64_PNN_OP(inst, rd, rd_hi, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg) \
+    TEST_P64_PNN_OP_32(inst, rd, rd_hi, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
+//Tests for a instructions with normal register rd, pair register rs1 and normal register rs2
+#define TEST_P64_NPN_OP(inst, rd, rs1, rs1_hi, rs2, correctval, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
+    TEST_P64_NPN_OP_32(inst, rd, rs1, rs1_hi, rs2, correctval, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg)
+
+//Tests for a instructions with normal register rd, pair register rs1
+#define TEST_P64_NP_OP(inst, rd, rs1, rs1_hi, correctval, rs1_val, rs1_val_hi, imm_val, swreg, offset, testreg) \
+    TEST_P64_NP_OP_32(inst, rd, rs1, rs1_hi, correctval, rs1_val, rs1_val_hi, imm_val, swreg, offset, testreg)
+
+#else
+// When in rv64, there are no instructions with pair operand, so Macro is redefined to normal TEST_RR_OP
+#define TEST_P64_PPP_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, testreg) \
+    TEST_RR_OP(inst, rd, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
+#define TEST_P64_PPN_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
+    TEST_RR_OP(inst, rd, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
+#define TEST_P64_PNN_OP(inst, rd, rd_hi, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg) \
+    TEST_RR_OP(inst, rd, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
+#define TEST_P64_NPN_OP(inst, rd, rs1, rs1_hi, rs2, correctval, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
+    TEST_RR_OP(inst, rd, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
+#define TEST_P64_NP_OP(inst, rd, rs1, rs1_hi, correctval, rs1_val, rs1_val_hi, imm_val, swreg, offset, testreg) \
+    TEST_IMM_OP(inst, rd, rs1, correctval, rs1_val, imm_val, swreg, offset, testreg)
+
+#endif
+
+
+
+
 #define TEST_CMV_OP( inst, destreg, reg, correctval, val2, swreg, offset, testreg) \
     TEST_CASE(testreg, destreg, correctval, swreg, offset, \
       LI(reg, MASK_XLEN(val2)); \

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -852,13 +852,20 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
       sub destreg, destreg, testreg; \
       )
 
-//Tests for a instructions with register-immediate operand
+//Tests for instructions with register-immediate operand
 #define TEST_IMM_OP( inst, destreg, reg, correctval, val, imm, swreg, offset, testreg) \
     TEST_CASE(testreg, destreg, correctval, swreg, offset, \
       LI(reg, MASK_XLEN(val)); \
       inst destreg, reg, SEXT_IMM(imm); \
     )
     
+//Tests for instructions with a single register operand
+#define TEST_R_OP( inst, destreg, reg, correctval, val, swreg, offset, testreg) \
+    TEST_CASE(testreg, destreg, correctval, swreg, offset, \
+      LI(reg, MASK_XLEN(val)); \
+      inst destreg, reg; \
+    )
+
 //Tests for floating-point instructions with a single register operand
 #define TEST_FPSR_OP( inst, destreg, freg, rm, correctval, valaddr_reg, val_offset, flagreg, swreg, offset, testreg) \
     TEST_CASE_F(testreg, destreg, correctval, swreg, flagreg, offset, \

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -607,6 +607,7 @@ rvtest_data_end:
     .set offset,offset+(2*REGWIDTH);\
   .endif;
   
+// for updating signatures when 'rd' is a paired register (64-bit) in Zpsfoperand extension in RV32.
 #define RVTEST_SIGUPD_P64(_BR,_R,_R_HI,...)\
   .if NARG(__VA_ARGS__) == 1;\
     SREG _R,_ARG1(__VA_ARGS__,0)(_BR);\
@@ -964,7 +965,7 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
 
 #if __riscv_xlen == 32
 //Tests for a instruction with register pair operands for all its three operands
-#define TEST_P64_PPP_OP_32(inst, destreg, destreg_hi, reg1, reg1_hi, reg2, reg2_hi, correctval, correctval_hi, val1, val1_hi, val2, val2_hi, swreg, offset, offset_hi, testreg) \
+#define TEST_P64_PPP_OP_32(inst, destreg, destreg_hi, reg1, reg1_hi, reg2, reg2_hi, correctval, correctval_hi, val1, val1_hi, val2, val2_hi, swreg, offset, testreg) \
       LI(reg1, MASK_XLEN(val1)); \
       LI(reg1_hi, MASK_XLEN(val1_hi)); \
       LI(reg2, MASK_XLEN(val2)); \
@@ -974,7 +975,7 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval); \
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg_hi, correctval_hi)
 
-#define TEST_P64_PPN_OP_32(inst, destreg, destreg_hi, reg1, reg1_hi, reg2, correctval, correctval_hi, val1, val1_hi, val2, swreg, offset, offset_hi, testreg) \
+#define TEST_P64_PPN_OP_32(inst, destreg, destreg_hi, reg1, reg1_hi, reg2, correctval, correctval_hi, val1, val1_hi, val2, swreg, offset, testreg) \
       LI(reg1, MASK_XLEN(val1)); \
       LI(reg1_hi, MASK_XLEN(val1_hi)); \
       LI(reg2, MASK_XLEN(val2)); \
@@ -983,7 +984,7 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval); \
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg_hi, correctval_hi)
 
-#define TEST_P64_PNN_OP_32(inst, destreg, destreg_hi, reg1, reg2, correctval, correctval_hi, val1, val2, swreg, offset, offset_hi, testreg) \
+#define TEST_P64_PNN_OP_32(inst, destreg, destreg_hi, reg1, reg2, correctval, correctval_hi, val1, val2, swreg, offset, testreg) \
       LI(reg1, MASK_XLEN(val1)); \
       LI(reg2, MASK_XLEN(val2)); \
       inst destreg, reg1, reg2; \
@@ -1007,14 +1008,14 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval);
 
 //Tests for a instruction with pair register rd, pair register rs1 and pair register rs2
-#define TEST_P64_PPP_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, offset_hi, testreg) \
-    TEST_P64_PPP_OP_32(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, offset_hi, testreg)
+#define TEST_P64_PPP_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, testreg) \
+    TEST_P64_PPP_OP_32(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, testreg)
 //Tests for a instruction with pair register rd, pair register rs1 and normal register rs2
-#define TEST_P64_PPN_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, offset_hi, testreg) \
-    TEST_P64_PPN_OP_32(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, offset_hi, testreg)
+#define TEST_P64_PPN_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
+    TEST_P64_PPN_OP_32(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg)
 //Tests for a instruction with pair register rd, normal register rs1 and normal register rs2
-#define TEST_P64_PNN_OP(inst, rd, rd_hi, rs1, rs2, correctval, correctval_hi, rs1_val, rs2_val, swreg, offset, offset_hi, testreg) \
-    TEST_P64_PNN_OP_32(inst, rd, rd_hi, rs1, rs2, correctval, correctval_hi, rs1_val, rs2_val, swreg, offset, offset_hi, testreg)
+#define TEST_P64_PNN_OP(inst, rd, rd_hi, rs1, rs2, correctval, correctval_hi, rs1_val, rs2_val, swreg, offset, testreg) \
+    TEST_P64_PNN_OP_32(inst, rd, rd_hi, rs1, rs2, correctval, correctval_hi, rs1_val, rs2_val, swreg, offset, testreg)
 //Tests for a instruction with normal register rd, pair register rs1 and normal register rs2
 #define TEST_P64_NPN_OP(inst, rd, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
     TEST_P64_NPN_OP_32(inst, rd, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg)
@@ -1024,11 +1025,11 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
 
 #else
 // When in rv64, there are no instructions with pair operand, so Macro is redefined to normal TEST_RR_OP
-#define TEST_P64_PPP_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, offset_hi, testreg) \
+#define TEST_P64_PPP_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, testreg) \
     TEST_RR_OP(inst, rd, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
-#define TEST_P64_PPN_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, offset_hi, testreg) \
+#define TEST_P64_PPN_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
     TEST_RR_OP(inst, rd, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
-#define TEST_P64_PNN_OP(inst, rd, rd_hi, rs1, rs2, correctval, correctval_hi, rs1_val, rs2_val, swreg, offset, offset_hi, testreg) \
+#define TEST_P64_PNN_OP(inst, rd, rd_hi, rs1, rs2, correctval, correctval_hi, rs1_val, rs2_val, swreg, offset, testreg) \
     TEST_RR_OP(inst, rd, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
 #define TEST_P64_NPN_OP(inst, rd, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
     TEST_RR_OP(inst, rd, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -607,6 +607,18 @@ rvtest_data_end:
     .set offset,offset+(2*REGWIDTH);\
   .endif;
   
+#define RVTEST_SIGUPD_P64(_BR,_R,_R_HI,...)\
+  .if NARG(__VA_ARGS__) == 1;\
+    SREG _R,_ARG1(__VA_ARGS__,0)(_BR);\
+    SREG _R_HI,(_ARG1(__VA_ARGS__,0)+4)(_BR);\
+    .set offset,_ARG1(__VA_OPT__(__VA_ARGS__,)0)+REGWIDTH+REGWIDTH;\
+  .endif;\
+  .if NARG(__VA_ARGS__) == 0;\
+    SREG _R,offset(_BR);\
+    SREG _R_HI,(offset+REGWIDTH)(_BR);\
+  .set offset,offset+REGWIDTH+REGWIDTH;\
+  .endif;
+
 #define RVTEST_VALBASEUPD(_BR,...)\
   .if NARG(__VA_ARGS__) == 0;\
       addi _BR,_BR,2040;\
@@ -958,9 +970,8 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
       LI(reg2, MASK_XLEN(val2)); \
       LI(reg2_hi, MASK_XLEN(val2_hi)); \
       inst destreg, reg1, reg2; \
-      RVTEST_SIGUPD(swreg,destreg,offset); \
+      RVTEST_SIGUPD_P64(swreg,destreg, destreg_hi, offset); \
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval); \
-      RVTEST_SIGUPD(swreg,destreg_hi,offset_hi); \
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg_hi, correctval_hi)
 
 #define TEST_P64_PPN_OP_32(inst, destreg, destreg_hi, reg1, reg1_hi, reg2, correctval, correctval_hi, val1, val1_hi, val2, swreg, offset, offset_hi, testreg) \
@@ -968,18 +979,16 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
       LI(reg1_hi, MASK_XLEN(val1_hi)); \
       LI(reg2, MASK_XLEN(val2)); \
       inst destreg, reg1, reg2; \
-      RVTEST_SIGUPD(swreg,destreg,offset); \
+      RVTEST_SIGUPD_P64(swreg,destreg, destreg_hi, offset); \
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval); \
-      RVTEST_SIGUPD(swreg,destreg_hi,offset_hi); \
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg_hi, correctval_hi)
 
 #define TEST_P64_PNN_OP_32(inst, destreg, destreg_hi, reg1, reg2, correctval, correctval_hi, val1, val2, swreg, offset, offset_hi, testreg) \
       LI(reg1, MASK_XLEN(val1)); \
       LI(reg2, MASK_XLEN(val2)); \
       inst destreg, reg1, reg2; \
-      RVTEST_SIGUPD(swreg,destreg,offset); \
+      RVTEST_SIGUPD_P64(swreg,destreg, destreg_hi, offset); \
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval); \
-      RVTEST_SIGUPD(swreg,destreg_hi,offset_hi); \
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg_hi, correctval_hi)
 
 #define TEST_P64_NPN_OP_32(inst, destreg, reg1, reg1_hi, reg2, correctval, val1, val1_hi, val2, swreg, offset, testreg) \

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -954,8 +954,8 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
 //Tests for a instruction with register pair operands for all its three operands
 #define TEST_P64_PPP_OP_32(inst, destreg, destreg_hi, reg1, reg1_hi, reg2, reg2_hi, correctval, correctval_hi, val1, val1_hi, val2, val2_hi, swreg, offset, offset_hi, testreg) \
       LI(reg1, MASK_XLEN(val1)); \
-      LI(reg2, MASK_XLEN(val2)); \
       LI(reg1_hi, MASK_XLEN(val1_hi)); \
+      LI(reg2, MASK_XLEN(val2)); \
       LI(reg2_hi, MASK_XLEN(val2_hi)); \
       inst destreg, reg1, reg2; \
       RVTEST_SIGUPD(swreg,destreg,offset); \
@@ -965,8 +965,8 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
 
 #define TEST_P64_PPN_OP_32(inst, destreg, destreg_hi, reg1, reg1_hi, reg2, correctval, correctval_hi, val1, val1_hi, val2, swreg, offset, offset_hi, testreg) \
       LI(reg1, MASK_XLEN(val1)); \
-      LI(reg2, MASK_XLEN(val2)); \
       LI(reg1_hi, MASK_XLEN(val1_hi)); \
+      LI(reg2, MASK_XLEN(val2)); \
       inst destreg, reg1, reg2; \
       RVTEST_SIGUPD(swreg,destreg,offset); \
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval); \
@@ -984,8 +984,8 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
 
 #define TEST_P64_NPN_OP_32(inst, destreg, reg1, reg1_hi, reg2, correctval, val1, val1_hi, val2, swreg, offset, testreg) \
       LI(reg1, MASK_XLEN(val1)); \
-      LI(reg2, MASK_XLEN(val2)); \
       LI(reg1_hi, MASK_XLEN(val1_hi)); \
+      LI(reg2, MASK_XLEN(val2)); \
       inst destreg, reg1, reg2; \
       RVTEST_SIGUPD(swreg,destreg,offset); \
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval);

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -982,7 +982,7 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
       RVTEST_SIGUPD(swreg,destreg_hi,offset_hi); \
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg_hi, correctval_hi)
 
-#define TEST_P64_NPN_OP_32(inst, destreg, reg1, reg1_hi, reg2, correctval, correct_val_hi, val1, val1_hi, val2, swreg, offset, testreg) \
+#define TEST_P64_NPN_OP_32(inst, destreg, reg1, reg1_hi, reg2, correctval, val1, val1_hi, val2, swreg, offset, testreg) \
       LI(reg1, MASK_XLEN(val1)); \
       LI(reg2, MASK_XLEN(val2)); \
       LI(reg1_hi, MASK_XLEN(val1_hi)); \
@@ -990,7 +990,7 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
       RVTEST_SIGUPD(swreg,destreg,offset); \
       RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval);
 
-#define TEST_P64_NP_OP_32(inst, destreg, reg1, reg1_hi, correctval, correctval_hi, val1, val1_hi, imm_val, swreg, offset, testreg) \
+#define TEST_P64_NP_OP_32(inst, destreg, reg1, reg1_hi, correctval, val1, val1_hi, imm_val, swreg, offset, testreg) \
       LI(reg1, MASK_XLEN(val1)); \
       LI(reg1_hi, MASK_XLEN(val1_hi)); \
       inst destreg, reg1, imm_val; \

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -950,13 +950,6 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
       inst imm_val; \
       )
 
-#define TEST_RRR_OP(inst, destreg, reg1, reg2, reg3, correctval, val1, val2, swreg, offset, testreg) \
-    TEST_CASE(testreg, destreg, correctval, swreg, offset, \
-      LI(reg1, MASK_XLEN(val1)); \
-      LI(reg2, MASK_XLEN(val2)); \
-      inst destreg, reg1, reg2; \
-    )
-
 #if __riscv_xlen == 32
 //Tests for a instruction with register pair operands for all its three operands
 #define TEST_P64_PPP_OP_32(inst, destreg, destreg_hi, reg1, reg1_hi, reg2, reg2_hi, correctval, correctval_hi, val1, val1_hi, val2, val2_hi, swreg, offset, offset_hi, testreg) \

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -951,35 +951,79 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
     )
 
 #if __riscv_xlen == 32
+//Tests for a instruction with register pair operands for all its three operands
+#define TEST_P64_PPP_OP_32(inst, destreg, destreg_hi, reg1, reg1_hi, reg2, reg2_hi, correctval, correctval_hi, val1, val1_hi, val2, val2_hi, swreg, offset, offset_hi, testreg) \
+      LI(reg1, MASK_XLEN(val1)); \
+      LI(reg2, MASK_XLEN(val2)); \
+      LI(reg1_hi, MASK_XLEN(val1_hi)); \
+      LI(reg2_hi, MASK_XLEN(val2_hi)); \
+      inst destreg, reg1, reg2; \
+      RVTEST_SIGUPD(swreg,destreg,offset); \
+      RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval); \
+      RVTEST_SIGUPD(swreg,destreg_hi,offset_hi); \
+      RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg_hi, correctval_hi)
 
-//Tests for a instructions with pair register rd, pair register rs1 and pair register rs2
-#define TEST_P64_PPP_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, testreg) \
-    TEST_P64_PPP_OP_32(inst, rd, rd_hi, rs1, rs1_hi, rs2,, rs2_hi correctval, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, testreg)
-//Tests for a instructions with pair register rd, pair register rs1 and normal register rs2
-#define TEST_P64_PPN_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
-    TEST_P64_PPN_OP_32(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg)
-//Tests for a instructions with pair register rd, normal register rs1 and normal register rs2
-#define TEST_P64_PNN_OP(inst, rd, rd_hi, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg) \
-    TEST_P64_PNN_OP_32(inst, rd, rd_hi, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
-//Tests for a instructions with normal register rd, pair register rs1 and normal register rs2
-#define TEST_P64_NPN_OP(inst, rd, rs1, rs1_hi, rs2, correctval, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
-    TEST_P64_NPN_OP_32(inst, rd, rs1, rs1_hi, rs2, correctval, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg)
+#define TEST_P64_PPN_OP_32(inst, destreg, destreg_hi, reg1, reg1_hi, reg2, correctval, correctval_hi, val1, val1_hi, val2, swreg, offset, offset_hi, testreg) \
+      LI(reg1, MASK_XLEN(val1)); \
+      LI(reg2, MASK_XLEN(val2)); \
+      LI(reg1_hi, MASK_XLEN(val1_hi)); \
+      inst destreg, reg1, reg2; \
+      RVTEST_SIGUPD(swreg,destreg,offset); \
+      RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval); \
+      RVTEST_SIGUPD(swreg,destreg_hi,offset_hi); \
+      RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg_hi, correctval_hi)
 
-//Tests for a instructions with normal register rd, pair register rs1
-#define TEST_P64_NP_OP(inst, rd, rs1, rs1_hi, correctval, rs1_val, rs1_val_hi, imm_val, swreg, offset, testreg) \
-    TEST_P64_NP_OP_32(inst, rd, rs1, rs1_hi, correctval, rs1_val, rs1_val_hi, imm_val, swreg, offset, testreg)
+#define TEST_P64_PNN_OP_32(inst, destreg, destreg_hi, reg1, reg2, correctval, correctval_hi, val1, val2, swreg, offset, offset_hi, testreg) \
+      LI(reg1, MASK_XLEN(val1)); \
+      LI(reg2, MASK_XLEN(val2)); \
+      inst destreg, reg1, reg2; \
+      RVTEST_SIGUPD(swreg,destreg,offset); \
+      RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval); \
+      RVTEST_SIGUPD(swreg,destreg_hi,offset_hi); \
+      RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg_hi, correctval_hi)
+
+#define TEST_P64_NPN_OP_32(inst, destreg, reg1, reg1_hi, reg2, correctval, correct_val_hi, val1, val1_hi, val2, swreg, offset, testreg) \
+      LI(reg1, MASK_XLEN(val1)); \
+      LI(reg2, MASK_XLEN(val2)); \
+      LI(reg1_hi, MASK_XLEN(val1_hi)); \
+      inst destreg, reg1, reg2; \
+      RVTEST_SIGUPD(swreg,destreg,offset); \
+      RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval);
+
+#define TEST_P64_NP_OP_32(inst, destreg, reg1, reg1_hi, correctval, correctval_hi, val1, val1_hi, imm_val, swreg, offset, testreg) \
+      LI(reg1, MASK_XLEN(val1)); \
+      LI(reg1_hi, MASK_XLEN(val1_hi)); \
+      inst destreg, reg1, imm_val; \
+      RVTEST_SIGUPD(swreg,destreg,offset); \
+      RVMODEL_IO_ASSERT_GPR_EQ(testreg, destreg, correctval);
+
+//Tests for a instruction with pair register rd, pair register rs1 and pair register rs2
+#define TEST_P64_PPP_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, offset_hi, testreg) \
+    TEST_P64_PPP_OP_32(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, offset_hi, testreg)
+//Tests for a instruction with pair register rd, pair register rs1 and normal register rs2
+#define TEST_P64_PPN_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, offset_hi, testreg) \
+    TEST_P64_PPN_OP_32(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, offset_hi, testreg)
+//Tests for a instruction with pair register rd, normal register rs1 and normal register rs2
+#define TEST_P64_PNN_OP(inst, rd, rd_hi, rs1, rs2, correctval, correctval_hi, rs1_val, rs2_val, swreg, offset, offset_hi, testreg) \
+    TEST_P64_PNN_OP_32(inst, rd, rd_hi, rs1, rs2, correctval, correctval_hi, rs1_val, rs2_val, swreg, offset, offset_hi, testreg)
+//Tests for a instruction with normal register rd, pair register rs1 and normal register rs2
+#define TEST_P64_NPN_OP(inst, rd, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
+    TEST_P64_NPN_OP_32(inst, rd, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg)
+//Tests for a instruction with normal register rd, pair register rs1
+#define TEST_P64_NP_OP(inst, rd, rs1, rs1_hi, correctval, correctval_hi, rs1_val, rs1_val_hi, imm_val, swreg, offset, testreg) \
+    TEST_P64_NP_OP_32(inst, rd, rs1, rs1_hi, correctval, correctval_hi, rs1_val, rs1_val_hi, imm_val, swreg, offset, testreg)
 
 #else
 // When in rv64, there are no instructions with pair operand, so Macro is redefined to normal TEST_RR_OP
-#define TEST_P64_PPP_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, testreg) \
+#define TEST_P64_PPP_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, rs2_hi, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, rs2_val_hi, swreg, offset, offset_hi, testreg) \
     TEST_RR_OP(inst, rd, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
-#define TEST_P64_PPN_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
+#define TEST_P64_PPN_OP(inst, rd, rd_hi, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, offset_hi, testreg) \
     TEST_RR_OP(inst, rd, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
-#define TEST_P64_PNN_OP(inst, rd, rd_hi, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg) \
+#define TEST_P64_PNN_OP(inst, rd, rd_hi, rs1, rs2, correctval, correctval_hi, rs1_val, rs2_val, swreg, offset, offset_hi, testreg) \
     TEST_RR_OP(inst, rd, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
-#define TEST_P64_NPN_OP(inst, rd, rs1, rs1_hi, rs2, correctval, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
+#define TEST_P64_NPN_OP(inst, rd, rs1, rs1_hi, rs2, correctval, correctval_hi, rs1_val, rs1_val_hi, rs2_val, swreg, offset, testreg) \
     TEST_RR_OP(inst, rd, rs1, rs2, correctval, rs1_val, rs2_val, swreg, offset, testreg)
-#define TEST_P64_NP_OP(inst, rd, rs1, rs1_hi, correctval, rs1_val, rs1_val_hi, imm_val, swreg, offset, testreg) \
+#define TEST_P64_NP_OP(inst, rd, rs1, rs1_hi, correctval, correctval_hi, rs1_val, rs1_val_hi, imm_val, swreg, offset, testreg) \
     TEST_IMM_OP(inst, rd, rs1, correctval, rs1_val, imm_val, swreg, offset, testreg)
 
 #endif

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -666,7 +666,7 @@ class Generator():
                 instr_dict.append(self.__bfmt_instr__(op,val))
             elif self.opcode in ['c.jal', 'c.jalr']:
                 instr_dict.append(self.__cj_instr__(op,val))
-            elif self.fmt == 'jformat':
+            elif self.fmt == 'jformat' or self.fmt == 'cjformat':
                 instr_dict.append(self.__jfmt_instr__(op,val))
             else:
                 instr_dict.append(self.__instr__(op,val))
@@ -826,6 +826,10 @@ class Generator():
             if 'rs2' in coverpoints:
                 if rs2 in coverpoints['rs2']:
                     cover_hits['rs2'] = set([rs2])
+            if 'rs3' in coverpoints:
+                if rs3 in coverpoints['rs3']:
+                    cover_hits['rs3'] = set([rs3])
+
             if 'rd' in coverpoints:
                 if rd in coverpoints['rd']:
                     cover_hits['rd'] = set([rd])
@@ -1065,8 +1069,16 @@ class Generator():
         '''
         mydict = instr_dict.copy()
         if (self.opnode['isa'] == 'IP'):
-            concat_simd_data(instr_dict, xlen, self.opnode['bit_width'])
-            return instr_dict
+            if ('p64_profile' in self.opnode):
+                gen_pair_reg_data(instr_dict, xlen, self.opnode['bit_width'], self.opnode['p64_profile'])
+
+            if ('bit_width' in self.opnode):
+                if (type(self.opnode['bit_width'])==int):
+                    concat_simd_data(instr_dict, xlen, self.opnode['bit_width'])
+                elif (type(self.opnode['bit_width'])==str):
+                    concat_simd_data(instr_dict, xlen, tuple(map(int, self.opnode['bit_width'].split(','))))
+                return instr_dict
+
         for i in range(len(instr_dict)):
             for field in instr_dict[i]:
                 # if xlen == 32:

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -967,11 +967,9 @@ class Generator():
                         val_offset = 0
            return instr_dict
 
-        rd_is_paired=False
         paired_regs=0
         if xlen == 32 and 'p64_profile' in self.opnode:
             p64_profile = self.opnode['p64_profile']
-            rd_is_paired = len(p64_profile) >= 3 and p64_profile[0]=='p'
             paired_regs = self.opnode['p64_profile'].count('p')
 
         regset = e_regset if 'e' in base_isa else default_regset
@@ -1006,11 +1004,6 @@ class Generator():
                         assigned += 1
                         if offset == 2048:
                             offset = 0
-                        if rd_is_paired:
-                            instr_dict[i]['offset_hi'] = str(offset)
-                            offset += int(xlen/8)
-                            if offset == 2048:
-                                offset = 0
                 available_reg = regset.copy()
                 available_reg.remove('x0')
             count += 1
@@ -1024,11 +1017,6 @@ class Generator():
                     offset += int(xlen/8)
                     if offset == 2048:
                         offset = 0
-                    if rd_is_paired:
-                        instr_dict[i]['offset_hi'] = str(offset)
-                        offset += int(xlen/8)
-                        if offset == 2048:
-                            offset = 0
         return instr_dict
 
     def testreg(self, instr_dict):
@@ -1227,10 +1215,8 @@ class Generator():
                 data.append("test_fp:")
             code.append("RVTEST_FP_ENABLE()")
 
-        rd_is_paired = False
         if xlen == 32 and 'p64_profile' in self.opnode:
             p64_profile = self.opnode['p64_profile']
-            rd_is_paired = len(p64_profile) >= 3 and p64_profile[0]=='p'
 
         n = 0
         opcode = instr_dict[0]['inst']
@@ -1285,8 +1271,6 @@ class Generator():
                 code.append("RVTEST_SIGBASE("+sreg+",signature_"+sreg+"_"+str(regs[sreg])+")")
             else:
                 n+=stride
-            if rd_is_paired:
-                n+=1
             code.append(res)
             count = count + 1
         case_str = ''.join([case_template.safe_substitute(xlen=xlen,num=i,cond=cond,cov_label=label) for i,cond in enumerate(node['config'])])

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -749,6 +749,14 @@ class Generator():
                 rs2_h2_val = int(instr['rs2_h2_val'])
             if 'rs2_h3_val' in instr:
                 rs2_h3_val = int(instr['rs2_h3_val'])
+            if 'rs1_w0_val' in instr:
+                rs1_w0_val = int(instr['rs1_w0_val'])
+            if 'rs1_w1_val' in instr:
+                rs1_w1_val = int(instr['rs1_w1_val'])
+            if 'rs2_w0_val' in instr:
+                rs2_w0_val = int(instr['rs2_w0_val'])
+            if 'rs2_w1_val' in instr:
+                rs2_w1_val = int(instr['rs2_w1_val'])
             if 'imm_val' in instr:
                 if self.fmt in ['jformat','bformat'] or instr['inst'] in \
                         ['c.beqz','c.bnez','c.jal','c.j','c.jalr']:

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -970,21 +970,12 @@ class Generator():
                         val_offset = 0
            return instr_dict
 
-        rs1_is_paired=False
-        rs2_is_paired=False
         rd_is_paired=False
         paired_regs=0
         if 'p64_profile' in self.opnode:
             p64_profile = self.opnode['p64_profile']
             rd_is_paired = len(p64_profile) >= 3 and p64_profile[0]=='p'
-            rs1_is_paired = len(p64_profile) >= 3 and p64_profile[1]=='p'
-            rs2_is_paired = len(p64_profile) >= 3 and p64_profile[2]=='p'
-        if rs1_is_paired:
-            paired_regs += 1
-        if rs2_is_paired:
-            paired_regs += 1
-        if rd_is_paired:
-            paired_regs += 1
+            paired_regs = self.opnode['p64_profile'].count('p')
 
         regset = e_regset if 'e' in base_isa else default_regset
         total_instr = len(instr_dict)
@@ -994,23 +985,20 @@ class Generator():
         assigned = 0
         offset = 0
         for instr in instr_dict:
-            if rd_is_paired and not 'rd_hi' in instr:
-                print("instr={}".format(instr))
-
             if 'rs1' in instr and instr['rs1'] in available_reg:
                 available_reg.remove(instr['rs1'])
             if 'rs2' in instr and instr['rs2'] in available_reg:
                 available_reg.remove(instr['rs2'])
             if 'rd' in instr and instr['rd'] in available_reg:
                 available_reg.remove(instr['rd'])
-            if rs1_is_paired and instr['rs1_hi'] in available_reg:
+            if 'rs1_hi' in instr and instr['rs1_hi'] in available_reg:
                 available_reg.remove(instr['rs1_hi'])
-            if rs2_is_paired and instr['rs2_hi'] in available_reg:
+            if 'rs2_hi' in instr and instr['rs2_hi'] in available_reg:
                 available_reg.remove(instr['rs2_hi'])
-            if rd_is_paired and instr['rd_hi'] in available_reg:
+            if 'rd_hi' in instr and instr['rd_hi'] in available_reg:
                 available_reg.remove(instr['rd_hi'])
 
-            if len(available_reg) <= 3+paired_regs:
+            if len(available_reg) <= 1+len(self.op_vars)+paired_regs:
                 curr_swreg = available_reg[0]
                 offset = 0
                 for i in range(assigned, count+1):
@@ -1079,39 +1067,28 @@ class Generator():
         count = 0
         assigned = 0
 
-        rs1_is_paired=False
-        rs2_is_paired=False
-        rd_is_paired=False
         paired_regs=0
         if 'p64_profile' in self.opnode:
             p64_profile = self.opnode['p64_profile']
-            rd_is_paired = len(p64_profile) >= 3 and p64_profile[0]=='p'
-            rs1_is_paired = len(p64_profile) >= 3 and p64_profile[1]=='p'
-            rs2_is_paired = len(p64_profile) >= 3 and p64_profile[2]=='p'
-        if rs1_is_paired:
-            paired_regs += 1
-        if rs2_is_paired:
-            paired_regs += 1
-        if rd_is_paired:
-            paired_regs += 1
+            paired_regs = p64_profile.count('p')
 
         for instr in instr_dict:
             if 'rs1' in instr and instr['rs1'] in available_reg:
                 available_reg.remove(instr['rs1'])
-                if rs1_is_paired and instr['rs1_hi'] in available_reg:
+                if 'rs1_hi' in instr and instr['rs1_hi'] in available_reg:
                     available_reg.remove(instr['rs1_hi'])
             if 'rs2' in instr and instr['rs2'] in available_reg:
                 available_reg.remove(instr['rs2'])
-                if rs2_is_paired and instr['rs2_hi'] in available_reg:
+                if 'rs2_hi' in instr and instr['rs2_hi'] in available_reg:
                     available_reg.remove(instr['rs2_hi'])
             if 'rd' in instr and instr['rd'] in available_reg:
                 available_reg.remove(instr['rd'])
-                if rd_is_paired and instr['rd_hi'] in available_reg:
+                if 'rd_hi' in instr and instr['rd_hi'] in available_reg:
                     available_reg.remove(instr['rd_hi'])
             if 'swreg' in instr and instr['swreg'] in available_reg:
                 available_reg.remove(instr['swreg'])
 
-            if len(available_reg) <= (4+paired_regs):
+            if len(available_reg) <= 1+len(self.op_vars)+paired_regs:
                 curr_testreg = available_reg[0]
                 for i in range(assigned, count+1):
                     if 'testreg' not in instr_dict[i]:

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -126,10 +126,16 @@ class Generator():
         base_isa = base_isa_str
         self.fmt = fmt
         self.opcode = opcode
+
         if (opnode['isa'] == 'IP'):
             init_rvp_ops_vals(OPS, VALS)
         self.op_vars = OPS[fmt]
-        self.val_vars = eval(VALS[fmt])
+
+        try:
+            self.val_vars = eval(VALS[fmt])
+        except:
+            self.val_vars=VALS[fmt]
+
         if opcode in ['sw', 'sh', 'sb', 'lw', 'lhu', 'lh', 'lb', 'lbu', 'ld', 'lwu', 'sd',"jal","beq","bge","bgeu","blt","bltu","bne","jalr","flw","fsw","fld","fsd"]:
             self.val_vars = self.val_vars + ['ea_align']
         self.template = opnode['template']
@@ -1071,6 +1077,7 @@ class Generator():
         if (self.opnode['isa'] == 'IP'):
             if ('p64_profile' in self.opnode):
                 gen_pair_reg_data(instr_dict, xlen, self.opnode['bit_width'], self.opnode['p64_profile'])
+                return instr_dict
 
             if ('bit_width' in self.opnode):
                 if (type(self.opnode['bit_width'])==int):

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -898,10 +898,7 @@ class Generator():
             if 'p64_profile' in self.opnode:
                 gen_pair_reg_data(final_instr, xlen, self.opnode['bit_width'], self.opnode['p64_profile'])
             elif 'bit_width' in self.opnode:
-                if (type(self.opnode['bit_width'])==int):
-                    concat_simd_data(final_instr, xlen, self.opnode['bit_width'])
-                elif (type(self.opnode['bit_width'])==str):
-                    concat_simd_data(final_instr, xlen, tuple(map(int, self.opnode['bit_width'].split(','))))
+                concat_simd_data(final_instr, xlen, self.opnode['bit_width'])
 
         return final_instr
 

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -969,7 +969,7 @@ class Generator():
 
         rd_is_paired=False
         paired_regs=0
-        if 'p64_profile' in self.opnode:
+        if xlen == 32 and 'p64_profile' in self.opnode:
             p64_profile = self.opnode['p64_profile']
             rd_is_paired = len(p64_profile) >= 3 and p64_profile[0]=='p'
             paired_regs = self.opnode['p64_profile'].count('p')
@@ -1065,7 +1065,7 @@ class Generator():
         assigned = 0
 
         paired_regs=0
-        if 'p64_profile' in self.opnode:
+        if xlen == 32 and 'p64_profile' in self.opnode:
             p64_profile = self.opnode['p64_profile']
             paired_regs = p64_profile.count('p')
 
@@ -1115,7 +1115,7 @@ class Generator():
             for i in range(len(instr_dict)):
                 instr_dict[i]['correctval'] = '0'
             return instr_dict
-        if 'p64_profile' in self.opnode:
+        if xlen == 32 and 'p64_profile' in self.opnode:
             p64_profile = self.opnode['p64_profile']
             if len(p64_profile) >= 3 and p64_profile[0]=='p':
                 for i in range(len(instr_dict)):
@@ -1146,7 +1146,7 @@ class Generator():
         mydict = instr_dict.copy()
 
         if self.opnode['isa'] == 'IP':
-            if 'p64_profile' in self.opnode or 'bit_width' in self.opnode:
+            if (xlen == 32 and 'p64_profile' in self.opnode) or 'bit_width' in self.opnode:
                 return mydict
 
         for i in range(len(instr_dict)):
@@ -1226,6 +1226,12 @@ class Generator():
             if self.opcode not in ['fsw','flw']:
                 data.append("test_fp:")
             code.append("RVTEST_FP_ENABLE()")
+
+        rd_is_paired = False
+        if xlen == 32 and 'p64_profile' in self.opnode:
+            p64_profile = self.opnode['p64_profile']
+            rd_is_paired = len(p64_profile) >= 3 and p64_profile[0]=='p'
+
         n = 0
         opcode = instr_dict[0]['inst']
         op_node_isa = (op_node['isa']).replace('I','E',1) if 'e' in base_isa else op_node['isa']
@@ -1279,6 +1285,8 @@ class Generator():
                 code.append("RVTEST_SIGBASE("+sreg+",signature_"+sreg+"_"+str(regs[sreg])+")")
             else:
                 n+=stride
+            if rd_is_paired:
+                n+=1
             code.append(res)
             count = count + 1
         case_str = ''.join([case_template.safe_substitute(xlen=xlen,num=i,cond=cond,cov_label=label) for i,cond in enumerate(node['config'])])

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -597,12 +597,15 @@ class Generator():
             for var,reg in zip(self.op_vars,op):
                 instr[var] = str(reg)
         else:
+            p64_profile = 'p64_profile' in self.opnode
             for i,var in enumerate(self.op_vars):
                 if self.opcode[0] == 'f' and 'fence' not in self.opcode:
                     if self.opnode[var+'_op_data'][2] == 'f':
                         instr[var] = 'f'+str(i+10)
                     else:
                         instr[var] = 'x'+str(i+10)
+                elif p64_profile:
+                    instr[var] = 'x'+str(i*2+10)
                 else:
                     instr[var] = 'x'+str(i+10)
         if val:

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -998,12 +998,14 @@ class Generator():
                 offset = 0
                 for i in range(assigned, count+1):
                     if 'swreg' not in instr_dict[i]:
+                        next_offset = offset + int(xlen/8)*self.stride
+                        if next_offset > 2048:
+                            offset = 0
+                            next_offset = 0
                         instr_dict[i]['swreg'] = curr_swreg
                         instr_dict[i]['offset'] = str(offset)
-                        offset += int(xlen/8)
+                        offset = next_offset
                         assigned += 1
-                        if offset == 2048:
-                            offset = 0
                 available_reg = regset.copy()
                 available_reg.remove('x0')
             count += 1
@@ -1012,11 +1014,13 @@ class Generator():
             offset = 0
             for i in range(len(instr_dict)):
                 if 'swreg' not in instr_dict[i]:
+                    next_offset = offset + int(xlen/8)*self.stride
+                    if next_offset > 2048:
+                        offset = 0
+                        next_offset = 0
                     instr_dict[i]['swreg'] = curr_swreg
                     instr_dict[i]['offset'] = str(offset)
-                    offset += int(xlen/8)
-                    if offset == 2048:
-                        offset = 0
+                    offset = next_offset
         return instr_dict
 
     def testreg(self, instr_dict):

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -43,32 +43,66 @@ OPS = {
     'kformat': ['rs1','rd'],
     'frformat': ['rs1', 'rs2', 'rd'],
     'fsrformat': ['rs1', 'rd'],
-    'fr4format': ['rs1', 'rs2', 'rs3', 'rd']
+    'fr4format': ['rs1', 'rs2', 'rs3', 'rd'],
+    'pbrrformat': ['rs1', 'rs2', 'rd'],
+    'phrrformat': ['rs1', 'rs2', 'rd'],
+    'pbrformat': ['rs1', 'rd'],
+    'phrformat': ['rs1', 'rd'],
+    'pbriformat': ['rs1', 'rd'],
+    'phriformat': ['rs1', 'rd'],
+    'psbrrformat': ['rs1', 'rs2', 'rd'],
+    'pshrrformat': ['rs1', 'rs2', 'rd'],
+    'pwrrformat': ['rs1', 'rs2', 'rd'],
+    'pwriformat': ['rs1', 'rd'],
+    'pwrformat': ['rs1', 'rd'],
+    'pswrrformat': ['rs1', 'rs2', 'rd'],
+    'pwhrrformat': ['rs1', 'rs2', 'rd'],
+    'pphrrformat': ['rs1', 'rs2', 'rd'],
+    'ppbrrformat': ['rs1', 'rs2', 'rd'],
+    'prrformat': ['rs1', 'rs2', 'rd'],
+    'prrrformat': ['rs1', 'rs2', 'rs3', 'rd']
 }
 ''' Dictionary mapping instruction formats to operands used by those formats '''
 
 VALS = {
-    'rformat': ['rs1_val', 'rs2_val'],
-    'iformat': ['rs1_val', 'imm_val'],
-    'sformat': ['rs1_val', 'rs2_val', 'imm_val'],
-    'bsformat': ['rs1_val', 'rs2_val', 'imm_val'],
-    'bformat': ['rs1_val', 'rs2_val', 'imm_val'],
-    'uformat': ['imm_val'],
-    'jformat': ['imm_val'],
-    'crformat': ['rs1_val', 'rs2_val'],
-    'cmvformat': ['rs2_val'],
-    'ciformat': ['rs1_val', 'imm_val'],
-    'cssformat': ['rs2_val', 'imm_val'],
-    'ciwformat': ['imm_val'],
-    'clformat': ['rs1_val', 'imm_val'],
-    'csformat': ['rs1_val', 'rs2_val', 'imm_val'],
-    'caformat': ['rs1_val', 'rs2_val'],
-    'cbformat': ['rs1_val', 'imm_val'],
-    'cjformat': ['imm_val'],
-    'kformat': ['rs1_val'],
-    'frformat': ['rs1_val', 'rs2_val', 'rm_val'],
-    'fsrformat': ['rs1_val', 'rm_val'],
-    'fr4format': ['rs1_val', 'rs2_val', 'rs3_val', 'rm_val']
+    'rformat': "['rs1_val', 'rs2_val']",
+    'iformat': "['rs1_val', 'imm_val']",
+    'sformat': "['rs1_val', 'rs2_val', 'imm_val']",
+    'bsformat': "['rs1_val', 'rs2_val', 'imm_val']",
+    'bformat': "['rs1_val', 'rs2_val', 'imm_val']",
+    'uformat': "['imm_val']",
+    'jformat': "['imm_val']",
+    'crformat': "['rs1_val', 'rs2_val']",
+    'cmvformat': "['rs2_val']",
+    'ciformat': "['rs1_val', 'imm_val']",
+    'cssformat': "['rs2_val', 'imm_val']",
+    'ciwformat': "['imm_val']",
+    'clformat': "['rs1_val', 'imm_val']",
+    'csformat': "['rs1_val', 'rs2_val', 'imm_val']",
+    'caformat': "['rs1_val', 'rs2_val']",
+    'cbformat': "['rs1_val', 'imm_val']",
+    'cjformat': "['imm_val']",
+    'kformat': "['rs1_val']",
+    'frformat': "['rs1_val', 'rs2_val', 'rm_val']",
+    'fsrformat': "['rs1_val', 'rm_val']",
+    'fr4format': "['rs1_val', 'rs2_val', 'rs3_val', 'rm_val']",
+    'pbrrformat': 'simd_val_vars("rs1", xlen, 8) + simd_val_vars("rs2", xlen, 8)',
+    'phrrformat': 'simd_val_vars("rs1", xlen, 16) + simd_val_vars("rs2", xlen, 16)',
+    'pbrformat': 'simd_val_vars("rs1", xlen, 8)',
+    'phrformat': 'simd_val_vars("rs1", xlen, 16)',
+    'pbriformat': 'simd_val_vars("rs1", xlen, 8) + ["imm_val"]',
+    'phriformat': 'simd_val_vars("rs1", xlen, 16) + ["imm_val"]',
+    'psbrrformat': 'simd_val_vars("rs1", xlen, 8) + ["rs2_val"]',
+    'pshrrformat': 'simd_val_vars("rs1", xlen, 16) + ["rs2_val"]',
+    'pwrrformat': 'simd_val_vars("rs1", xlen, 32) + simd_val_vars("rs2", xlen, 32)',
+    'pwriformat': 'simd_val_vars("rs1", xlen, 32) + ["imm_val"]',
+    'pwrformat': 'simd_val_vars("rs1", xlen, 32)',
+    'pswrrformat': 'simd_val_vars("rs1", xlen, 32) + ["rs2_val"]',
+    'pwhrrformat': 'simd_val_vars("rs1", xlen, 32) + simd_val_vars("rs2", xlen, 16)',
+    'pphrrformat': '["rs1_val"] + simd_val_vars("rs2", xlen, 16)',
+    'ppbrrformat': '["rs1_val"] + simd_val_vars("rs2", xlen, 8)',
+    'prrformat': '["rs1_val", "rs2_val"]',
+    'prrrformat': "['rs1_val', 'rs2_val' , 'rs3_val']"
 }
 ''' Dictionary mapping instruction formats to operand value variables used by those formats '''
 
@@ -156,14 +190,9 @@ class Generator():
         self.fmt = fmt
         self.opcode = opcode
 
-        if (opnode['isa'] == 'IP'):
-            init_rvp_ops_vals(OPS, VALS)
         self.op_vars = OPS[fmt]
 
-        try:
-            self.val_vars = eval(VALS[fmt])
-        except:
-            self.val_vars=VALS[fmt]
+        self.val_vars = eval(VALS[fmt])
 
         if opcode in ['sw', 'sh', 'sb', 'lw', 'lhu', 'lh', 'lb', 'lbu', 'ld', 'lwu', 'sd',"jal","beq","bge","bgeu","blt","bltu","bne","jalr","flw","fsw","fld","fsd"]:
             self.val_vars = self.val_vars + ['ea_align']

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -970,20 +970,20 @@ class Generator():
                         val_offset = 0
            return instr_dict
 
-        rs1_is_pair=False
-        rs2_is_pair=False
-        rd_is_pair=False
+        rs1_is_paired=False
+        rs2_is_paired=False
+        rd_is_paired=False
         paired_regs=0
         if 'p64_profile' in self.opnode:
             p64_profile = self.opnode['p64_profile']
-            rd_is_pair = len(p64_profile) >= 3 and p64_profile[0]=='p'
-            rs1_is_pair = len(p64_profile) >= 3 and p64_profile[1]=='p'
-            rs2_is_pair = len(p64_profile) >= 3 and p64_profile[2]=='p'
-        if rs1_is_pair:
+            rd_is_paired = len(p64_profile) >= 3 and p64_profile[0]=='p'
+            rs1_is_paired = len(p64_profile) >= 3 and p64_profile[1]=='p'
+            rs2_is_paired = len(p64_profile) >= 3 and p64_profile[2]=='p'
+        if rs1_is_paired:
             paired_regs += 1
-        if rs2_is_pair:
+        if rs2_is_paired:
             paired_regs += 1
-        if rd_is_pair:
+        if rd_is_paired:
             paired_regs += 1
 
         regset = e_regset if 'e' in base_isa else default_regset
@@ -994,7 +994,7 @@ class Generator():
         assigned = 0
         offset = 0
         for instr in instr_dict:
-            if rd_is_pair and not 'rd_hi' in instr:
+            if rd_is_paired and not 'rd_hi' in instr:
                 print("instr={}".format(instr))
 
             if 'rs1' in instr and instr['rs1'] in available_reg:
@@ -1003,11 +1003,11 @@ class Generator():
                 available_reg.remove(instr['rs2'])
             if 'rd' in instr and instr['rd'] in available_reg:
                 available_reg.remove(instr['rd'])
-            if rs1_is_pair and instr['rs1_hi'] in available_reg:
+            if rs1_is_paired and instr['rs1_hi'] in available_reg:
                 available_reg.remove(instr['rs1_hi'])
-            if rs2_is_pair and instr['rs2_hi'] in available_reg:
+            if rs2_is_paired and instr['rs2_hi'] in available_reg:
                 available_reg.remove(instr['rs2_hi'])
-            if rd_is_pair and instr['rd_hi'] in available_reg:
+            if rd_is_paired and instr['rd_hi'] in available_reg:
                 available_reg.remove(instr['rd_hi'])
 
             if len(available_reg) <= 3+paired_regs:
@@ -1021,7 +1021,7 @@ class Generator():
                         assigned += 1
                         if offset == 2048:
                             offset = 0
-                        if rd_is_pair:
+                        if rd_is_paired:
                             instr_dict[i]['offset_hi'] = str(offset)
                             offset += int(xlen/8)
                             if offset == 2048:
@@ -1039,7 +1039,7 @@ class Generator():
                     offset += int(xlen/8)
                     if offset == 2048:
                         offset = 0
-                    if rd_is_pair:
+                    if rd_is_paired:
                         instr_dict[i]['offset_hi'] = str(offset)
                         offset += int(xlen/8)
                         if offset == 2048:
@@ -1079,34 +1079,34 @@ class Generator():
         count = 0
         assigned = 0
 
-        rs1_is_pair=False
-        rs2_is_pair=False
-        rd_is_pair=False
+        rs1_is_paired=False
+        rs2_is_paired=False
+        rd_is_paired=False
         paired_regs=0
         if 'p64_profile' in self.opnode:
             p64_profile = self.opnode['p64_profile']
-            rd_is_pair = len(p64_profile) >= 3 and p64_profile[0]=='p'
-            rs1_is_pair = len(p64_profile) >= 3 and p64_profile[1]=='p'
-            rs2_is_pair = len(p64_profile) >= 3 and p64_profile[2]=='p'
-        if rs1_is_pair:
+            rd_is_paired = len(p64_profile) >= 3 and p64_profile[0]=='p'
+            rs1_is_paired = len(p64_profile) >= 3 and p64_profile[1]=='p'
+            rs2_is_paired = len(p64_profile) >= 3 and p64_profile[2]=='p'
+        if rs1_is_paired:
             paired_regs += 1
-        if rs2_is_pair:
+        if rs2_is_paired:
             paired_regs += 1
-        if rd_is_pair:
+        if rd_is_paired:
             paired_regs += 1
 
         for instr in instr_dict:
             if 'rs1' in instr and instr['rs1'] in available_reg:
                 available_reg.remove(instr['rs1'])
-                if rs1_is_pair and instr['rs1_hi'] in available_reg:
+                if rs1_is_paired and instr['rs1_hi'] in available_reg:
                     available_reg.remove(instr['rs1_hi'])
             if 'rs2' in instr and instr['rs2'] in available_reg:
                 available_reg.remove(instr['rs2'])
-                if rs2_is_pair and instr['rs2_hi'] in available_reg:
+                if rs2_is_paired and instr['rs2_hi'] in available_reg:
                     available_reg.remove(instr['rs2_hi'])
             if 'rd' in instr and instr['rd'] in available_reg:
                 available_reg.remove(instr['rd'])
-                if rd_is_pair and instr['rd_hi'] in available_reg:
+                if rd_is_paired and instr['rd_hi'] in available_reg:
                     available_reg.remove(instr['rd_hi'])
             if 'swreg' in instr and instr['swreg'] in available_reg:
                 available_reg.remove(instr['swreg'])

--- a/sample_cgfs/cgf.yaml
+++ b/sample_cgfs/cgf.yaml
@@ -35,6 +35,25 @@ datasets:
     x30: 0
     x31: 0
 
+  pair_regs: &pair_regs
+    x0: 0
+    x2: 0
+    x4: 0
+    x6: 0
+    x8: 0
+    x10: 0
+    x12: 0
+    x14: 0
+    x16: 0
+    x18: 0
+    x20: 0
+    x22: 0
+    x24: 0
+    x26: 0
+    x28: 0
+    x30: 0
+
+
   c_regs: &c_regs
     x8: 0
     x9: 0
@@ -120,6 +139,12 @@ datasets:
     'rs2_val == 0': 0
     'rs2_val == (2**(xlen)-1)': 0
     'rs2_val == 1': 0
+
+  base_rs3val_unsgn: &base_rs3val_unsgn
+    'rs3_val == 0': 0
+    'rs3_val == (2**(xlen)-1)': 0
+    'rs3_val == 1': 0
+
 
   rfmt_val_comb_sgn: &rfmt_val_comb_sgn
     'rs1_val > 0 and rs2_val > 0': 0
@@ -225,6 +250,11 @@ datasets:
     'walking_ones("rs2_val", xlen)': 0
     'walking_zeros("rs2_val", xlen)': 0
     'alternate("rs2_val",xlen)': 0
+  
+  rs3val_walking: &rs3val_walking
+    'walking_ones("rs3_val", xlen)': 0
+    'walking_zeros("rs3_val", xlen)': 0
+    'alternate("rs3_val",xlen)': 0
   
   ifmt_immval_walking: &ifmt_immval_walking
     'walking_ones("imm_val", 12)': 0

--- a/sample_cgfs/coverpoints.yaml
+++ b/sample_cgfs/coverpoints.yaml
@@ -225,7 +225,12 @@ datasets:
     'walking_ones("rs2_val", xlen)': 0
     'walking_zeros("rs2_val", xlen)': 0
     'alternate("rs2_val",xlen)': 0
-  
+
+  rs3val_walking: &rs3val_walking
+    'walking_ones("rs3_val", xlen)': 0
+    'walking_zeros("rs3_val", xlen)': 0
+    'alternate("rs3_val",xlen)': 0
+
   ifmt_immval_walking: &ifmt_immval_walking
     'walking_ones("imm_val", 12)': 0
     'walking_zeros("imm_val", 12)': 0

--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -446,3 +446,45 @@ datasets:
     'walking_ones("imm_val", 12,False)': 0
     'walking_zeros("imm_val", 12,False)': 0
     'alternate("imm_val",12,False)': 0
+
+  rvp64_rs1val_sgn: &rvp64_rs1val_sgn
+    'rs1_val == (-2**63)': 0
+    'rs1_val == 0': 0
+    'rs1_val == (2**63-1)': 0
+    'rs1_val == 1': 0
+
+  rvp64_rs2val_sgn: &rvp64_rs2val_sgn
+    'rs2_val == (-2**63)': 0
+    'rs2_val == 0': 0
+    'rs2_val == (2**63-1)': 0
+    'rs2_val == 1': 0
+
+  rvp64_rs1val_unsgn: &rvp64_rs1val_unsgn
+    'rs1_val == 0': 0
+    'rs1_val == (2**64-1)': 0
+    'rs1_val == 1': 0
+
+  rvp64_rs2val_unsgn: &rvp64_rs2val_unsgn
+    'rs2_val == 0': 0
+    'rs2_val == (2**64-1)': 0
+    'rs2_val == 1': 0
+
+  rvp64_rs1val_walking_sgn: &rvp64_rs1val_walking_sgn
+    'walking_ones("rs1_val", 64)': 0
+    'walking_zeros("rs1_val", 64)': 0
+    'alternate("rs1_val",64)': 0
+
+  rvp64_rs2val_walking_sgn: &rvp64_rs2val_walking_sgn
+    'walking_ones("rs2_val", 64)': 0
+    'walking_zeros("rs2_val", 64)': 0
+    'alternate("rs2_val",64)': 0
+
+  rvp64_rs1val_walking_unsgn: &rvp64_rs1val_walking_unsgn
+    'walking_ones("rs1_val", 64, signed=False)': 0
+    'walking_zeros("rs1_val", 64, signed=False)': 0
+    'alternate("rs1_val",64, signed=False)': 0
+
+  rvp64_rs2val_walking_unsgn: &rvp64_rs2val_walking_unsgn
+    'walking_ones("rs2_val", 64, signed=False)': 0
+    'walking_zeros("rs2_val", 64, signed=False)': 0
+    'alternate("rs2_val",64, signed=False)': 0

--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -301,7 +301,7 @@ datasets:
     'rs1_val > 0 and imm_val < 0': 0
     'rs1_val < 0 and imm_val > 0': 0
     'rs1_val < 0 and imm_val < 0': 0
-  
+
   ifmt_val_comb_unsgn: &ifmt_val_comb_unsgn
     'rs1_val == imm_val and rs1_val > 0 and imm_val > 0': 0
     'rs1_val != imm_val and rs1_val > 0 and imm_val > 0': 0
@@ -318,7 +318,11 @@ datasets:
     'imm_val == (2**(ceil(log(xlen,2))-1)-1)': 0
     'imm_val == 1': 0
 
-  
+  ifmt_base_immval_unsgn_len_sub_3: &ifmt_base_immval_unsgn_len_sub_3
+    'imm_val == 0': 0
+    'imm_val == (2**(ceil(log(xlen,2))-3))': 0
+    'imm_val == 1': 0
+
   ifmt_base_immval_unsgn: &ifmt_base_immval_unsgn
     'imm_val == 0': 0
     'imm_val == (2**(12)-1)': 0
@@ -407,6 +411,12 @@ datasets:
     'walking_ones("imm_val", ceil(log(xlen,2)), False)': 0
     'walking_zeros("imm_val", ceil(log(xlen,2)), False)': 0
     'alternate("imm_val",ceil(log(xlen,2)), False)': 0
+
+  ifmt_immval_walking_len_sub_3: &ifmt_immval_walking_len_sub_3
+    'walking_ones("imm_val", ceil(log(xlen,2))-3, False)': 0
+    'walking_zeros("imm_val", ceil(log(xlen,2))-3, False)': 0
+    'alternate("imm_val", ceil(log(xlen,2))-3, False)': 0
+
 
   ifmt_immval_walking_5u: &ifmt_immval_walking_5u
     'walking_ones("imm_val", 5, False)': 0

--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -120,6 +120,23 @@ datasets:
     f30: 0
     f31: 0
 
+  pair_regs: &pair_regs
+    x2: 0
+    x4: 0
+    x6: 0
+    x8: 0
+    x10: 0
+    x12: 0
+    x14: 0
+    x16: 0
+    x18: 0
+    x20: 0
+    x22: 0
+    x24: 0
+    x26: 0
+    x28: 0
+    x30: 0
+
   c_regs: &c_regs
     x8: 0
     x9: 0
@@ -241,6 +258,13 @@ datasets:
     'rs2_val == 0': 0
     'rs2_val == (2**(xlen-1)-1)': 0
     'rs2_val == 1': 0
+
+  base_rs3val_sgn: &base_rs3val_sgn
+    'rs3_val == (-2**(xlen-1))': 0
+    'rs3_val == 0': 0
+    'rs3_val == (2**(xlen-1)-1)': 0
+    'rs3_val == 1': 0
+
   
   base_rs1val_unsgn: &base_rs1val_unsgn
     'rs1_val == 0': 0
@@ -251,6 +275,11 @@ datasets:
     'rs2_val == 0': 0
     'rs2_val == (2**(xlen)-1)': 0
     'rs2_val == 1': 0
+
+  base_rs3val_unsgn: &base_rs3val_unsgn
+    'rs3_val == 0': 0
+    'rs3_val == (2**(xlen)-1)': 0
+    'rs3_val == 1': 0
 
   rfmt_val_comb_sgn: &rfmt_val_comb_sgn
     'rs1_val > 0 and rs2_val > 0': 0
@@ -282,6 +311,13 @@ datasets:
     'imm_val == 0': 0
     'imm_val == (2**(12-1)-1)': 0
     'imm_val == 1': 0
+
+  ifmt_base_immval_sgn_len: &ifmt_base_immval_sgn_len
+    'imm_val == (-2**(ceil(log(xlen,2))-1))': 0
+    'imm_val == 0': 0
+    'imm_val == (2**(ceil(log(xlen,2))-1)-1)': 0
+    'imm_val == 1': 0
+
   
   ifmt_base_immval_unsgn: &ifmt_base_immval_unsgn
     'imm_val == 0': 0
@@ -356,11 +392,26 @@ datasets:
     'walking_ones("rs2_val", xlen)': 0
     'walking_zeros("rs2_val", xlen)': 0
     'alternate("rs2_val",xlen)': 0
-  
+
+  rs3val_walking: &rs3val_walking
+    'walking_ones("rs3_val", xlen)': 0
+    'walking_zeros("rs3_val", xlen)': 0
+    'alternate("rs3_val",xlen)': 0
+
   ifmt_immval_walking: &ifmt_immval_walking
     'walking_ones("imm_val", 12)': 0
     'walking_zeros("imm_val", 12)': 0
     'alternate("imm_val",12)': 0
+
+  ifmt_immval_walking_len: &ifmt_immval_walking_len
+    'walking_ones("imm_val", ceil(log(xlen,2)), False)': 0
+    'walking_zeros("imm_val", ceil(log(xlen,2)), False)': 0
+    'alternate("imm_val",ceil(log(xlen,2)), False)': 0
+
+  ifmt_immval_walking_5u: &ifmt_immval_walking_5u
+    'walking_ones("imm_val", 5, False)': 0
+    'walking_zeros("imm_val", 5, False)': 0
+    'alternate("imm_val", 5, False)': 0
   
   rs1val_walking_unsgn: &rs1val_walking_unsgn
     'walking_ones("rs1_val", xlen,False)': 0

--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -320,7 +320,7 @@ datasets:
 
   ifmt_base_immval_unsgn_len_sub_3: &ifmt_base_immval_unsgn_len_sub_3
     'imm_val == 0': 0
-    'imm_val == (2**(ceil(log(xlen,2))-3))': 0
+    'imm_val == (2**(ceil(log(xlen,2))-3)-1)': 0
     'imm_val == 1': 0
 
   ifmt_base_immval_unsgn: &ifmt_base_immval_unsgn

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -2197,3 +2197,79 @@ zunpkd832:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
+pkbb16:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      pkbb16: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=False)': 0
+        'simd_base_val("rs2", xlen, 16, signed=False)': 0
+        'simd_val_comb(xlen, 16, signed=False)': 0
+
+pkbt16:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      pkbt16: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=False)': 0
+        'simd_base_val("rs2", xlen, 16, signed=False)': 0
+        'simd_val_comb(xlen, 16, signed=False)': 0
+
+pktb16:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      pktb16: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=False)': 0
+        'simd_base_val("rs2", xlen, 16, signed=False)': 0
+        'simd_val_comb(xlen, 16, signed=False)': 0
+
+pktt16:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      pktt16: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=False)': 0
+        'simd_base_val("rs2", xlen, 16, signed=False)': 0
+        'simd_val_comb(xlen, 16, signed=False)': 0
+

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -1503,7 +1503,7 @@ smul16:
     rs2:
       <<: *all_regs
     rd:
-      <<: *all_regs
+      <<: *pair_regs
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
@@ -1522,7 +1522,7 @@ smulx16:
     rs2:
       <<: *all_regs
     rd:
-      <<: *all_regs
+      <<: *pair_regs
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
@@ -1541,7 +1541,7 @@ umul16:
     rs2:
       <<: *all_regs
     rd:
-      <<: *all_regs
+      <<: *pair_regs
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
@@ -1560,7 +1560,7 @@ umulx16:
     rs2:
       <<: *all_regs
     rd:
-      <<: *all_regs
+      <<: *pair_regs
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
@@ -1617,7 +1617,7 @@ smul8:
     rs2:
       <<: *all_regs
     rd:
-      <<: *all_regs
+      <<: *pair_regs
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
@@ -1636,7 +1636,7 @@ smulx8:
     rs2:
       <<: *all_regs
     rd:
-      <<: *all_regs
+      <<: *pair_regs
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
@@ -1655,7 +1655,7 @@ umul8:
     rs2:
       <<: *all_regs
     rd:
-      <<: *all_regs
+      <<: *pair_regs
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
@@ -1674,7 +1674,7 @@ umulx8:
     rs2:
       <<: *all_regs
     rd:
-      <<: *all_regs
+      <<: *pair_regs
     op_comb:
       <<: *rfmt_op_comb
     val_comb:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -3070,9 +3070,9 @@ smal:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*rvp64_rs1val_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
 
 # 2.3.6 Miscellaneous Instructions
 
@@ -3257,9 +3257,9 @@ add64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*rvp64_rs1val_sgn, *rvp64_rs2val_sgn, *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        <<: [*rvp64_rs1val_walking_sgn, *rvp64_rs2val_walking_sgn]
 
 radd64:
     config:
@@ -3275,9 +3275,9 @@ radd64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*rvp64_rs1val_sgn, *rvp64_rs2val_sgn, *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        <<: [*rvp64_rs1val_walking_sgn, *rvp64_rs2val_walking_sgn]
 
 uradd64:
     config:
@@ -3293,9 +3293,9 @@ uradd64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_unsgn , *base_rs2val_unsgn , *rfmt_val_comb_unsgn]
+      <<: [*rvp64_rs1val_unsgn, *rvp64_rs2val_unsgn, *rfmt_val_comb_unsgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        <<: [*rvp64_rs1val_walking_unsgn, *rvp64_rs2val_walking_unsgn]
 
 kadd64:
     config:
@@ -3311,9 +3311,9 @@ kadd64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*rvp64_rs1val_sgn, *rvp64_rs2val_sgn, *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        <<: [*rvp64_rs1val_walking_sgn, *rvp64_rs2val_walking_sgn]
 
 ukadd64:
     config:
@@ -3329,9 +3329,9 @@ ukadd64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_unsgn , *base_rs2val_unsgn , *rfmt_val_comb_unsgn]
+      <<: [*rvp64_rs1val_unsgn, *rvp64_rs2val_unsgn, *rfmt_val_comb_unsgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        <<: [*rvp64_rs1val_walking_unsgn, *rvp64_rs2val_walking_unsgn]
 
 sub64:
     config:
@@ -3347,9 +3347,9 @@ sub64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*rvp64_rs1val_sgn, *rvp64_rs2val_sgn, *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        <<: [*rvp64_rs1val_walking_sgn, *rvp64_rs2val_walking_sgn]
 
 rsub64:
     config:
@@ -3365,9 +3365,9 @@ rsub64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*rvp64_rs1val_sgn, *rvp64_rs2val_sgn, *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        <<: [*rvp64_rs1val_walking_sgn, *rvp64_rs2val_walking_sgn]
 
 ursub64:
     config:
@@ -3383,9 +3383,9 @@ ursub64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_unsgn , *base_rs2val_unsgn , *rfmt_val_comb_unsgn]
+      <<: [*rvp64_rs1val_unsgn, *rvp64_rs2val_unsgn, *rfmt_val_comb_unsgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        <<: [*rvp64_rs1val_walking_unsgn, *rvp64_rs2val_walking_unsgn]
 
 ksub64:
     config:
@@ -3401,9 +3401,9 @@ ksub64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*rvp64_rs1val_sgn, *rvp64_rs2val_sgn, *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        <<: [*rvp64_rs1val_walking_sgn, *rvp64_rs2val_walking_sgn]
 
 uksub64:
     config:
@@ -3419,9 +3419,9 @@ uksub64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_unsgn , *base_rs2val_unsgn , *rfmt_val_comb_unsgn]
+      <<: [*rvp64_rs1val_unsgn, *rvp64_rs2val_unsgn, *rfmt_val_comb_unsgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        <<: [*rvp64_rs1val_walking_unsgn, *rvp64_rs2val_walking_unsgn]
 
 # 2.4.2
 smar64:
@@ -3762,9 +3762,10 @@ smslxda:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
 
 # 2.5 Non-SIMD Instructions
 
@@ -4212,8 +4213,8 @@ uraddw:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=True)': 0
-        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
 
 rsubw:
     config:
@@ -4248,16 +4249,32 @@ ursubw:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=True)': 0
-        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
 
-maxw:
+wexti:
     config:
       - check ISA:=regex(.*I.*P.*)
     opcode:
-      maxw: 0
+      wexti: 0
     rs1:
+      <<: *pair_regs
+    rd:
       <<: *all_regs
+    op_comb:
+      <<: *ifmt_op_comb
+    val_comb:
+      <<: [*rvp64_rs1val_sgn]
+      abstract_comb:
+        'simd_imm_val("imm_val", 5)': 0
+
+wext:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      wext: 0
+    rs1:
+      <<: *pair_regs
     rs2:
       <<: *all_regs
     rd:
@@ -4265,27 +4282,9 @@ maxw:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
+      <<: [*rvp64_rs1val_sgn]
       abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=True)': 0
-        'simd_base_val("rs2", xlen, 32, signed=True)': 0
-
-minw:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      minw: 0
-    rs1:
-      <<: *all_regs
-    rs2:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *rfmt_op_comb
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=True)': 0
-        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 8, signed=False)': 0
 
 msubr32:
     config:
@@ -4298,6 +4297,41 @@ msubr32:
       <<: *all_regs
     rd:
       <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+mulr64:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      mulr64: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+mulsr64:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      mulrs64: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
@@ -4339,7 +4373,7 @@ ave:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*base_rs1val_sgn, *base_rs2val_sgn, *rfmt_val_comb_sgn]
       abstract_comb:
         <<: [*rs1val_walking, *rs2val_walking]
 
@@ -4357,7 +4391,7 @@ sra.u:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*base_rs1val_sgn, *base_rs2val_sgn, *rfmt_val_comb_sgn]
       abstract_comb:
         <<: [*rs1val_walking, *rs2val_walking]
 
@@ -4391,7 +4425,7 @@ bitrev:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*base_rs1val_sgn, *base_rs2val_sgn, *rfmt_val_comb_sgn]
       abstract_comb:
         <<: [*rs1val_walking, *rs2val_walking]
 
@@ -4423,9 +4457,9 @@ insb:
     op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      <<: [ *ifmt_val_comb_unsgn, *base_rs1val_sgn, *ifmt_base_immval_unsgn_len_sub_3]
+      <<: [*base_rs1val_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *ifmt_immval_walking_len_sub_3]
+        'simd_imm_val("imm_val", 3)': 0
 
 
 maddr32:
@@ -4443,6 +4477,6 @@ maddr32:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'simd_base_val("rs1", xlen, xlen, signed=True)': 0
-        'simd_base_val("rs2", xlen, xlen, signed=True)': 0
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
 

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -4289,23 +4289,23 @@ msubr32:
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
 
 # 2.5.4
-
-rdov:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      rdov: 0
-    rd:
-      <<: *all_regs
-
-
-clrov:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      clrov: 0
-    rd:
-      <<: *all_regs
+# alias of csr operations 
+# rdov:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       rdov: 0
+#     rd:
+#       <<: *all_regs
+# 
+# 
+# clrov:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       clrov: 0
+#     rd:
+#       <<: *all_regs
 
 # 2.5.5.
 ave:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -3180,7 +3180,7 @@ smaqa.su:
 # 2.4.1
 add64:
     config:
-      - check ISA:=regex(.*I.*P.*)
+      - check ISA:=regex(.*32.*I.*P.*)
     opcode:
       add64: 0
     rs1:
@@ -3270,7 +3270,7 @@ ukadd64:
 
 sub64:
     config:
-      - check ISA:=regex(.*I.*P.*)
+      - check ISA:=regex(.*32.*I.*P.*)
     opcode:
       sub64: 0
     rs1:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -4050,7 +4050,7 @@ kdmabb:
     config:
       - check ISA:=regex(.*I.*P.*)
     opcode:
-      kdmbb: 0
+      kdmabb: 0
     rs1:
       <<: *all_regs
     rs2:
@@ -4069,7 +4069,7 @@ kdmabt:
     config:
       - check ISA:=regex(.*I.*P.*)
     opcode:
-      kdmbt: 0
+      kdmabt: 0
     rs1:
       <<: *all_regs
     rs2:
@@ -4088,7 +4088,7 @@ kdmatt:
     config:
       - check ISA:=regex(.*I.*P.*)
     opcode:
-      kdmtt: 0
+      kdmatt: 0
     rs1:
       <<: *all_regs
     rs2:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -2727,6 +2727,63 @@ pbsada:
         'simd_base_val("rs2", xlen, 8, signed=False)': 0
         'simd_val_comb(xlen, 8, signed=False)': 0
 
+smaqa:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      smaqa: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=True)': 0
+        'simd_base_val("rs2", xlen, 8, signed=True)': 0
+        'simd_val_comb(xlen, 8, signed=True)': 0
+
+umaqa:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      umaqa: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+        'simd_base_val("rs2", xlen, 8, signed=False)': 0
+        'simd_val_comb(xlen, 8, signed=False)': 0
+
+smaqa.su:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      smaqa.su: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=True)': 0
+        'simd_base_val("rs2", xlen, 8, signed=True)': 0
+        'simd_val_comb(xlen, 8, signed=True)': 0
+
 # 2.5 Non-SIMD Instructions
 
 kaddh:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -4006,7 +4006,8 @@ kslraw.u:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=False)': 0
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
-        'simd_val_comb(xlen, 32, signed=True)': 0
+        'rs1_val == rs2_val': 0
+        'rs1_val != rs2_val': 0
 
 ksllw:
     config:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -2067,3 +2067,133 @@ swap8:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
+sunpkd810:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      sunpkd810: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=True)': 0
+
+sunpkd820:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      sunpkd820: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=True)': 0
+
+sunpkd830:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      sunpkd830: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=True)': 0
+
+sunpkd831:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      sunpkd831: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=True)': 0
+
+sunpkd832:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      sunpkd832: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=True)': 0
+
+zunpkd810:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      zunpkd810: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+
+zunpkd820:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      zunpkd820: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+
+zunpkd830:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      zunpkd830: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+
+zunpkd831:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      zunpkd831: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+
+zunpkd832:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      zunpkd832: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -3058,7 +3058,7 @@ kmsxda:
 # 2.3.5
 smal:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smal: 0
     rs1:
@@ -3245,7 +3245,7 @@ smaqa.su:
 # 2.4.1
 add64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       add64: 0
     rs1:
@@ -3263,7 +3263,7 @@ add64:
 
 radd64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       radd64: 0
     rs1:
@@ -3281,7 +3281,7 @@ radd64:
 
 uradd64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       uradd64: 0
     rs1:
@@ -3293,13 +3293,13 @@ uradd64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*base_rs1val_unsgn , *base_rs2val_unsgn , *rfmt_val_comb_unsgn]
       abstract_comb:
         <<: [*rs1val_walking, *rs2val_walking]
 
 kadd64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       kadd64: 0
     rs1:
@@ -3317,7 +3317,7 @@ kadd64:
 
 ukadd64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       ukadd64: 0
     rs1:
@@ -3329,13 +3329,13 @@ ukadd64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*base_rs1val_unsgn , *base_rs2val_unsgn , *rfmt_val_comb_unsgn]
       abstract_comb:
         <<: [*rs1val_walking, *rs2val_walking]
 
 sub64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       sub64: 0
     rs1:
@@ -3353,7 +3353,7 @@ sub64:
 
 rsub64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       rsub64: 0
     rs1:
@@ -3371,7 +3371,7 @@ rsub64:
 
 ursub64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       ursub64: 0
     rs1:
@@ -3383,13 +3383,13 @@ ursub64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*base_rs1val_unsgn , *base_rs2val_unsgn , *rfmt_val_comb_unsgn]
       abstract_comb:
         <<: [*rs1val_walking, *rs2val_walking]
 
 ksub64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       ksub64: 0
     rs1:
@@ -3407,7 +3407,7 @@ ksub64:
 
 uksub64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       uksub64: 0
     rs1:
@@ -3419,14 +3419,14 @@ uksub64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*base_rs1val_unsgn , *base_rs2val_unsgn , *rfmt_val_comb_unsgn]
       abstract_comb:
         <<: [*rs1val_walking, *rs2val_walking]
 
 # 2.4.2
 smar64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smar64: 0
     rs1:
@@ -3438,13 +3438,14 @@ smar64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
 
 smsr64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smsr64: 0
     rs1:
@@ -3456,13 +3457,14 @@ smsr64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
 
 umar64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       umar64: 0
     rs1:
@@ -3474,13 +3476,14 @@ umar64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
 
 umsr64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       umsr64: 0
     rs1:
@@ -3492,13 +3495,14 @@ umsr64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
 
 kmar64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       kmar64: 0
     rs1:
@@ -3510,13 +3514,14 @@ kmar64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
 
 kmsr64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       kmsr64: 0
     rs1:
@@ -3528,13 +3533,14 @@ kmsr64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
 
 ukmar64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       ukmar64: 0
     rs1:
@@ -3546,13 +3552,14 @@ ukmar64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
 
 ukmsr64:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       ukmsr64: 0
     rs1:
@@ -3564,14 +3571,15 @@ ukmsr64:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
 
 # 2.4.3
 smalbb:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smalbb: 0
     rs1:
@@ -3583,13 +3591,14 @@ smalbb:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
 
 smalbt:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smalbt: 0
     rs1:
@@ -3601,13 +3610,14 @@ smalbt:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
 
 smaltt:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smaltt: 0
     rs1:
@@ -3619,13 +3629,14 @@ smaltt:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
 
 smalda:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smalda: 0
     rs1:
@@ -3637,13 +3648,14 @@ smalda:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
 
 smalxda:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smalxda: 0
     rs1:
@@ -3655,13 +3667,14 @@ smalxda:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
 
 smalds:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smalds: 0
     rs1:
@@ -3673,13 +3686,14 @@ smalds:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
 
 smaldrs:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smaldrs: 0
     rs1:
@@ -3691,13 +3705,14 @@ smaldrs:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
 
 smalxds:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smalxds: 0
     rs1:
@@ -3709,13 +3724,14 @@ smalxds:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
 
 smslda:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smslda: 0
     rs1:
@@ -3727,13 +3743,14 @@ smslda:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
 
 smslxda:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       smslxda: 0
     rs1:
@@ -4292,7 +4309,7 @@ msubr32:
 
 rdov:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       rdov: 0
     rd:
@@ -4301,7 +4318,7 @@ rdov:
 
 clrov:
     config:
-      - check ISA:=regex(.*I.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       clrov: 0
     rd:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -2616,6 +2616,117 @@ kmsxda:
         'simd_base_val("rs2", xlen, 16, signed=True)': 0
         'simd_val_comb(xlen, 16, signed=True)': 0
 
+# 2.3.6 Miscellaneous Instructions
+
+sclip32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      sclip32: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb: 
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_imm_val("imm_val", 5)': 0
+
+uclip32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      uclip32: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb: 
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_imm_val("imm_val", 5)': 0
+
+clrs32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      clrs32: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+
+clz32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      clz32: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+
+clo32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      clo32: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+
+pbsad:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      pbsad: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+        'simd_base_val("rs2", xlen, 8, signed=False)': 0
+        'simd_val_comb(xlen, 8, signed=False)': 0
+
+pbsada:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      pbsada: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+        'simd_base_val("rs2", xlen, 8, signed=False)': 0
+        'simd_val_comb(xlen, 8, signed=False)': 0
+
 # 2.5 Non-SIMD Instructions
 
 kaddh:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -17,10 +17,7 @@ add16:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
         'simd_base_val("rs2", xlen, 16, signed=True)': 0
-        'simd_base_val("rs1", xlen, 16, signed=False)': 0
-        'simd_base_val("rs2", xlen, 16, signed=False)': 0
         'simd_val_comb(xlen, 16, signed=True)': 0
-        'simd_val_comb(xlen, 16, signed=False)': 0
 
 radd16:
     config:
@@ -115,10 +112,7 @@ sub16:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
         'simd_base_val("rs2", xlen, 16, signed=True)': 0
-        'simd_base_val("rs1", xlen, 16, signed=False)': 0
-        'simd_base_val("rs2", xlen, 16, signed=False)': 0
         'simd_val_comb(xlen, 16, signed=True)': 0
-        'simd_val_comb(xlen, 16, signed=False)': 0
 
 rsub16:
     config:
@@ -214,10 +208,7 @@ cras16:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
         'simd_base_val("rs2", xlen, 16, signed=True)': 0
-        'simd_base_val("rs1", xlen, 16, signed=False)': 0
-        'simd_base_val("rs2", xlen, 16, signed=False)': 0
         'simd_val_comb(xlen, 16, signed=True)': 0
-        'simd_val_comb(xlen, 16, signed=False)': 0
 
 rcras16:
     config:
@@ -312,10 +303,7 @@ crsa16:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
         'simd_base_val("rs2", xlen, 16, signed=True)': 0
-        'simd_base_val("rs1", xlen, 16, signed=False)': 0
-        'simd_base_val("rs2", xlen, 16, signed=False)': 0
         'simd_val_comb(xlen, 16, signed=True)': 0
-        'simd_val_comb(xlen, 16, signed=False)': 0
 
 rcrsa16:
     config:
@@ -410,10 +398,7 @@ stas16:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
         'simd_base_val("rs2", xlen, 16, signed=True)': 0
-        'simd_base_val("rs1", xlen, 16, signed=False)': 0
-        'simd_base_val("rs2", xlen, 16, signed=False)': 0
         'simd_val_comb(xlen, 16, signed=True)': 0
-        'simd_val_comb(xlen, 16, signed=False)': 0
 
 rstas16:
     config:
@@ -508,10 +493,7 @@ stsa16:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
         'simd_base_val("rs2", xlen, 16, signed=True)': 0
-        'simd_base_val("rs1", xlen, 16, signed=False)': 0
-        'simd_base_val("rs2", xlen, 16, signed=False)': 0
         'simd_val_comb(xlen, 16, signed=True)': 0
-        'simd_val_comb(xlen, 16, signed=False)': 0
 
 rstsa16:
     config:
@@ -606,10 +588,7 @@ add8:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
         'simd_base_val("rs2", xlen, 8, signed=True)': 0
-        'simd_base_val("rs1", xlen, 8, signed=False)': 0
-        'simd_base_val("rs2", xlen, 8, signed=False)': 0
         'simd_val_comb(xlen, 8, signed=True)': 0
-        'simd_val_comb(xlen, 8, signed=False)': 0
 
 radd8:
     config:
@@ -704,10 +683,7 @@ sub8:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
         'simd_base_val("rs2", xlen, 8, signed=True)': 0
-        'simd_base_val("rs1", xlen, 8, signed=False)': 0
-        'simd_base_val("rs2", xlen, 8, signed=False)': 0
         'simd_val_comb(xlen, 8, signed=True)': 0
-        'simd_val_comb(xlen, 8, signed=False)': 0
 
 rsub8:
     config:
@@ -1314,10 +1290,7 @@ cmpeq16:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
         'simd_base_val("rs2", xlen, 16, signed=True)': 0
-        'simd_base_val("rs1", xlen, 16, signed=False)': 0
-        'simd_base_val("rs2", xlen, 16, signed=False)': 0
         'simd_val_comb(xlen, 16, signed=True)': 0
-        'simd_val_comb(xlen, 16, signed=False)': 0
 
 scmplt16:
     config:
@@ -1412,10 +1385,7 @@ cmpeq8:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
         'simd_base_val("rs2", xlen, 8, signed=True)': 0
-        'simd_base_val("rs1", xlen, 8, signed=False)': 0
-        'simd_base_val("rs2", xlen, 8, signed=False)': 0
         'simd_val_comb(xlen, 8, signed=True)': 0
-        'simd_val_comb(xlen, 8, signed=False)': 0
 
 scmplt8:
     config:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -993,9 +993,9 @@ kslra16:
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
-        'walking_ones("rs2_val", ceil(log(16, 2)), True)': 0
-        'walking_zeros("rs2_val", ceil(log(16, 2)), True)': 0
-        'alternate("rs2_val", ceil(log(16, 2)), True)': 0
+        'walking_ones("rs2_val", xlen, True)': 0
+        'walking_zeros("rs2_val", xlen, True)': 0
+        'alternate("rs2_val", xlen, True)': 0
 
 kslra16.u:
     config:
@@ -1012,10 +1012,10 @@ kslra16.u:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'simd_base_val("rs1", xlen, 16, signed=True)': 0
-        'walking_ones("rs2_val", ceil(log(16, 2)), True)': 0
-        'walking_zeros("rs2_val", ceil(log(16, 2)), True)': 0
-        'alternate("rs2_val", ceil(log(16, 2)), True)': 0
+        'simd_base_val("rs1", xlen, 16, signed=False)': 0
+        'walking_ones("rs2_val", xlen, True)': 0
+        'walking_zeros("rs2_val", xlen, True)': 0
+        'alternate("rs2_val", xlen, True)': 0
 
 sra8:
     config:
@@ -1249,9 +1249,9 @@ kslra8:
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
-        'walking_ones("rs2_val", ceil(log(8, 2)), True)': 0
-        'walking_zeros("rs2_val", ceil(log(8, 2)), True)': 0
-        'alternate("rs2_val", ceil(log(8, 2)), True)': 0
+        'walking_ones("rs2_val", xlen, True)': 0
+        'walking_zeros("rs2_val", xlen, True)': 0
+        'alternate("rs2_val", xlen, True)': 0
 
 kslra8.u:
     config:
@@ -1268,10 +1268,10 @@ kslra8.u:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'simd_base_val("rs1", xlen, 8, signed=True)': 0
-        'walking_ones("rs2_val", ceil(log(8, 2)), True)': 0
-        'walking_zeros("rs2_val", ceil(log(8, 2)), True)': 0
-        'alternate("rs2_val", ceil(log(8, 2)), True)': 0
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+        'walking_ones("rs2_val", xlen, True)': 0
+        'walking_zeros("rs2_val", xlen, True)': 0
+        'alternate("rs2_val", xlen, True)': 0
 
 cmpeq16:
     config:
@@ -4004,7 +4004,7 @@ kslraw.u:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
         'simd_val_comb(xlen, 32, signed=True)': 0
 

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -2028,18 +2028,19 @@ clz8:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
-swap8:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      swap8: 0
-    rs1:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+# instructions overlapping with those in the B extension in RV32/RV64 configuration (Zbpbo)
+# swap8:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       swap8: 0
+#     rs1:
+#       <<: *all_regs
+#     rd:
+#       <<: *all_regs
+#     val_comb:
+#       abstract_comb:
+#         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
 sunpkd810:
     config:
@@ -2171,24 +2172,25 @@ zunpkd832:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
-pkbb16:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      pkbb16: 0
-    rs1:
-      <<: *all_regs
-    rs2:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *rfmt_op_comb
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 16, signed=False)': 0
-        'simd_base_val("rs2", xlen, 16, signed=False)': 0
-        'simd_val_comb(xlen, 16, signed=False)': 0
+# instructions overlapping with those in the B extension in RV32 configuration (Zbpbo)
+# pkbb16:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       pkbb16: 0
+#     rs1:
+#       <<: *all_regs
+#     rs2:
+#       <<: *all_regs
+#     rd:
+#       <<: *all_regs
+#     op_comb:
+#       <<: *rfmt_op_comb
+#     val_comb:
+#       abstract_comb:
+#         'simd_base_val("rs1", xlen, 16, signed=False)': 0
+#         'simd_base_val("rs2", xlen, 16, signed=False)': 0
+#         'simd_val_comb(xlen, 16, signed=False)': 0
 
 pkbt16:
     config:
@@ -2228,24 +2230,25 @@ pktb16:
         'simd_base_val("rs2", xlen, 16, signed=False)': 0
         'simd_val_comb(xlen, 16, signed=False)': 0
 
-pktt16:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      pktt16: 0
-    rs1:
-      <<: *all_regs
-    rs2:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *rfmt_op_comb
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 16, signed=False)': 0
-        'simd_base_val("rs2", xlen, 16, signed=False)': 0
-        'simd_val_comb(xlen, 16, signed=False)': 0
+# instructions overlapping with those in the B extension in RV32 configuration (Zbpbo)
+# pktt16:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       pktt16: 0
+#     rs1:
+#       <<: *all_regs
+#     rs2:
+#       <<: *all_regs
+#     rd:
+#       <<: *all_regs
+#     op_comb:
+#       <<: *rfmt_op_comb
+#     val_comb:
+#       abstract_comb:
+#         'simd_base_val("rs1", xlen, 16, signed=False)': 0
+#         'simd_base_val("rs2", xlen, 16, signed=False)': 0
+#         'simd_val_comb(xlen, 16, signed=False)': 0
 
 # 2.3.2.
 smmul:
@@ -3095,18 +3098,19 @@ clrs32:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
 
-clz32:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      clz32: 0
-    rs1:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+# instructions overlapping with those in the B extension in RV32 configuration (Zbpbo)
+# clz32:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       clz32: 0
+#     rs1:
+#       <<: *all_regs
+#     rd:
+#       <<: *all_regs
+#     val_comb:
+#       abstract_comb:
+#         'simd_base_val("rs1", xlen, 32, signed=False)': 0
 
 pbsad:
     config:
@@ -4356,73 +4360,75 @@ srai.u:
         <<: [*rs1val_walking, *ifmt_immval_walking_len]
 
 
-bitrev:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      bitrev: 0
-    rs1:
-      <<: *all_regs
-    rs2:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *rfmt_op_comb
-    val_comb:
-      <<: [*base_rs1val_sgn, *base_rs2val_sgn, *rfmt_val_comb_sgn]
-      abstract_comb:
-        <<: [*rs1val_walking, *rs2val_walking]
+# instructions overlapping with those in the B extension in RV32/RV64 configuration (Zbpbo)
+# bitrev:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       bitrev: 0
+#     rs1:
+#       <<: *all_regs
+#     rs2:
+#       <<: *all_regs
+#     rd:
+#       <<: *all_regs
+#     op_comb:
+#       <<: *rfmt_op_comb
+#     val_comb:
+#       <<: [*base_rs1val_sgn, *base_rs2val_sgn, *rfmt_val_comb_sgn]
+#       abstract_comb:
+#         <<: [*rs1val_walking, *rs2val_walking]
+# 
+# 
+# bitrevi:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       bitrevi: 0
+#     rs1:
+#       <<: *all_regs
+#     rd:
+#       <<: *all_regs
+#     op_comb:
+#       <<: *ifmt_op_comb
+#     val_comb:
+#       abstract_comb:
+#         <<: [*rs1val_walking, *ifmt_immval_walking_len]
 
-
-bitrevi:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      bitrevi: 0
-    rs1:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *ifmt_op_comb
-    val_comb:
-      abstract_comb:
-        <<: [*rs1val_walking, *ifmt_immval_walking_len]
-
-wext:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      wext: 0
-    rs1:
-      <<: *pair_regs
-    rs2:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *rfmt_op_comb
-    val_comb:
-      <<: [*rvp64_rs1val_sgn]
-      abstract_comb:
-        'simd_base_val("rs2", xlen, 8, signed=False)': 0
-
-wexti:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      wexti: 0
-    rs1:
-      <<: *pair_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *ifmt_op_comb
-    val_comb:
-      <<: [*rvp64_rs1val_sgn]
-      abstract_comb:
-        'simd_imm_val("imm_val", 5)': 0
+# instructions overlapping with those in the B extension in RV32/RV64 configuration (Zbpbo)
+# wext:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       wext: 0
+#     rs1:
+#       <<: *pair_regs
+#     rs2:
+#       <<: *all_regs
+#     rd:
+#       <<: *all_regs
+#     op_comb:
+#       <<: *rfmt_op_comb
+#     val_comb:
+#       <<: [*rvp64_rs1val_sgn]
+#       abstract_comb:
+#         'simd_base_val("rs2", xlen, 8, signed=False)': 0
+# 
+# wexti:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       wexti: 0
+#     rs1:
+#       <<: *pair_regs
+#     rd:
+#       <<: *all_regs
+#     op_comb:
+#       <<: *ifmt_op_comb
+#     val_comb:
+#       <<: [*rvp64_rs1val_sgn]
+#       abstract_comb:
+#         'simd_imm_val("imm_val", 5)': 0
 
 insb:
     config:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -2406,3 +2406,280 @@ uksubh:
         'simd_base_val("rs2", xlen, 32, signed=False)': 0
         'simd_val_comb(xlen, 32, signed=False)': 0
 
+kaddw:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      kaddw: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+ukaddw:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      ukaddw: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+ksubw:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      ksubw: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+uksubw:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      uksubw: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+kdmbb:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kdmbb: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kdmbt:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kdmbt: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kdmtt:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kdmtt: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kslraw:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kslraw: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+kslraw.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kslraw.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+ksllw:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      ksllw: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'walking_ones("rs2_val", ceil(log(32, 2)), False)': 0
+        'walking_zeros("rs2_val", ceil(log(32, 2)), False)': 0
+        'alternate("rs2_val", ceil(log(32, 2)), False)': 0
+
+kslliw:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      kslliw: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb: 
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_imm_val("imm_val", 5)': 0
+
+kdmabb:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kdmbb: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kdmabt:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kdmbt: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kdmatt:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kdmtt: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kabsw:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kabsw: 0
+    rs1:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -1003,7 +1003,7 @@ kslli16:
 
 kslra16:
     config:
-      - check isa:=regex(.*i.*p.*)
+      - check isa:=regex(.*I.*P.*)
     opcode:
       kslra16: 0
     rs1:
@@ -1023,7 +1023,7 @@ kslra16:
 
 kslra16.u:
     config:
-      - check isa:=regex(.*i.*p.*)
+      - check isa:=regex(.*I.*P.*)
     opcode:
       kslra16.u: 0
     rs1:
@@ -1279,7 +1279,7 @@ kslra8:
 
 kslra8.u:
     config:
-      - check isa:=regex(.*i.*p.*)
+      - check isa:=regex(.*I.*P.*)
     opcode:
       kslra8.u: 0
     rs1:
@@ -4299,11 +4299,13 @@ rdov:
       <<: *all_regs
 
 
-clov:
+clrov:
     config:
       - check ISA:=regex(.*I.*)
     opcode:
-      clov: 0
+      clrov: 0
+    rd:
+      <<: *all_regs
 
 # 2.5.5.
 ave:
@@ -4320,11 +4322,9 @@ ave:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        'simd_base_val("rs1", xlen, xlen, signed=True)': 0
-        'simd_base_val("rs2", xlen, xlen, signed=True)': 0
-        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
-
+        <<: [*rs1val_walking, *rs2val_walking]
 
 sra.u:
     config:
@@ -4340,10 +4340,9 @@ sra.u:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        'simd_base_val("rs1", xlen, xlen, signed=True)': 0
-        'simd_base_val("rs2", xlen, xlen, signed=True)': 0
-        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
+        <<: [*rs1val_walking, *rs2val_walking]
 
 srai.u:
     config:
@@ -4357,11 +4356,9 @@ srai.u:
     op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      <<: *ifmt_base_shift
       abstract_comb:
-        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
-        'sp_dataset(xlen,["rs1_val",("imm_val",ceil(log(xlen,2)))])': 0
-        <<: [*rs1val_walking, *ifmt_immval_walking]
+        <<: [*rs1val_walking, *ifmt_immval_walking_len]
+
 
 bitrev:
     config:
@@ -4377,10 +4374,10 @@ bitrev:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
-        'simd_base_val("rs1", xlen, xlen, signed=True)': 0
-        'simd_base_val("rs2", xlen, xlen, signed=True)': 0
-        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
+        <<: [*rs1val_walking, *rs2val_walking]
+
 
 bitrevi:
     config:
@@ -4394,17 +4391,14 @@ bitrevi:
     op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      <<: *ifmt_base_shift
       abstract_comb:
-        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
-        'sp_dataset(xlen,["rs1_val",("imm_val",ceil(log(xlen,2)))])': 0
-        <<: [*rs1val_walking, *ifmt_immval_walking]
+        <<: [*rs1val_walking, *ifmt_immval_walking_len]
 
 insb:
     config:
       - check ISA:=regex(.*I.*P.*)
     opcode:
-      bitrevi: 0
+      insb: 0
     rs1:
       <<: *all_regs
     rd:
@@ -4412,11 +4406,10 @@ insb:
     op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      <<: *ifmt_base_shift
+      <<: [ *ifmt_val_comb_unsgn, *base_rs1val_sgn, *ifmt_base_immval_unsgn_len_sub_3]
       abstract_comb:
-        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
-        'sp_dataset(xlen,["rs1_val",("imm_val",ceil(log(xlen,2))-2)])': 0
-        <<: [*rs1val_walking, *ifmt_immval_walking]
+        <<: [*rs1val_walking, *ifmt_immval_walking_len_sub_3]
+
 
 maddr32:
     config:
@@ -4435,5 +4428,4 @@ maddr32:
       abstract_comb:
         'simd_base_val("rs1", xlen, xlen, signed=True)': 0
         'simd_base_val("rs2", xlen, xlen, signed=True)': 0
-        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
 

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -2273,3 +2273,136 @@ pktt16:
         'simd_base_val("rs2", xlen, 16, signed=False)': 0
         'simd_val_comb(xlen, 16, signed=False)': 0
 
+kaddh:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      kaddh: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+ksubh:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      ksubh: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+khmbb:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      khmbb: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+khmbt:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      khmbt: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+khmtt:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      khmtt: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+ukaddh:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      ukaddh: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+uksubh:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      uksubh: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -4238,7 +4238,7 @@ mulsr64:
     config:
       - check ISA:=regex(.*I.*P.*)
     opcode:
-      mulrs64: 0
+      mulsr64: 0
     rs1:
       <<: *all_regs
     rs2:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -4444,4 +4444,4 @@ insb:
     val_comb:
       <<: [*base_rs1val_sgn]
       abstract_comb:
-        'simd_imm_val("imm_val", 3)': 0
+        'simd_imm_val("imm_val", ceil(log(xlen,2))-3)': 0

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -1868,19 +1868,6 @@ clz16:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=False)': 0
 
-clo16:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      clo16: 0
-    rs1:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 16, signed=False)': 0
-
 swap16:
     config:
       - check ISA:=regex(.*I.*P.*)
@@ -2033,19 +2020,6 @@ clz8:
       - check ISA:=regex(.*I.*P.*)
     opcode:
       clz8: 0
-    rs1:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 8, signed=False)': 0
-
-clo8:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      clo8: 0
     rs1:
       <<: *all_regs
     rd:
@@ -3126,19 +3100,6 @@ clz32:
       - check ISA:=regex(.*I.*P.*)
     opcode:
       clz32: 0
-    rs1:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=False)': 0
-
-clo32:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      clo32: 0
     rs1:
       <<: *all_regs
     rd:
@@ -4252,58 +4213,6 @@ ursubw:
         'simd_base_val("rs1", xlen, 32, signed=False)': 0
         'simd_base_val("rs2", xlen, 32, signed=False)': 0
 
-wexti:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      wexti: 0
-    rs1:
-      <<: *pair_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *ifmt_op_comb
-    val_comb:
-      <<: [*rvp64_rs1val_sgn]
-      abstract_comb:
-        'simd_imm_val("imm_val", 5)': 0
-
-wext:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      wext: 0
-    rs1:
-      <<: *pair_regs
-    rs2:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *rfmt_op_comb
-    val_comb:
-      <<: [*rvp64_rs1val_sgn]
-      abstract_comb:
-        'simd_base_val("rs2", xlen, 8, signed=False)': 0
-
-msubr32:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      msubr32: 0
-    rs1:
-      <<: *all_regs
-    rs2:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *rfmt_op_comb
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=True)': 0
-        'simd_base_val("rs2", xlen, 32, signed=True)': 0
-
 mulr64:
     config:
       - check ISA:=regex(.*I.*P.*)
@@ -4332,6 +4241,42 @@ mulsr64:
       <<: *all_regs
     rd:
       <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+maddr32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      maddr32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+msubr32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      msubr32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
@@ -4445,6 +4390,40 @@ bitrevi:
       abstract_comb:
         <<: [*rs1val_walking, *ifmt_immval_walking_len]
 
+wext:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      wext: 0
+    rs1:
+      <<: *pair_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*rvp64_rs1val_sgn]
+      abstract_comb:
+        'simd_base_val("rs2", xlen, 8, signed=False)': 0
+
+wexti:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      wexti: 0
+    rs1:
+      <<: *pair_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *ifmt_op_comb
+    val_comb:
+      <<: [*rvp64_rs1val_sgn]
+      abstract_comb:
+        'simd_imm_val("imm_val", 5)': 0
+
 insb:
     config:
       - check ISA:=regex(.*I.*P.*)
@@ -4460,23 +4439,3 @@ insb:
       <<: [*base_rs1val_sgn]
       abstract_comb:
         'simd_imm_val("imm_val", 3)': 0
-
-
-maddr32:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      maddr32: 0
-    rs1:
-      <<: *all_regs
-    rs2:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *rfmt_op_comb
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=True)': 0
-        'simd_base_val("rs2", xlen, 32, signed=True)': 0
-

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -1,17 +1,17 @@
 # For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
 
 add16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       add16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -590,17 +590,17 @@ ukstsa16:
         'simd_val_comb(xlen, 16, signed=False)': 0
 
 add8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       add8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -612,17 +612,17 @@ add8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 radd8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       radd8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -631,17 +631,17 @@ radd8:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 uradd8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       uradd8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -650,17 +650,17 @@ uradd8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 kadd8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       kadd8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -669,7 +669,7 @@ kadd8:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 ukadd8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
     opcode: 
       ukadd8: 0
@@ -688,17 +688,17 @@ ukadd8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 sub8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sub8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -710,17 +710,17 @@ sub8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 rsub8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       rsub8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -729,17 +729,17 @@ rsub8:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 ursub8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       ursub8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -748,17 +748,17 @@ ursub8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 ksub8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       ksub8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -767,17 +767,17 @@ ksub8:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 uksub8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       uksub8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -786,17 +786,17 @@ uksub8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 sra16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sra16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -806,33 +806,33 @@ sra16:
         'alternate("rs2_val", ceil(log(16, 2)), False)': 0
 
 srai16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       srai16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
         'simd_imm_val("imm_val", 4)': 0
 
 sra16.u:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sra16.u: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -842,33 +842,33 @@ sra16.u:
         'alternate("rs2_val", ceil(log(16, 2)), False)': 0
 
 srai16.u:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       srai16.u: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
         'simd_imm_val("imm_val", 4)': 0
 
 srl16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       srl16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -878,33 +878,33 @@ srl16:
         'alternate("rs2_val", ceil(log(16, 2)), False)': 0
 
 srli16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       srli16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=False)': 0
         'simd_imm_val("imm_val", 4)': 0
 
 srl16.u:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       srl16.u: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -914,33 +914,33 @@ srl16.u:
         'alternate("rs2_val", ceil(log(16, 2)), False)': 0
 
 srli16.u:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       srli16.u: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=False)': 0
         'simd_imm_val("imm_val", 4)': 0
 
 sll16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sll16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -950,33 +950,33 @@ sll16:
         'alternate("rs2_val", ceil(log(16, 2)), False)': 0
 
 slli16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       slli16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=False)': 0
         'simd_imm_val("imm_val", 4)': 0
 
 ksll16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       ksll16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -986,33 +986,33 @@ ksll16:
         'alternate("rs2_val", ceil(log(16, 2)), False)': 0
 
 kslli16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       kslli16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
         'simd_imm_val("imm_val", 4)': 0
 
 kslra16:
-    config: 
+    config:
       - check isa:=regex(.*i.*p.*)
-    opcode: 
+    opcode:
       kslra16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1022,17 +1022,17 @@ kslra16:
         'alternate("rs2_val", ceil(log(16, 2)), True)': 0
 
 kslra16.u:
-    config: 
+    config:
       - check isa:=regex(.*i.*p.*)
-    opcode: 
+    opcode:
       kslra16.u: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1042,17 +1042,17 @@ kslra16.u:
         'alternate("rs2_val", ceil(log(16, 2)), True)': 0
 
 sra8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sra8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1062,33 +1062,33 @@ sra8:
         'alternate("rs2_val", ceil(log(8, 2)), False)': 0
 
 srai8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       srai8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
         'simd_imm_val("imm_val", 3)': 0
 
 sra8.u:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sra8.u: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1098,33 +1098,33 @@ sra8.u:
         'alternate("rs2_val", ceil(log(8, 2)), False)': 0
 
 srai8.u:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       srai8.u: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
         'simd_imm_val("imm_val", 3)': 0
 
 srl8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       srl8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1134,33 +1134,33 @@ srl8:
         'alternate("rs2_val", ceil(log(8, 2)), False)': 0
 
 srli8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       srli8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
         'simd_imm_val("imm_val", 3)': 0
 
 srl8.u:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       srl8.u: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1170,33 +1170,33 @@ srl8.u:
         'alternate("rs2_val", ceil(log(8, 2)), False)': 0
 
 srli8.u:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       srli8.u: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
         'simd_imm_val("imm_val", 3)': 0
 
 sll8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sll8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1206,33 +1206,33 @@ sll8:
         'alternate("rs2_val", ceil(log(8, 2)), False)': 0
 
 slli8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       slli8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
         'simd_imm_val("imm_val", 3)': 0
 
 ksll8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       ksll8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1242,33 +1242,33 @@ ksll8:
         'alternate("rs2_val", ceil(log(8, 2)), False)': 0
 
 kslli8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       kslli8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
         'simd_imm_val("imm_val", 3)': 0
 
 kslra8:
-    config: 
+    config:
       - check isa:=regex(.*i.*p.*)
-    opcode: 
+    opcode:
       kslra8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1278,17 +1278,17 @@ kslra8:
         'alternate("rs2_val", ceil(log(8, 2)), True)': 0
 
 kslra8.u:
-    config: 
+    config:
       - check isa:=regex(.*i.*p.*)
-    opcode: 
+    opcode:
       kslra8.u: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1298,17 +1298,17 @@ kslra8.u:
         'alternate("rs2_val", ceil(log(8, 2)), True)': 0
 
 cmpeq16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       cmpeq16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1396,17 +1396,17 @@ ucmple16:
         'simd_val_comb(xlen, 16, signed=False)': 0
 
 cmpeq8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       cmpeq8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1418,17 +1418,17 @@ cmpeq8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 scmplt8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       scmplt8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1437,17 +1437,17 @@ scmplt8:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 scmple8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       scmple8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1456,17 +1456,17 @@ scmple8:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 ucmplt8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       ucmplt8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1475,17 +1475,17 @@ ucmplt8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 ucmple8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       ucmple8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1494,17 +1494,17 @@ ucmple8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 smul16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       smul16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1513,17 +1513,17 @@ smul16:
         'simd_val_comb(xlen, 16, signed=True)': 0
 
 smulx16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       smulx16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1532,17 +1532,17 @@ smulx16:
         'simd_val_comb(xlen, 16, signed=True)': 0
 
 umul16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       umul16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1551,17 +1551,17 @@ umul16:
         'simd_val_comb(xlen, 16, signed=False)': 0
 
 umulx16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       umulx16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1570,17 +1570,17 @@ umulx16:
         'simd_val_comb(xlen, 16, signed=False)': 0
 
 khm16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       khm16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1589,17 +1589,17 @@ khm16:
         'simd_val_comb(xlen, 16, signed=True)': 0
 
 khmx16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       khmx16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1608,17 +1608,17 @@ khmx16:
         'simd_val_comb(xlen, 16, signed=True)': 0
 
 smul8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       smul8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1627,17 +1627,17 @@ smul8:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 smulx8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       smulx8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1646,17 +1646,17 @@ smulx8:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 umul8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       umul8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1665,17 +1665,17 @@ umul8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 umulx8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       umulx8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1684,17 +1684,17 @@ umulx8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 khm8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       khm8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1703,17 +1703,17 @@ khm8:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 khmx8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       khmx8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1722,17 +1722,17 @@ khmx8:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 smin16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       smin16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1741,17 +1741,17 @@ smin16:
         'simd_val_comb(xlen, 16, signed=True)': 0
 
 umin16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       umin16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1760,17 +1760,17 @@ umin16:
         'simd_val_comb(xlen, 16, signed=False)': 0
 
 smax16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       smax16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1779,17 +1779,17 @@ smax16:
         'simd_val_comb(xlen, 16, signed=True)': 0
 
 umax16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       umax16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1798,114 +1798,114 @@ umax16:
         'simd_val_comb(xlen, 16, signed=False)': 0
 
 sclip16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sclip16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
         'simd_imm_val("imm_val", 4)': 0
 
 uclip16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       uclip16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=False)': 0
         'simd_imm_val("imm_val", 4)': 0
 
 kabs16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       kabs16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
 
 clrs16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       clrs16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=True)': 0
 
 clz16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       clz16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=False)': 0
 
 clo16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       clo16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=False)': 0
 
 swap16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       swap16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=False)': 0
 
 smin8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       smin8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1914,17 +1914,17 @@ smin8:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 umin8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       umin8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1933,17 +1933,17 @@ umin8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 smax8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       smax8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1952,17 +1952,17 @@ smax8:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 umax8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       umax8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -1971,244 +1971,244 @@ umax8:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 kabs8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       kabs8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
 
 sclip8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sclip8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
         'simd_imm_val("imm_val", 3)': 0
 
 uclip8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       uclip8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
         'simd_imm_val("imm_val", 3)': 0
 
 clrs8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       clrs8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
 
 clz8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       clz8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
 clo8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       clo8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
 swap8:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       swap8: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
 sunpkd810:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sunpkd810: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
 
 sunpkd820:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sunpkd820: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
 
 sunpkd830:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sunpkd830: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
 
 sunpkd831:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sunpkd831: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
 
 sunpkd832:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sunpkd832: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
 
 zunpkd810:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       zunpkd810: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
 zunpkd820:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       zunpkd820: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
 zunpkd830:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       zunpkd830: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
 zunpkd831:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       zunpkd831: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
 zunpkd832:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       zunpkd832: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 8, signed=False)': 0
 
 pkbb16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       pkbb16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2217,17 +2217,17 @@ pkbb16:
         'simd_val_comb(xlen, 16, signed=False)': 0
 
 pkbt16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       pkbt16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2236,17 +2236,17 @@ pkbt16:
         'simd_val_comb(xlen, 16, signed=False)': 0
 
 pktb16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       pktb16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2255,23 +2255,462 @@ pktb16:
         'simd_val_comb(xlen, 16, signed=False)': 0
 
 pktt16:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       pktt16: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=False)': 0
         'simd_base_val("rs2", xlen, 16, signed=False)': 0
         'simd_val_comb(xlen, 16, signed=False)': 0
+
+# 2.3.2.
+smmul:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smmul: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+smmul.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smmul.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+kmmac:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmac: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+kmmac.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmac.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+kmmsb:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmsb: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+kmmsb.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmsb.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+kwmmul:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kwmmul: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+kwmmul.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kwmmul.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+
+# 2.3.3 Most Significant Word 32x32 Multiply & Add Instructions
+
+smmwb:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smmwb: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+smmwb.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smmwb.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+smmwt:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smmwt: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+smmwt.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smmwt.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+
+kmmawb:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmawb: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+kmmawb.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmawb.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+kmmawt:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmawt: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+kmmawt.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmawt.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+
+kmmwb2:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmwb2: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+kmmwb2.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmwb2.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+kmmwt2:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmwt2: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+kmmwt2.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmwt2.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+
+kmmawb2:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmawb2: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+kmmawb2.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmawb2.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+kmmawt2:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmawt2: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+
+kmmawt2.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmmawt2.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
 
 # 2.3.4
 
@@ -2616,91 +3055,110 @@ kmsxda:
         'simd_base_val("rs2", xlen, 16, signed=True)': 0
         'simd_val_comb(xlen, 16, signed=True)': 0
 
+# 2.3.5
+smal:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smal: 0
+    rs1:
+      <<: *pair_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
 # 2.3.6 Miscellaneous Instructions
 
 sclip32:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       sclip32: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
         'simd_imm_val("imm_val", 5)': 0
 
 uclip32:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       uclip32: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=False)': 0
         'simd_imm_val("imm_val", 5)': 0
 
 clrs32:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       clrs32: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
 
 clz32:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       clz32: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=False)': 0
 
 clo32:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       clo32: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=False)': 0
 
 pbsad:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       pbsad: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2709,17 +3167,17 @@ pbsad:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 pbsada:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       pbsada: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2728,17 +3186,17 @@ pbsada:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 smaqa:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       smaqa: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2747,17 +3205,17 @@ smaqa:
         'simd_val_comb(xlen, 8, signed=True)': 0
 
 umaqa:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       umaqa: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2766,17 +3224,17 @@ umaqa:
         'simd_val_comb(xlen, 8, signed=False)': 0
 
 smaqa.su:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       smaqa.su: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2784,20 +3242,527 @@ smaqa.su:
         'simd_base_val("rs2", xlen, 8, signed=True)': 0
         'simd_val_comb(xlen, 8, signed=True)': 0
 
+# 2.4.1
+add64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      add64: 0
+    rs1:
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+radd64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      radd64: 0
+    rs1:
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+uradd64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      uradd64: 0
+    rs1:
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+kadd64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      kadd64: 0
+    rs1:
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+ukadd64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      ukadd64: 0
+    rs1:
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+sub64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      sub64: 0
+    rs1:
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+rsub64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      rsub64: 0
+    rs1:
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+ursub64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      ursub64: 0
+    rs1:
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+ksub64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      ksub64: 0
+    rs1:
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+uksub64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      uksub64: 0
+    rs1:
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+# 2.4.2
+smar64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smar64: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+smsr64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smsr64: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+umar64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      umar64: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+umsr64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      umsr64: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+kmar64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      kmar64: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+kmsr64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      kmsr64: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+ukmar64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      ukmar64: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+ukmsr64:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      ukmsr64: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+# 2.4.3
+smalbb:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smalbb: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+smalbt:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smalbt: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+smaltt:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smaltt: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+smalda:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smalda: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+smalxda:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smalxda: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+smalds:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smalds: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+smaldrs:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smaldrs: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+smalxds:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smalxds: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+smslda:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smslda: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+smslxda:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      smslxda: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
 # 2.5 Non-SIMD Instructions
 
 kaddh:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       kaddh: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2806,17 +3771,17 @@ kaddh:
         'simd_val_comb(xlen, 32, signed=True)': 0
 
 ksubh:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       ksubh: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2825,17 +3790,17 @@ ksubh:
         'simd_val_comb(xlen, 32, signed=True)': 0
 
 khmbb:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       khmbb: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2844,17 +3809,17 @@ khmbb:
         'simd_val_comb(xlen, 16, signed=True)': 0
 
 khmbt:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       khmbt: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2863,17 +3828,17 @@ khmbt:
         'simd_val_comb(xlen, 16, signed=True)': 0
 
 khmtt:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       khmtt: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2882,17 +3847,17 @@ khmtt:
         'simd_val_comb(xlen, 16, signed=True)': 0
 
 ukaddh:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       ukaddh: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2901,17 +3866,17 @@ ukaddh:
         'simd_val_comb(xlen, 32, signed=False)': 0
 
 uksubh:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       uksubh: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2920,17 +3885,17 @@ uksubh:
         'simd_val_comb(xlen, 32, signed=False)': 0
 
 kaddw:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       kaddw: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2939,17 +3904,17 @@ kaddw:
         'simd_val_comb(xlen, 32, signed=True)': 0
 
 ukaddw:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       ukaddw: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2958,17 +3923,17 @@ ukaddw:
         'simd_val_comb(xlen, 32, signed=False)': 0
 
 ksubw:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       ksubw: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -2977,17 +3942,17 @@ ksubw:
         'simd_val_comb(xlen, 32, signed=True)': 0
 
 uksubw:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       uksubw: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -3091,17 +4056,17 @@ kslraw.u:
         'simd_val_comb(xlen, 32, signed=True)': 0
 
 ksllw:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       ksllw: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rs2: 
+    rs2:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
@@ -3111,18 +4076,18 @@ ksllw:
         'alternate("rs2_val", ceil(log(32, 2)), False)': 0
 
 kslliw:
-    config: 
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
+    opcode:
       kslliw: 0
-    rs1: 
+    rs1:
       <<: *all_regs
-    rd: 
+    rd:
       <<: *all_regs
-    op_comb: 
+    op_comb:
       <<: *ifmt_op_comb
     val_comb:
-      abstract_comb: 
+      abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
         'simd_imm_val("imm_val", 5)': 0
 
@@ -3195,4 +4160,280 @@ kabsw:
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
+
+# 2.5.3.
+raddw:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      raddw: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+uraddw:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      uraddw: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+rsubw:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      rsubw: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+ursubw:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      ursubw: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+maxw:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      maxw: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+minw:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      minw: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+msubr32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      msubr32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+
+# 2.5.4
+
+rdov:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      rdov: 0
+    rd:
+      <<: *all_regs
+
+
+clov:
+    config:
+      - check ISA:=regex(.*I.*)
+    opcode:
+      clov: 0
+
+# 2.5.5.
+ave:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      ave: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, xlen, signed=True)': 0
+        'simd_base_val("rs2", xlen, xlen, signed=True)': 0
+        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
+
+
+sra.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      sra.u: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, xlen, signed=True)': 0
+        'simd_base_val("rs2", xlen, xlen, signed=True)': 0
+        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
+
+srai.u:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      srai.u: 0
+    rs1:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *ifmt_op_comb
+    val_comb:
+      <<: *ifmt_base_shift
+      abstract_comb:
+        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
+        'sp_dataset(xlen,["rs1_val",("imm_val",ceil(log(xlen,2)))])': 0
+        <<: [*rs1val_walking, *ifmt_immval_walking]
+
+bitrev:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      bitrev: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, xlen, signed=True)': 0
+        'simd_base_val("rs2", xlen, xlen, signed=True)': 0
+        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
+
+bitrevi:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      bitrevi: 0
+    rs1:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *ifmt_op_comb
+    val_comb:
+      <<: *ifmt_base_shift
+      abstract_comb:
+        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
+        'sp_dataset(xlen,["rs1_val",("imm_val",ceil(log(xlen,2)))])': 0
+        <<: [*rs1val_walking, *ifmt_immval_walking]
+
+insb:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      bitrevi: 0
+    rs1:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *ifmt_op_comb
+    val_comb:
+      <<: *ifmt_base_shift
+      abstract_comb:
+        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
+        'sp_dataset(xlen,["rs1_val",("imm_val",ceil(log(xlen,2))-2)])': 0
+        <<: [*rs1val_walking, *ifmt_immval_walking]
+
+maddr32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      maddr32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, xlen, signed=True)': 0
+        'simd_base_val("rs2", xlen, xlen, signed=True)': 0
+        'sp_dataset(xlen,["rs1_val","rs2_val"])': 0
 

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -1894,6 +1894,95 @@ swap16:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=False)': 0
 
+smin8:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      smin8: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=True)': 0
+        'simd_base_val("rs2", xlen, 8, signed=True)': 0
+        'simd_val_comb(xlen, 8, signed=True)': 0
+
+umin8:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      umin8: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+        'simd_base_val("rs2", xlen, 8, signed=False)': 0
+        'simd_val_comb(xlen, 8, signed=False)': 0
+
+smax8:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      smax8: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=True)': 0
+        'simd_base_val("rs2", xlen, 8, signed=True)': 0
+        'simd_val_comb(xlen, 8, signed=True)': 0
+
+umax8:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      umax8: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+        'simd_base_val("rs2", xlen, 8, signed=False)': 0
+        'simd_val_comb(xlen, 8, signed=False)': 0
+
+kabs8:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      kabs8: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=True)': 0
+
 sclip8:
     config: 
       - check ISA:=regex(.*I.*P.*)
@@ -1909,4 +1998,72 @@ sclip8:
       abstract_comb: 
         'simd_base_val("rs1", xlen, 8, signed=True)': 0
         'simd_imm_val("imm_val", 3)': 0
+
+uclip8:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      uclip8: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb: 
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+        'simd_imm_val("imm_val", 3)': 0
+
+clrs8:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      clrs8: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=True)': 0
+
+clz8:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      clz8: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+
+clo8:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      clo8: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
+
+swap8:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      swap8: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 8, signed=False)': 0
 

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -3719,9 +3719,9 @@ kaddh:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=True)': 0
-        'simd_base_val("rs2", xlen, 32, signed=True)': 0
-        'simd_val_comb(xlen, 32, signed=True)': 0
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
 
 ksubh:
     config:
@@ -3738,9 +3738,9 @@ ksubh:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=True)': 0
-        'simd_base_val("rs2", xlen, 32, signed=True)': 0
-        'simd_val_comb(xlen, 32, signed=True)': 0
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
 
 khmbb:
     config:
@@ -3814,9 +3814,9 @@ ukaddh:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=False)': 0
-        'simd_base_val("rs2", xlen, 32, signed=False)': 0
-        'simd_val_comb(xlen, 32, signed=False)': 0
+        'simd_base_val("rs1", xlen, 16, signed=False)': 0
+        'simd_base_val("rs2", xlen, 16, signed=False)': 0
+        'simd_val_comb(xlen, 16, signed=False)': 0
 
 uksubh:
     config:
@@ -3833,9 +3833,9 @@ uksubh:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=False)': 0
-        'simd_base_val("rs2", xlen, 32, signed=False)': 0
-        'simd_val_comb(xlen, 32, signed=False)': 0
+        'simd_base_val("rs1", xlen, 16, signed=False)': 0
+        'simd_base_val("rs2", xlen, 16, signed=False)': 0
+        'simd_val_comb(xlen, 16, signed=False)': 0
 
 kaddw:
     config:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -2273,6 +2273,351 @@ pktt16:
         'simd_base_val("rs2", xlen, 16, signed=False)': 0
         'simd_val_comb(xlen, 16, signed=False)': 0
 
+# 2.3.4
+
+smbb16:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smbb16: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+smbt16:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smbt16: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+smtt16:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smtt16: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kmda:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmda: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kmxda:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmxda: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+smds:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smds: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+smdrs:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smdrs: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+smxds:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smxds: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kmabb:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmabb: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kmabt:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmabt: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kmatt:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmatt: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kmada:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmada: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kmaxda:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmaxda: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kmads:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmads: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kmadrs:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmadrs: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kmaxds:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmaxds: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kmsda:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmsda: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kmsxda:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmsxda: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+# 2.5 Non-SIMD Instructions
+
 kaddh:
     config: 
       - check ISA:=regex(.*I.*P.*)

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -1838,18 +1838,19 @@ clz16:
       abstract_comb:
         'simd_base_val("rs1", xlen, 16, signed=False)': 0
 
-swap16:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      swap16: 0
-    rs1:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 16, signed=False)': 0
+# alias of pkbt16
+# swap16:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       swap16: 0
+#     rs1:
+#       <<: *all_regs
+#     rd:
+#       <<: *all_regs
+#     val_comb:
+#       abstract_comb:
+#         'simd_base_val("rs1", xlen, 16, signed=False)': 0
 
 smin8:
     config:

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -1003,7 +1003,7 @@ kslli16:
 
 kslra16:
     config:
-      - check isa:=regex(.*I.*P.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       kslra16: 0
     rs1:
@@ -1023,7 +1023,7 @@ kslra16:
 
 kslra16.u:
     config:
-      - check isa:=regex(.*I.*P.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       kslra16.u: 0
     rs1:
@@ -1259,7 +1259,7 @@ kslli8:
 
 kslra8:
     config:
-      - check isa:=regex(.*i.*p.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       kslra8: 0
     rs1:
@@ -1279,7 +1279,7 @@ kslra8:
 
 kslra8.u:
     config:
-      - check isa:=regex(.*I.*P.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode:
       kslra8.u: 0
     rs1:

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -17,10 +17,7 @@ add32:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
-        'simd_base_val("rs1", xlen, 32, signed=False)': 0
-        'simd_base_val("rs2", xlen, 32, signed=False)': 0
         'simd_val_comb(xlen, 32, signed=True)': 0
-        'simd_val_comb(xlen, 32, signed=False)': 0
 
 radd32:
     config:
@@ -115,10 +112,7 @@ sub32:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
-        'simd_base_val("rs1", xlen, 32, signed=False)': 0
-        'simd_base_val("rs2", xlen, 32, signed=False)': 0
         'simd_val_comb(xlen, 32, signed=True)': 0
-        'simd_val_comb(xlen, 32, signed=False)': 0
 
 rsub32:
     config:
@@ -214,10 +208,7 @@ cras32:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
-        'simd_base_val("rs1", xlen, 32, signed=False)': 0
-        'simd_base_val("rs2", xlen, 32, signed=False)': 0
         'simd_val_comb(xlen, 32, signed=True)': 0
-        'simd_val_comb(xlen, 32, signed=False)': 0
 
 rcras32:
     config:
@@ -312,10 +303,7 @@ crsa32:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
-        'simd_base_val("rs1", xlen, 32, signed=False)': 0
-        'simd_base_val("rs2", xlen, 32, signed=False)': 0
         'simd_val_comb(xlen, 32, signed=True)': 0
-        'simd_val_comb(xlen, 32, signed=False)': 0
 
 rcrsa32:
     config:
@@ -410,10 +398,7 @@ stas32:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
-        'simd_base_val("rs1", xlen, 32, signed=False)': 0
-        'simd_base_val("rs2", xlen, 32, signed=False)': 0
         'simd_val_comb(xlen, 32, signed=True)': 0
-        'simd_val_comb(xlen, 32, signed=False)': 0
 
 rstas32:
     config:
@@ -508,10 +493,7 @@ stsa32:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
-        'simd_base_val("rs1", xlen, 32, signed=False)': 0
-        'simd_base_val("rs2", xlen, 32, signed=False)': 0
         'simd_val_comb(xlen, 32, signed=True)': 0
-        'simd_val_comb(xlen, 32, signed=False)': 0
 
 rstsa32:
     config:

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -845,3 +845,92 @@ kslra32.u:
         'walking_zeros("rs2_val", ceil(log(32, 2)), True)': 0
         'alternate("rs2_val", ceil(log(32, 2)), True)': 0
 
+smin32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      smin32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+umin32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      umin32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+smax32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      smax32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+umax32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      umax32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+kabs32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      kabs32: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -1463,24 +1463,25 @@ sraiw.u:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
         'simd_imm_val("imm_val", 5)': 0
 
-pkbb32:
-    config: 
-      - check ISA:=regex(.*I.*P.*)
-    opcode: 
-      pkbb32: 0
-    rs1: 
-      <<: *all_regs
-    rs2: 
-      <<: *all_regs
-    rd: 
-      <<: *all_regs
-    op_comb: 
-      <<: *rfmt_op_comb
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=False)': 0
-        'simd_base_val("rs2", xlen, 32, signed=False)': 0
-        'simd_val_comb(xlen, 32, signed=False)': 0
+# instructions overlapping with those in the B extension in RV64 configuration (Zbpbo)
+# pkbb32:
+#     config: 
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode: 
+#       pkbb32: 0
+#     rs1: 
+#       <<: *all_regs
+#     rs2: 
+#       <<: *all_regs
+#     rd: 
+#       <<: *all_regs
+#     op_comb: 
+#       <<: *rfmt_op_comb
+#     val_comb:
+#       abstract_comb:
+#         'simd_base_val("rs1", xlen, 32, signed=False)': 0
+#         'simd_base_val("rs2", xlen, 32, signed=False)': 0
+#         'simd_val_comb(xlen, 32, signed=False)': 0
 
 pkbt32:
     config: 
@@ -1520,22 +1521,74 @@ pktb32:
         'simd_base_val("rs2", xlen, 32, signed=False)': 0
         'simd_val_comb(xlen, 32, signed=False)': 0
 
-pktt32:
-    config: 
+# instructions overlapping with those in the B extension in RV64 configuration (Zbpbo)
+# pktt32:
+#     config: 
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode: 
+#       pktt32: 0
+#     rs1: 
+#       <<: *all_regs
+#     rs2: 
+#       <<: *all_regs
+#     rd: 
+#       <<: *all_regs
+#     op_comb: 
+#       <<: *rfmt_op_comb
+#     val_comb:
+#       abstract_comb:
+#         'simd_base_val("rs1", xlen, 32, signed=False)': 0
+#         'simd_base_val("rs2", xlen, 32, signed=False)': 0
+#         'simd_val_comb(xlen, 32, signed=False)': 0
+
+# instructions overlapping with those in the B extension in RV32 configuration (Zbpbo)
+clz32:
+    config:
       - check ISA:=regex(.*I.*P.*)
-    opcode: 
-      pktt32: 0
-    rs1: 
+    opcode:
+      clz32: 0
+    rs1:
       <<: *all_regs
-    rs2: 
+    rd:
       <<: *all_regs
-    rd: 
-      <<: *all_regs
-    op_comb: 
-      <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=False)': 0
-        'simd_base_val("rs2", xlen, 32, signed=False)': 0
-        'simd_val_comb(xlen, 32, signed=False)': 0
 
+pkbb16:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      pkbb16: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=False)': 0
+        'simd_base_val("rs2", xlen, 16, signed=False)': 0
+        'simd_val_comb(xlen, 16, signed=False)': 0
+
+pktt16:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      pktt16: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=False)': 0
+        'simd_base_val("rs2", xlen, 16, signed=False)': 0
+        'simd_val_comb(xlen, 16, signed=False)': 0

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -934,3 +934,174 @@ kabs32:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
 
+khmbb16:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      khmbb16: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+khmbt16:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      khmbt16: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+khmtt16:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      khmtt16: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kdmbb16:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kdmbb16: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kdmbt16:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kdmbt16: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kdmtt16:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kdmtt16: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kdmabb16:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kdmbb16: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kdmabt16:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kdmbt16: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+
+kdmatt16:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kdmtt16: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 16, signed=True)': 0
+        'simd_base_val("rs2", xlen, 16, signed=True)': 0
+        'simd_val_comb(xlen, 16, signed=True)': 0
+

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -1447,3 +1447,95 @@ smxds32:
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
         'simd_val_comb(xlen, 32, signed=True)': 0
 
+sraiw.u:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      sraiw.u: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb: 
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_imm_val("imm_val", 5)': 0
+
+pkbb32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      pkbb32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+pkbt32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      pkbt32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+pktb32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      pktb32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+pktt32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      pktt32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -1219,3 +1219,231 @@ kmatt32:
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
         'simd_val_comb(xlen, 32, signed=True)': 0
 
+kmda32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmda32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+kmxda32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmxda32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+kmada32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmada32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+kmaxda32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmaxda32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+kmads32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmads32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+kmadrs32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmadrs32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+kmaxds32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmaxds32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+kmsda32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmsda32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+kmsxda32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmsxda32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+smds32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smds32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+smdrs32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smdrs32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+smxds32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smxds32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -1162,3 +1162,60 @@ smtt32:
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
         'simd_val_comb(xlen, 32, signed=True)': 0
 
+kmabb32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmabb32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+kmabt32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmabt32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+kmatt32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kmatt32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -1034,7 +1034,7 @@ kdmabb16:
     config:
       - check ISA:=regex(.*I.*P.*)
     opcode:
-      kdmbb16: 0
+      kdmabb16: 0
     rs1:
       <<: *all_regs
     rs2:
@@ -1053,7 +1053,7 @@ kdmabt16:
     config:
       - check ISA:=regex(.*I.*P.*)
     opcode:
-      kdmbt16: 0
+      kdmabt16: 0
     rs1:
       <<: *all_regs
     rs2:
@@ -1072,7 +1072,7 @@ kdmatt16:
     config:
       - check ISA:=regex(.*I.*P.*)
     opcode:
-      kdmtt16: 0
+      kdmatt16: 0
     rs1:
       <<: *all_regs
     rs2:

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -803,9 +803,9 @@ kslra32:
     val_comb:
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=True)': 0
-        'walking_ones("rs2_val", ceil(log(32, 2)), True)': 0
-        'walking_zeros("rs2_val", ceil(log(32, 2)), True)': 0
-        'alternate("rs2_val", ceil(log(32, 2)), True)': 0
+        'walking_ones("rs2_val", xlen, True)': 0
+        'walking_zeros("rs2_val", xlen, True)': 0
+        'alternate("rs2_val", xlen, True)': 0
 
 kslra32.u:
     config: 
@@ -822,10 +822,10 @@ kslra32.u:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=True)': 0
-        'walking_ones("rs2_val", ceil(log(32, 2)), True)': 0
-        'walking_zeros("rs2_val", ceil(log(32, 2)), True)': 0
-        'alternate("rs2_val", ceil(log(32, 2)), True)': 0
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'walking_ones("rs2_val", xlen, True)': 0
+        'walking_zeros("rs2_val", xlen, True)': 0
+        'alternate("rs2_val", xlen, True)': 0
 
 smin32:
     config: 

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -588,3 +588,260 @@ ukstsa32:
         'simd_base_val("rs1", xlen, 32, signed=False)': 0
         'simd_base_val("rs2", xlen, 32, signed=False)': 0
         'simd_val_comb(xlen, 32, signed=False)': 0
+
+sra32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      sra32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'walking_ones("rs2_val", ceil(log(32, 2)), False)': 0
+        'walking_zeros("rs2_val", ceil(log(32, 2)), False)': 0
+        'alternate("rs2_val", ceil(log(32, 2)), False)': 0
+
+srai32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      srai32: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb: 
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_imm_val("imm_val", 5)': 0
+
+sra32.u:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      sra32.u: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'walking_ones("rs2_val", ceil(log(32, 2)), False)': 0
+        'walking_zeros("rs2_val", ceil(log(32, 2)), False)': 0
+        'alternate("rs2_val", ceil(log(32, 2)), False)': 0
+
+srai32.u:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      srai32.u: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb: 
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_imm_val("imm_val", 5)': 0
+
+srl32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      srl32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'walking_ones("rs2_val", ceil(log(32, 2)), False)': 0
+        'walking_zeros("rs2_val", ceil(log(32, 2)), False)': 0
+        'alternate("rs2_val", ceil(log(32, 2)), False)': 0
+
+srli32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      srli32: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb: 
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_imm_val("imm_val", 5)': 0
+
+srl32.u:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      srl32.u: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'walking_ones("rs2_val", ceil(log(32, 2)), False)': 0
+        'walking_zeros("rs2_val", ceil(log(32, 2)), False)': 0
+        'alternate("rs2_val", ceil(log(32, 2)), False)': 0
+
+srli32.u:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      srli32.u: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb: 
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_imm_val("imm_val", 5)': 0
+
+sll32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      sll32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'walking_ones("rs2_val", ceil(log(32, 2)), False)': 0
+        'walking_zeros("rs2_val", ceil(log(32, 2)), False)': 0
+        'alternate("rs2_val", ceil(log(32, 2)), False)': 0
+
+slli32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      slli32: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb: 
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_imm_val("imm_val", 5)': 0
+        
+ksll32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      ksll32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'walking_ones("rs2_val", ceil(log(32, 2)), False)': 0
+        'walking_zeros("rs2_val", ceil(log(32, 2)), False)': 0
+        'alternate("rs2_val", ceil(log(32, 2)), False)': 0
+
+kslli32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      kslli32: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb: 
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_imm_val("imm_val", 5)': 0
+
+kslra32:
+    config: 
+      - check isa:=regex(.*i.*p.*)
+    opcode: 
+      kslra32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'walking_ones("rs2_val", ceil(log(32, 2)), True)': 0
+        'walking_zeros("rs2_val", ceil(log(32, 2)), True)': 0
+        'alternate("rs2_val", ceil(log(32, 2)), True)': 0
+
+kslra32.u:
+    config: 
+      - check isa:=regex(.*i.*p.*)
+    opcode: 
+      kslra32.u: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'walking_ones("rs2_val", ceil(log(32, 2)), True)': 0
+        'walking_zeros("rs2_val", ceil(log(32, 2)), True)': 0
+        'alternate("rs2_val", ceil(log(32, 2)), True)': 0
+

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -1,0 +1,590 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+add32:
+    config: 
+      - check ISA:=regex(.*I.*P.*)
+    opcode: 
+      add32: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+radd32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      radd32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+uradd32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      uradd32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+kadd32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kadd32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+ukadd32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      ukadd32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+sub32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      sub32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+rsub32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      rsub32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+
+ursub32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      ursub32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+ksub32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      ksub32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+uksub32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      uksub32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+cras32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      cras32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+rcras32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      rcras32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+urcras32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      urcras32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+kcras32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kcras32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+ukcras32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      ukcras32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+crsa32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      crsa32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+rcrsa32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      rcrsa32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+urcrsa32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      urcrsa32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+kcrsa32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kcrsa32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+ukcrsa32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      ukcrsa32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+stas32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      stas32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+rstas32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      rstas32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+urstas32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      urstas32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+kstas32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kstas32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+ukstas32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      ukstas32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+stsa32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      stsa32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+rstsa32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      rstsa32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+urstsa32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      urstsa32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0
+
+kstsa32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      kstsa32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+ukstsa32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      ukstsa32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=False)': 0
+        'simd_base_val("rs2", xlen, 32, signed=False)': 0
+        'simd_val_comb(xlen, 32, signed=False)': 0

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -807,7 +807,7 @@ kslli32:
 
 kslra32:
     config: 
-      - check isa:=regex(.*i.*p.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode: 
       kslra32: 0
     rs1: 
@@ -827,7 +827,7 @@ kslra32:
 
 kslra32.u:
     config: 
-      - check isa:=regex(.*i.*p.*)
+      - check ISA:=regex(.*I.*P.*)
     opcode: 
       kslra32.u: 0
     rs1: 

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -1087,30 +1087,31 @@ kdmatt16:
         'simd_base_val("rs2", xlen, 16, signed=True)': 0
         'simd_val_comb(xlen, 16, signed=True)': 0
 
-smbb32:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      smbb32: 0
-    rs1:
-      <<: *all_regs
-    rs2:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *rfmt_op_comb
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=True)': 0
-        'simd_base_val("rs2", xlen, 32, signed=True)': 0
-        'simd_val_comb(xlen, 32, signed=True)': 0
+# alias of mulsr64
+# smbb32:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       smbb32: 0
+#     rs1:
+#       <<: *all_regs
+#     rs2:
+#       <<: *all_regs
+#     rd:
+#       <<: *all_regs
+#     op_comb:
+#       <<: *rfmt_op_comb
+#     val_comb:
+#       abstract_comb:
+#         'simd_base_val("rs1", xlen, 32, signed=True)': 0
+#         'simd_base_val("rs2", xlen, 32, signed=True)': 0
+#         'simd_val_comb(xlen, 32, signed=True)': 0
 
 smbt32:
     config:
       - check ISA:=regex(.*I.*P.*)
     opcode:
-      smbb32: 0
+      smbt32: 0
     rs1:
       <<: *all_regs
     rs2:
@@ -1239,24 +1240,25 @@ kmxda32:
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
         'simd_val_comb(xlen, 32, signed=True)': 0
 
-kmada32:
-    config:
-      - check ISA:=regex(.*I.*P.*)
-    opcode:
-      kmada32: 0
-    rs1:
-      <<: *all_regs
-    rs2:
-      <<: *all_regs
-    rd:
-      <<: *all_regs
-    op_comb:
-      <<: *rfmt_op_comb
-    val_comb:
-      abstract_comb:
-        'simd_base_val("rs1", xlen, 32, signed=True)': 0
-        'simd_base_val("rs2", xlen, 32, signed=True)': 0
-        'simd_val_comb(xlen, 32, signed=True)': 0
+# alias of kmar64
+# kmada32:
+#     config:
+#       - check ISA:=regex(.*I.*P.*)
+#     opcode:
+#       kmada32: 0
+#     rs1:
+#       <<: *all_regs
+#     rs2:
+#       <<: *all_regs
+#     rd:
+#       <<: *all_regs
+#     op_comb:
+#       <<: *rfmt_op_comb
+#     val_comb:
+#       abstract_comb:
+#         'simd_base_val("rs1", xlen, 32, signed=True)': 0
+#         'simd_base_val("rs2", xlen, 32, signed=True)': 0
+#         'simd_val_comb(xlen, 32, signed=True)': 0
 
 kmaxda32:
     config:

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -1105,3 +1105,60 @@ kdmatt16:
         'simd_base_val("rs2", xlen, 16, signed=True)': 0
         'simd_val_comb(xlen, 16, signed=True)': 0
 
+smbb32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smbb32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+smbt32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smbb32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+
+smtt32:
+    config:
+      - check ISA:=regex(.*I.*P.*)
+    opcode:
+      smtt32: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'simd_base_val("rs1", xlen, 32, signed=True)': 0
+        'simd_base_val("rs2", xlen, 32, signed=True)': 0
+        'simd_val_comb(xlen, 32, signed=True)': 0
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.8
+current_version = 0.5.9
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_ctg',
-    version='0.5.8',
+    version='0.5.9',
     description="RISC-V CTG",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
Hello Neel,

I’m the Andes engineer working on the “P” extension support for RISCV-CTG and RISCV-ISAC. We are ready to submit our initial pull request for the modification. 
AS P-extension divides a register into 8/16-bit subfields for packed SIMD operations, the dataset and coverpoints become more complicated. Our first pull request will contain modifications for three instructions from the P extension only: ADD8, ADD16, and SCLIP8.  We would like to seek your review first before proceed into the rest of the instructions. Please kindly review our pull request and give us guidance on how to proceed next.


Reference for P-extension, [ADD8](https://github.com/riscv/riscv-p-spec/blob/master/P-ext-proposal.adoc#add8-simd-8-bit-addition), [ADD16 ](https://github.com/riscv/riscv-p-spec/blob/master/P-ext-proposal.adoc#add16-simd-16-bit-addition)on pages 83-84, and  [SCLIP8](https://github.com/riscv/riscv-p-spec/blob/master/P-ext-proposal.adoc#sclip8-simd-8-bit-signed-clip-value) on page 263.
https://github.com/riscv/riscv-p-spec

Hsueh-Liang