### PR TITLE
changes for listing duplicate coverpoints

### DIFF
--- a/riscv_ctg/ctg.py
+++ b/riscv_ctg/ctg.py
@@ -61,7 +61,7 @@ def create_test(usage_str, node,label,base_isa,max_inst):
         my_dict = gen.reformat_instr(instr_dict)
         gen.write_test(fprefix,node,label,my_dict, op_node, usage_str, max_inst)
 
-def ctg(verbose, out, random ,xlen_arg, cgf_file,num_procs,base_isa, max_inst):
+def ctg(verbose, out, random ,xlen_arg, cgf_file,num_procs,base_isa, max_inst,list_duplicate):
     global op_template
     global randomize
     global out_dir
@@ -88,7 +88,7 @@ def ctg(verbose, out, random ,xlen_arg, cgf_file,num_procs,base_isa, max_inst):
             cgf=cgf_argument, version = __version__, time=mytime, \
             randomize=randomize_argument,xlen=str(xlen_arg))
     op_template = utils.load_yaml(const.template_file)
-    cgf = expand_cgf(cgf_file,xlen)
+    cgf = expand_cgf(cgf_file,xlen,list_duplicate)
     pool = mp.Pool(num_procs)
     results = pool.starmap(create_test, [(usage_str, node,label,base_isa,max_inst) for label,node in cgf.items()])
     pool.close()

--- a/riscv_ctg/main.py
+++ b/riscv_ctg/main.py
@@ -17,7 +17,7 @@ from riscv_isac.cgf_normalize import expand_cgf
 @click.option('--procs','-p',type=int,default=1,help='Max number of processes to spawn')
 @click.option('--base-isa','-bi',type=click.Choice(['rv32e','rv32i','rv64i']),help="Base ISA string for the tests.")
 @click.option("--inst",type=int,help="Maximum number of Macro Instances per test.")
-@click.option('--list-duplicate','-l', default=False , is_flag='True', help='Enable to print out the duplicate coverpoints generated')
+@click.option('--list-duplicate','-z', default=False , is_flag='True', help='Enable to print out the duplicate coverpoints generated')
 def cli(verbose, out_dir, randomize , cgf,procs,base_isa,inst,list_duplicate):
     if not os.path.exists(out_dir):
         os.mkdir(out_dir)

--- a/riscv_ctg/main.py
+++ b/riscv_ctg/main.py
@@ -17,11 +17,12 @@ from riscv_isac.cgf_normalize import expand_cgf
 @click.option('--procs','-p',type=int,default=1,help='Max number of processes to spawn')
 @click.option('--base-isa','-bi',type=click.Choice(['rv32e','rv32i','rv64i']),help="Base ISA string for the tests.")
 @click.option("--inst",type=int,help="Maximum number of Macro Instances per test.")
-def cli(verbose, out_dir, randomize , cgf,procs,base_isa,inst):
+@click.option('--list-duplicate','-l', default=False , is_flag='True', help='Enable to print out the duplicate coverpoints generated')
+def cli(verbose, out_dir, randomize , cgf,procs,base_isa,inst,list_duplicate):
     if not os.path.exists(out_dir):
         os.mkdir(out_dir)
     if '32' in base_isa:
         xlen = 32
     elif '64' in base_isa:
         xlen = 64
-    ctg(verbose, out_dir, randomize ,xlen, cgf,procs,base_isa,inst)
+    ctg(verbose, out_dir, randomize ,xlen, cgf,procs,base_isa,inst,list_duplicate)


### PR DESCRIPTION
Task : Explicitly specify redundant coverpoints in the terminal messages - The normalization functions used to abstract representations of coverpoints can potentially produce duplicate coverpoints. It is desirable to identify and optimize these to reduce the time taken to normalize a CGF. In order to do this, the duplicate coverpoints need to be printed out in the generated logs (enabled by a switch)