### PR TITLE
Fix rv32ec/cswsp test generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] - 2021-09-13
+- Fix the generation of rv32ec/cswsp test
+
 ## [0.5.5] - 2021-09-10
 - Add CGFs for F&D extensions
 - Add support for F & D extension test generation

--- a/riscv_ctg/__init__.py
+++ b/riscv_ctg/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'incorebot@gmail.com'
-__version__ = '0.5.5'
+__version__ = '0.5.6'

--- a/riscv_ctg/__init__.py
+++ b/riscv_ctg/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'incorebot@gmail.com'
-__version__ = '0.5.6'
+__version__ = '0.5.7'

--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -17,6 +17,23 @@ datasets:
     x13: 0
     x14: 0
     x15: 0
+
+  rv32e_regs_mx2: &rv32e_regs_mx2
+    x1: 0
+    x3: 0
+    x4: 0
+    x5: 0
+    x6: 0
+    x7: 0
+    x8: 0
+    x9: 0
+    x10: 0
+    x11: 0
+    x12: 0
+    x13: 0
+    x14: 0
+    x15: 0
+
   rv32e_regs: &rv32e_regs
     x0: 0
     x1: 0

--- a/sample_cgfs/rv32ec.cgf
+++ b/sample_cgfs/rv32ec.cgf
@@ -451,7 +451,7 @@ cswsp:
     opcode: 
       c.swsp: 0
     rs2: 
-      <<: *rv32e_regs_mx0
+      <<: *rv32e_regs_mx2
     val_comb:
         'imm_val > 0': 0
         'imm_val == 0': 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.5
+current_version = 0.5.6
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.6
+current_version = 0.5.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_ctg',
-    version='0.5.6',
+    version='0.5.7',
     description="RISC-V CTG",
     long_description=readme + '\n\n',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_ctg',
-    version='0.5.5',
+    version='0.5.6',
     description="RISC-V CTG",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
Fix for the issue [206](https://github.com/riscv-non-isa/riscv-arch-test/issues/206)