### PR TITLE
F macro changes

### DIFF
--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -586,24 +586,14 @@ rvtest_data_end:
 #define RVTEST_SIGUPD_F(_BR,_R,_F,...)\
   .if NARG(__VA_ARGS__) == 1;\
     FSREG _R,_ARG1(__VA_ARGS__,0)(_BR);\
-    .if offset<REGWIDTH;\
-    SREG _F,_ARG1(__VA_ARGS__,0)+2*REGWIDTH(_BR);\
-    .endif;\
-    .if offset>=REGWIDTH;\
     SREG _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
-    .endif;\
     .set offset,_ARG1(__VA_OPT__(__VA_ARGS__,)0)+(REGWIDTH+REGWIDTH);\
   .endif;\
   .if NARG(__VA_ARGS__) == 0;\
     FSREG _R,offset(_BR);\
-    .if offset<REGWIDTH;\
-    SREG _F,_ARG1(__VA_ARGS__,0)+2*REGWIDTH(_BR);\
-    .endif;\
-    .if offset>=REGWIDTH;\
-    SREG _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
-    .endif;\
+    SREG _F,offset+REGWIDTH(_BR);\
     .set offset,offset+(REGWIDTH+REGWIDTH);\
-  .endif; 
+  .endif;
   
 #define RVTEST_SIGUPD_FID(_BR,_R,_F,...)\
   .if NARG(__VA_ARGS__) == 1;\

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -585,13 +585,23 @@ rvtest_data_end:
   
 #define RVTEST_SIGUPD_F(_BR,_R,_F,...)\
   .if NARG(__VA_ARGS__) == 1;\
-    FSREG _R,_ARG1(__VA_ARGS__,0)(_BR);\
+    FSREG _R,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
+    .if offset<REGWIDTH;\
+    SREG _F,_ARG1(__VA_ARGS__,0)+2*REGWIDTH(_BR);\
+    .endif;\
+    .if offset>=REGWIDTH;\
     SREG _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
+    .endif;\
     .set offset,_ARG1(__VA_OPT__(__VA_ARGS__,)0)+(REGWIDTH+REGWIDTH);\
   .endif;\
   .if NARG(__VA_ARGS__) == 0;\
-    FSREG _R,offset(_BR);\
-    SREG _F,offset+REGWIDTH(_BR);\
+    FSREG _R,offset(_BR)+REGWIDTH(_BR);\
+    .if offset<REGWIDTH;\
+    SREG _F,_ARG1(__VA_ARGS__,0)+2*REGWIDTH(_BR);\
+    .endif;\
+    .if offset>=REGWIDTH;\
+    SREG _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
+    .endif;\
     .set offset,offset+(REGWIDTH+REGWIDTH);\
   .endif;
   

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -613,10 +613,11 @@ hidden_offset is initialized to zero*/
   
   
 /*  RVTEST_SIGUPD_F(basereg, sigreg,flagreg,newoff)*/
-/*  This macro is used to store the signature values of (32 & 64) F and D instructions which uses TEST_(FPSR_OP, FPIO_OP, FPRR_OP, FPR4_OP) opcodes 
-/*  It Adjust base and offset, if offset is too big for total signature size  (offset > 2048-(2*SIGALIGN))
-/*  SIGALIGN is used to store the maximum value between FREGWIDTH and REGWIDTH.
-/*  stores flagreg,sigreg at newoff+SIGALIGN(basereg) and updates offset by 2*SIGALIGN
+/*  This macro is used to store the signature values of (32 & 64) F and D instructions which uses TEST_(FPSR_OP, FPIO_OP, FPRR_OP, FPR4_OP) opcodes */
+/*  Stores an integer register and a floating point register.
+/*  It Adjust base and offset, if offset is too big for total signature size  (offset > 2048-(2*SIGALIGN)) */
+/*  SIGALIGN is used to store the maximum value between FREGWIDTH and REGWIDTH. */
+/*  stores flagreg,sigreg at newoff+SIGALIGN(basereg) and updates offset by 2*SIGALIGN */
 /*  _BR - Base Register, _R - Signature register, _F - Flag register */ 
 #define RVTEST_SIGUPD_F(_BR,_R,_F,...) \
   .if NARG(__VA_ARGS__) == 1	;\
@@ -640,7 +641,8 @@ hidden_offset is initialized to zero*/
 
 
 /*  RVTEST_SIGUPD_FID(basereg, sigreg,flagreg,newoff) */
-/*  This macro is used to store the signature values of (32 & 64) F and D instructions which uses TEST_(FPID_OP, FCMP_OP) opcodes 
+/*  This macro is used to store the signature values of (32 & 64) F and D instructions which uses TEST_(FPID_OP, FCMP_OP) opcodes */
+/*  Stores two integer registers */
 /*  SigReg is stored at offset[BaseReg]  */
 /*  FlagReg is stored at offset+Regwidth[BaseReg] */
 /*  Updates offset by 2*regwidth and is post incremented so repeated uses store signature values sequentially */

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -586,13 +586,23 @@ rvtest_data_end:
 #define RVTEST_SIGUPD_F(_BR,_R,_F,...)\
   .if NARG(__VA_ARGS__) == 1;\
     FSREG _R,_ARG1(__VA_ARGS__,0)(_BR);\
+    .if offset<REGWIDTH;\
+    SREG _F,_ARG1(__VA_ARGS__,0)+2*REGWIDTH(_BR);\
+    .endif;\
+    .if offset>=REGWIDTH;\
     SREG _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
-    .set offset,_ARG1(__VA_OPT__(__VA_ARGS__,)0)+(REGWIDTH);\
+    .endif;\
+    .set offset,_ARG1(__VA_OPT__(__VA_ARGS__,)0)+(REGWIDTH+REGWIDTH);\
   .endif;\
   .if NARG(__VA_ARGS__) == 0;\
     FSREG _R,offset(_BR);\
-    SREG _F,offset+REGWIDTH(_BR);\
-    .set offset,offset+(REGWIDTH);\
+    .if offset<REGWIDTH;\
+    SREG _F,_ARG1(__VA_ARGS__,0)+2*REGWIDTH(_BR);\
+    .endif;\
+    .if offset>=REGWIDTH;\
+    SREG _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
+    .endif;\
+    .set offset,offset+(REGWIDTH+REGWIDTH);\
   .endif; 
   
 #define RVTEST_SIGUPD_FID(_BR,_R,_F,...)\

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -94,6 +94,12 @@
   #endif
 #endif
 
+#if FREGWIDTH>REGWIDTH
+    #define SIGALIGN FREGWIDTH
+#else
+    #define SIGALIGN REGWIDTH
+#endif 
+
 /*#if XLEN==64
   #if FLEN==32
     #define SREG sw
@@ -594,7 +600,6 @@ rvtest_data_end:
   
   
 #define RVTEST_SIGUPD_F(_BR,_R,_F,...) \
-  FLENN() ;\
   .if NARG(__VA_ARGS__) == 1	;\
     .set offset, _ARG1(__VA_ARGS__,0) ;\
     .if offset > 2048-(2*SIGALIGN) ;\
@@ -606,7 +611,7 @@ rvtest_data_end:
     .endif;\
     FSREG _R,offset+ 0(_BR) ;\
     .if XLEN==64 && FLEN==32;\
-      sw _F,offset+SIGALIGN(_BR) ;\
+      sw _F,offset+4(_BR) ;\
     .else;\
       SREG _F,offset+SIGALIGN(_BR) ;\
     .endif;\
@@ -615,11 +620,10 @@ rvtest_data_end:
 
   
 #define RVTEST_SIGUPD_FID(_BR,_R,_F,...)\
-  FLENN();\
   .if NARG(__VA_ARGS__) == 1;\
     .if XLEN==64 && FLEN==32;\
       sw _R,_ARG1(__VA_ARGS__,0)(_BR);\
-      sw _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
+      sw _F,_ARG1(__VA_ARGS__,0)+4(_BR);\
     .else;\
       SREG _R,_ARG1(__VA_ARGS__,0)(_BR);\
       SREG _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
@@ -629,7 +633,7 @@ rvtest_data_end:
   .if NARG(__VA_ARGS__) == 0;\
     .if XLEN==64 && FLEN==32;\
       sw _R,offset(_BR);\
-      sw _F,offset+REGWIDTH(_BR);\
+      sw _F,offset+4(_BR);\
     .else;\
       SREG _R,offset(_BR);\
       SREG _F,offset+REGWIDTH(_BR);\
@@ -637,20 +641,6 @@ rvtest_data_end:
     .set offset,offset+(2*REGWIDTH);\
   .endif;
 
-#define FLENN()
-  #if XLEN==64
-    #if FLEN==32
-      #undef REGWIDTH
-      #undef MASK
-      #define REGWIDTH 4
-      #define MASK 0xFFFFFFFF
-    #endif
-  #endif
-  #if FREGWIDTH>REGWIDTH
-    #define SIGALIGN FREGWIDTH
-  #else
-    #define SIGALIGN REGWIDTH
-  #endif 
   
 #define RVTEST_VALBASEUPD(_BR,...)\
   .if NARG(__VA_ARGS__) == 0;\

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -585,15 +585,25 @@ rvtest_data_end:
   
 #define RVTEST_SIGUPD_F(_BR,_R,_F,...)\
   .if NARG(__VA_ARGS__) == 1;\
-    FSREG _R,_ARG1(__VA_ARGS__,0)(_BR);\
+    FSREG _R,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
+    .if offset<REGWIDTH;\
+    SREG _F,_ARG1(__VA_ARGS__,0)+2*REGWIDTH(_BR);\
+    .endif;\
+    .if offset>=REGWIDTH;\
     SREG _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
+    .endif;\
     .set offset,_ARG1(__VA_OPT__(__VA_ARGS__,)0)+(REGWIDTH+REGWIDTH);\
   .endif;\
   .if NARG(__VA_ARGS__) == 0;\
-    FSREG _R,offset(_BR);\
-    SREG _F,offset+REGWIDTH(_BR);\
+    FSREG _R,offset+REGWIDTH(_BR);\
+    .if offset<REGWIDTH;\
+    SREG _F,_ARG1(__VA_ARGS__,0)+2*REGWIDTH(_BR);\
+    .endif;\
+    .if offset>=REGWIDTH;\
+    SREG _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
+    .endif;\
     .set offset,offset+(REGWIDTH+REGWIDTH);\
-  .endif;
+  .endif; 
   
 #define RVTEST_SIGUPD_FID(_BR,_R,_F,...)\
   .if NARG(__VA_ARGS__) == 1;\

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -616,8 +616,7 @@ hidden_offset is initialized to zero*/
 /*  This macro is used to store the signature values of (32 & 64) F and D instructions which uses TEST_(FPSR_OP, FPIO_OP, FPRR_OP, FPR4_OP) opcodes 
 /*  It Adjust base and offset, if offset is too big for total signature size  (offset > 2048-(2*SIGALIGN))
 /*  SIGALIGN is used to store the maximum value between FREGWIDTH and REGWIDTH.
-/*  flagreg stores offset+0(basereg) 
-/*  sigreg stores offset+SIGALIGN(basereg) and then updates offset by 2*SIGALIGN
+/*  stores flagreg,sigreg at newoff+SIGALIGN(basereg) and updates offset by 2*SIGALIGN
 /*  _BR - Base Register, _R - Signature register, _F - Flag register */ 
 #define RVTEST_SIGUPD_F(_BR,_R,_F,...) \
   .if NARG(__VA_ARGS__) == 1	;\

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -585,7 +585,7 @@ rvtest_data_end:
   
 #define RVTEST_SIGUPD_F(_BR,_R,_F,...)\
   .if NARG(__VA_ARGS__) == 1;\
-    FSREG _R,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
+    FSREG _R,_ARG1(__VA_ARGS__,0)(_BR);\
     .if offset<REGWIDTH;\
     SREG _F,_ARG1(__VA_ARGS__,0)+2*REGWIDTH(_BR);\
     .endif;\
@@ -595,7 +595,7 @@ rvtest_data_end:
     .set offset,_ARG1(__VA_OPT__(__VA_ARGS__,)0)+(REGWIDTH+REGWIDTH);\
   .endif;\
   .if NARG(__VA_ARGS__) == 0;\
-    FSREG _R,offset(_BR)+REGWIDTH(_BR);\
+    FSREG _R,offset(_BR);\
     .if offset<REGWIDTH;\
     SREG _F,_ARG1(__VA_ARGS__,0)+2*REGWIDTH(_BR);\
     .endif;\
@@ -603,7 +603,7 @@ rvtest_data_end:
     SREG _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
     .endif;\
     .set offset,offset+(REGWIDTH+REGWIDTH);\
-  .endif;
+  .endif; 
   
 #define RVTEST_SIGUPD_FID(_BR,_R,_F,...)\
   .if NARG(__VA_ARGS__) == 1;\

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -568,6 +568,11 @@ rvtest_data_end:
     or x2, x3, x2;\
     csrrw x0,mstatus,x2;                      
 
+
+
+/*defines the base register used to update signature values
+Register BaseReg is loaded with value Val
+hidden_offset is initialized to zero*/
 #define RVTEST_SIGBASE(_R,_TAG) \
   LA(_R,_TAG);\
   .set offset,0;
@@ -582,9 +587,11 @@ rvtest_data_end:
 #define NARG(...) _ARG5(__VA_OPT__(__VA_ARGS__,)4,3,2,1,0)
 
 
-/* automatically adjust base and offset if offset is too big for sig size*/
+/* automatically adjust base and offset if offset is too big for signature size*/
 /* RVTEST_SIGUPD(basereg, sigreg)        stores sigreg at offset(basereg) and updates offset by regwidth*/
 /* RVTEST_SIGUPD(basereg, sigreg,newoff) stores sigreg at newoff(basereg) and updates offset to regwidth+newoff*/
+/*hidden_offset is post incremented so repeated uses store signature values sequentially*/
+
 #define RVTEST_SIGUPD(_BR,_R,...)\
   .if NARG(__VA_ARGS__) == 1;\
     /* For if XLEN==64 && FLEN==32 the sw instruction should be used. so, if statements is been given to use sw in place of sd */\
@@ -604,9 +611,13 @@ rvtest_data_end:
     .set offset,offset+REGWIDTH;\
   .endif;
   
-/* automatically adjust base and offset for Floating point tests if offset is too big for total signature size */
-/* RVTEST_SIGUPD_F(basereg, sigreg,fsigreg,newoff) stores fsigreg,sigreg at newoff(basereg) and updates offset by 2*max(fregwidth,regwidth) i.e SIGALIGN */
-/* first, figure out and align size, then replace offset with opt arg, and then make sure offset in range, then store fregwidth,regwidth */
+  
+/*  RVTEST_SIGUPD_F(basereg, sigreg,flagreg,newoff)*/
+/*  This macro is used to store the signature values of (32 & 64) F and D instructions which uses TEST_(FPSR_OP, FPIO_OP, FPRR_OP, FPR4_OP) opcodes 
+/*  It Adjust base and offset, if offset is too big for total signature size  (offset > 2048-(2*SIGALIGN))
+/*  SIGALIGN is used to store the maximum value between FREGWIDTH and REGWIDTH.
+/*  stores flagreg,sigreg at newoff+SIGALIGN(basereg) and updates offset by 2*SIGALIGN
+/*  _BR - Base Register, _R - Signature register, _F - Flag register */ 
 #define RVTEST_SIGUPD_F(_BR,_R,_F,...) \
   .if NARG(__VA_ARGS__) == 1	;\
     .set offset, _ARG1(__VA_ARGS__,0) ;\
@@ -627,14 +638,16 @@ rvtest_data_end:
     .set offset,offset+(2*SIGALIGN) ;\
   .endif ;
 
-/*RVTEST_SIGUPD_FID(basereg, sigreg,fsigreg,newoff)*/
-/*It is same as the RVTEST_SIGUPD but stores twice*/
-/* stores sigreg at offset(basereg)  */
-/*stores fsigreg at offset(basereg) by adding regwidth */
-/*updates offset by 2*regwidth*/
+
+/*  RVTEST_SIGUPD_FID(basereg, sigreg,flagreg,newoff) */
+/*  This macro is used to store the signature values of (32 & 64) F and D instructions which uses TEST_(FPID_OP, FCMP_OP) opcodes 
+/*  SigReg is stored at offset[BaseReg]  */
+/*  FlagReg is stored at offset+Regwidth[BaseReg] */
+/*  Updates offset by 2*regwidth and is post incremented so repeated uses store signature values sequentially */
+/*  _BR - Base Register, _R - Signature register, _F - Flag register */ 
 #define RVTEST_SIGUPD_FID(_BR,_R,_F,...)\
   .if NARG(__VA_ARGS__) == 1;\
-    /* For if XLEN==64 && FLEN==32 the sw instruction should be used. so, if statements is been given to use sw in place of sd and the regwidth should be 4 instead of 8*/\
+    /* For if XLEN==64 && FLEN==32 the sw instruction should be used. so, if statements is been given to use sw in place of sd and the regwidth should be 4 instead of 8 */\
     .if XLEN==64 && FLEN==32;\
       sw _R,_ARG1(__VA_ARGS__,0)(_BR);\
       sw _F,_ARG1(__VA_ARGS__,0)+4(_BR);\

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -568,6 +568,11 @@ rvtest_data_end:
     or x2, x3, x2;\
     csrrw x0,mstatus,x2;                      
 
+
+
+/*defines the base register used to update signature values
+Register BaseReg is loaded with value Val
+hidden_offset is initialized to zero*/
 #define RVTEST_SIGBASE(_R,_TAG) \
   LA(_R,_TAG);\
   .set offset,0;
@@ -582,9 +587,11 @@ rvtest_data_end:
 #define NARG(...) _ARG5(__VA_OPT__(__VA_ARGS__,)4,3,2,1,0)
 
 
-/* automatically adjust base and offset if offset is too big for sig size*/
+/* automatically adjust base and offset if offset is too big for signature size*/
 /* RVTEST_SIGUPD(basereg, sigreg)        stores sigreg at offset(basereg) and updates offset by regwidth*/
 /* RVTEST_SIGUPD(basereg, sigreg,newoff) stores sigreg at newoff(basereg) and updates offset to regwidth+newoff*/
+/*hidden_offset is post incremented so repeated uses store signature values sequentially*/
+
 #define RVTEST_SIGUPD(_BR,_R,...)\
   .if NARG(__VA_ARGS__) == 1;\
     /* For if XLEN==64 && FLEN==32 the sw instruction should be used. so, if statements is been given to use sw in place of sd */\
@@ -604,9 +611,14 @@ rvtest_data_end:
     .set offset,offset+REGWIDTH;\
   .endif;
   
-/* automatically adjust base and offset for Floating point tests if offset is too big for total signature size */
-/* RVTEST_SIGUPD_F(basereg, sigreg,fsigreg,newoff) stores fsigreg,sigreg at newoff(basereg) and updates offset by 2*max(fregwidth,regwidth) i.e SIGALIGN */
-/* first, figure out and align size, then replace offset with opt arg, and then make sure offset in range, then store fregwidth,regwidth */
+  
+/*  RVTEST_SIGUPD_F(basereg, sigreg,flagreg,newoff)*/
+/*  This macro is used to store the signature values of (32 & 64) F and D instructions which uses TEST_(FPSR_OP, FPIO_OP, FPRR_OP, FPR4_OP) opcodes 
+/*  It Adjust base and offset, if offset is too big for total signature size  (offset > 2048-(2*SIGALIGN))
+/*  SIGALIGN is used to store the maximum value between FREGWIDTH and REGWIDTH.
+/*  flagreg stores offset+0(basereg) 
+/*  sigreg stores offset+SIGALIGN(basereg) and then updates offset by 2*SIGALIGN
+/*  _BR - Base Register, _R - Signature register, _F - Flag register */ 
 #define RVTEST_SIGUPD_F(_BR,_R,_F,...) \
   .if NARG(__VA_ARGS__) == 1	;\
     .set offset, _ARG1(__VA_ARGS__,0) ;\
@@ -627,14 +639,16 @@ rvtest_data_end:
     .set offset,offset+(2*SIGALIGN) ;\
   .endif ;
 
-/*RVTEST_SIGUPD_FID(basereg, sigreg,fsigreg,newoff)*/
-/*It is same as the RVTEST_SIGUPD but stores twice*/
-/* stores sigreg at offset(basereg)  */
-/*stores fsigreg at offset(basereg) by adding regwidth */
-/*updates offset by 2*regwidth*/
+
+/*  RVTEST_SIGUPD_FID(basereg, sigreg,flagreg,newoff) */
+/*  This macro is used to store the signature values of (32 & 64) F and D instructions which uses TEST_(FPID_OP, FCMP_OP) opcodes 
+/*  SigReg is stored at offset[BaseReg]  */
+/*  FlagReg is stored at offset+Regwidth[BaseReg] */
+/*  Updates offset by 2*regwidth and is post incremented so repeated uses store signature values sequentially */
+/*  _BR - Base Register, _R - Signature register, _F - Flag register */ 
 #define RVTEST_SIGUPD_FID(_BR,_R,_F,...)\
   .if NARG(__VA_ARGS__) == 1;\
-    /* For if XLEN==64 && FLEN==32 the sw instruction should be used. so, if statements is been given to use sw in place of sd and the regwidth should be 4 instead of 8*/\
+    /* For if XLEN==64 && FLEN==32 the sw instruction should be used. so, if statements is been given to use sw in place of sd and the regwidth should be 4 instead of 8 */\
     .if XLEN==64 && FLEN==32;\
       sw _R,_ARG1(__VA_ARGS__,0)(_BR);\
       sw _F,_ARG1(__VA_ARGS__,0)+4(_BR);\

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -586,23 +586,13 @@ rvtest_data_end:
 #define RVTEST_SIGUPD_F(_BR,_R,_F,...)\
   .if NARG(__VA_ARGS__) == 1;\
     FSREG _R,_ARG1(__VA_ARGS__,0)(_BR);\
-    .if offset<REGWIDTH;\
-    SREG _F,_ARG1(__VA_ARGS__,0)+2*REGWIDTH(_BR);\
-    .endif;\
-    .if offset>=REGWIDTH;\
     SREG _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
-    .endif;\
-    .set offset,_ARG1(__VA_OPT__(__VA_ARGS__,)0)+(REGWIDTH+REGWIDTH);\
+    .set offset,_ARG1(__VA_OPT__(__VA_ARGS__,)0)+(REGWIDTH);\
   .endif;\
   .if NARG(__VA_ARGS__) == 0;\
     FSREG _R,offset(_BR);\
-    .if offset<REGWIDTH;\
-    SREG _F,_ARG1(__VA_ARGS__,0)+2*REGWIDTH(_BR);\
-    .endif;\
-    .if offset>=REGWIDTH;\
-    SREG _F,_ARG1(__VA_ARGS__,0)+REGWIDTH(_BR);\
-    .endif;\
-    .set offset,offset+(REGWIDTH+REGWIDTH);\
+    SREG _F,offset+REGWIDTH(_BR);\
+    .set offset,offset+(REGWIDTH);\
   .endif; 
   
 #define RVTEST_SIGUPD_FID(_BR,_R,_F,...)\


### PR DESCRIPTION
Hi, Based on the discussion I have modified the sigupd_f macro. And the definition of the SREG and LREG will get changed  based on the each F test. The macro working fine with RV32F and RV64F. I have attached the link below for the test coverage details and the signature file.
[Link](https://drive.google.com/drive/folders/1NQ87dw-Jq5yYWYwDVkFFSJ6gUhxykzIm?usp=sharing)