### PR TITLE
add support for cbo.zero in CMO extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2022-09-23
+- Added support for zicboz extension
+- Fix NameError: name 'size' is not defined
+- Fix ValueError: invalid literal for int() with base 10
+
 ## [0.11.0] - 2022-12-11
 - Added support for csr_comb test generation
 

--- a/riscv_ctg/__init__.py
+++ b/riscv_ctg/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'incorebot@gmail.com'
-__version__ = '0.11.0'
+__version__ = '0.11.1'

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -10341,3 +10341,20 @@ czero.nez:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+cbo.zero:
+  std_op:
+  sig:
+    stride: 1
+    sz: 'RVMODEL_CBZ_BLOCKSIZE'
+  xlen: [32,64]
+  isa:
+    - IZicbozZicsr
+  formattype: 'zformat'
+  rs1_op_data: *all_regs_mx0
+  rs1_val_data: 'gen_usign_dataset(12)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op1val:$rs1_val
+    TEST_CBO_ZERO($swreg,$rs1,$inst,$rs1_val)

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -3,6 +3,12 @@
 #ifndef NUM_SPECD_INTCAUSES 
   #define NUM_SPECD_INTCAUSES 16
 #endif
+#ifndef RVMODEL_CBZ_BLOCKSIZE
+  #define RVMODEL_CBZ_BLOCKSIZE 64
+#endif
+#ifndef RVMODEL_CMO_BLOCKSIZE
+  #define RVMODEL_CMO_BLOCKSIZE 64
+#endif
 //#define RVTEST_FIXED_LEN
 #ifndef UNROLLSZ
   #define UNROLLSZ 5
@@ -64,6 +70,15 @@
         la reg,val;\
         .option pop;
 #endif
+
+#define ADDI(dst, src, imm) /* helper*/ ;\
+#if (imm<=2048)                         ;\
+        addi    dst, src, imm           ;\
+#else                                   ;\
+        LI(     dst, imm)               ;\
+        addi    dst, src, dst           ;\
+#endif
+
 #if XLEN==64
   #define SREG sd
   #define LREG ld
@@ -903,6 +918,14 @@ sub rs1,rs1,testreg                                                          ;\
 inst rs2, imm_val(rs1)                                                      ;\
 nop                                                                         ;\
 nop                                                                         
+
+#define TEST_CBO_ZERO(swreg,rs1,inst,imm_val)                               ;\
+LI(rs1,imm_val&(RVMODEL_CBZ_BLOCKSIZE-1))                                   ;\
+add rs1,rs1,swreg                                                           ;\
+inst (rs1)                                                                  ;\
+nop                                                                         ;\
+nop                                                                         ;\
+ADDI(swreg, swreg, RVMODEL_CBZ_BLOCKSIZE)
 
 #define TEST_LOAD(swreg,testreg,index,rs1,destreg,imm_val,offset,inst,adj)   ;\
 LA(rs1,rvtest_data+(index*4)+adj-imm_val)                                      ;\

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -793,13 +793,13 @@ class Generator():
                     if self.fmt in ['jformat','bformat'] or instr['inst'] in \
                         ['c.beqz','c.bnez','c.jal','c.j','c.jalr']:
                         var_dict['imm_val'] = \
-                            (-1 if instr['label'] == '1b' else 1) * int(instr['imm_val'])
+                            (-1 if instr['label'] == '1b' else 1) * int(instr['imm_val'], 0)
                     else:
-                        var_dict['imm_val'] = int(instr['imm_val'])
+                        var_dict['imm_val'] = int(instr['imm_val'], 0)
                 elif key == 'rm_val':
                     var_dict['rm_val'] = int(rm_dict[instr['rm_val']])
                 else:
-                    var_dict[key] = int(instr[key])
+                    var_dict[key] = int(instr[key], 0)
             for key in self.op_vars:
                 var_dict[key] = instr[key]
 
@@ -1164,7 +1164,7 @@ class Generator():
         if self.operation:
             for i in range(len(instr_dict)):
                 for var in self.val_vars:
-                    locals()[var]=int(instr_dict[i][var])
+                    locals()[var]=int(instr_dict[i][var], 0)
                 correctval = eval(self.operation)
                 instr_dict[i]['correctval'] = str(normalise(correctval,instr_dict[i]))
         else:
@@ -1201,8 +1201,9 @@ class Generator():
                     field != 'val_section' and field != 'val_offset' and field != 'rm_val':
                     value = instr_dict[i][field]
                     if '0x' in value:
-                        value = '0x' + value[2:].zfill(int(self.xlen/4))
-                        value = struct.unpack(size, bytes.fromhex(value[2:]))[0]
+#                        value = '0x' + value[2:].zfill(int(self.xlen/4))
+#                        value = struct.unpack(size, bytes.fromhex(value[2:]))[0]
+                        value = int(value, 16)
                     else:
                         value = int(value)
 #                    value = '0x' + struct.pack(size,value).hex()

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -71,7 +71,8 @@ OPS = {
     'pphrrformat': ['rs1', 'rs2', 'rd'],
     'ppbrrformat': ['rs1', 'rs2', 'rd'],
     'prrformat': ['rs1', 'rs2', 'rd'],
-    'prrrformat': ['rs1', 'rs2', 'rs3', 'rd']
+    'prrrformat': ['rs1', 'rs2', 'rs3', 'rd'],
+    'zformat': ['rs1']
 }
 ''' Dictionary mapping instruction formats to operands used by those formats '''
 
@@ -117,7 +118,8 @@ VALS = {
     'pphrrformat': '["rs1_val"] + simd_val_vars("rs2", xlen, 16)',
     'ppbrrformat': '["rs1_val"] + simd_val_vars("rs2", xlen, 8)',
     'prrformat': '["rs1_val", "rs2_val"]',
-    'prrrformat': "['rs1_val', 'rs2_val' , 'rs3_val']"
+    'prrrformat': "['rs1_val', 'rs2_val' , 'rs3_val']",
+    'zformat': "['rs1_val']"
 }
 ''' Dictionary mapping instruction formats to operand value variables used by those formats '''
 
@@ -1031,6 +1033,7 @@ class Generator():
         else:
             FLEN = 0
         XLEN = max(self.opnode['xlen'])
+        RVMODEL_CBZ_BLOCKSIZE = XLEN
         SIGALIGN = max(XLEN,FLEN)/8
         stride_sz = eval(suffix)
         for instr in instr_dict:
@@ -1306,7 +1309,7 @@ class Generator():
                 #         dval = (instr['rs{0}_val'.format(i)],self.iflen)
                 data.extend(instr['val_section'])
             if instr['swreg'] != sreg or eval(instr['offset'],{},
-                        {'FLEN':width,'XLEN':self.xlen,'SIGALIGN':max(self.xlen,self.flen)/8}) == 0:
+                        {'FLEN':width,'XLEN':self.xlen,'RVMODEL_CBZ_BLOCKSIZE':self.xlen, 'SIGALIGN':max(self.xlen,self.flen)/8}) == 0:
                 sign.append(signode_template.substitute(
                     {'n':n,'label':"signature_"+sreg+"_"+str(regs[sreg]),'sz':sig_sz}))
                 n = stride

--- a/sample_cgfs/rv32i_cbo.cgf
+++ b/sample_cgfs/rv32i_cbo.cgf
@@ -1,0 +1,14 @@
+# For Licence details look at https://github.com/riscv-software-src/riscv-ctg/-/blob/master/LICENSE.incore
+
+cbozero:
+    config:
+      - check ISA:=regex(.*I.*Zicboz.*Zicsr.*)
+    mnemonics:
+      cbo.zero: 0
+    rs1:
+      <<: *all_regs_mx0
+    val_comb:
+      abstract_comb:
+        'walking_ones("rs1_val", 12, False)': 0
+        'walking_zeros("rs1_val", 12, False)': 0
+        'uniform_random(20, 100, ["rs1_val"], [12])': 0

--- a/sample_cgfs/rv64i_cbo.cgf
+++ b/sample_cgfs/rv64i_cbo.cgf
@@ -1,0 +1,14 @@
+# For Licence details look at https://github.com/riscv-software-src/riscv-ctg/-/blob/master/LICENSE.incore
+
+cbozero:
+    config:
+      - check ISA:=regex(.*I.*Zicboz.*Zicsr.*)
+    mnemonics:
+      cbo.zero: 0
+    rs1:
+      <<: *all_regs_mx0
+    val_comb:
+      abstract_comb:
+        'walking_ones("rs1_val", 12, False)': 0
+        'walking_zeros("rs1_val", 12, False)': 0
+        'uniform_random(10, 100, ["rs1_val"], [12])': 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.0
+current_version = 0.11.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_ctg',
-    version='0.11.0',
+    version='0.11.1',
     description="RISC-V CTG",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
Currently, the cache block size is assumed to be two times of xlen.