### PR TITLE
Fix default rvtestdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] - 2021-09-19
+- rvtest\_data section now includes 16 bytes of rotated versions of `0xbabecafe`
+
 ## [0.5.5] - 2021-09-10
 - Add CGFs for F&D extensions
 - Add support for F & D extension test generation

--- a/riscv_ctg/__init__.py
+++ b/riscv_ctg/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'incorebot@gmail.com'
-__version__ = '0.5.5'
+__version__ = '0.5.6'

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -1072,7 +1072,8 @@ class Generator():
         vreg = 0
         code = []
         sign = [""]
-        data = [".align 4","rvtest_data:",".word 0xbabecafe"]
+        data = [".align 4","rvtest_data:",".word 0xbabecafe", \
+                ".word 0xabecafeb", ".word 0xbecafeba", ".word 0xecafebab"]
         stride = self.stride
         if self.opcode[0] == 'f' and 'fence' not in self.opcode:
             vreg = instr_dict[0]['valaddr_reg']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.5
+current_version = 0.5.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_ctg',
-    version='0.5.5',
+    version='0.5.6',
     description="RISC-V CTG",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
- rvtest\_data section now includes 16 bytes of rotated versions of `0xbabecafe`