### PR TITLE
Fixing Address Offset for F&D Instructions

### DIFF
--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -1697,7 +1697,7 @@ fadd.s:
   xlen: [32,64]
   isa: 
     - IF
-  flen: [32,64]
+  flen: [32]
   std_op:
   formattype: 'frformat'
   rs1_op_data: *all_fregs
@@ -1731,7 +1731,7 @@ fsub.s:
   xlen: [32,64]
   isa: 
     - IF
-  flen: [32,64]
+  flen: [32]
   std_op:
   formattype: 'frformat'
   rs1_op_data: *all_fregs
@@ -1765,7 +1765,7 @@ fmul.s:
   xlen: [32,64]
   isa: 
     - IF
-  flen: [32,64]
+  flen: [32]
   std_op:
   formattype: 'frformat'
   rs1_op_data: *all_fregs
@@ -1799,7 +1799,7 @@ fdiv.s:
   xlen: [32,64]
   isa: 
     - IF
-  flen: [32,64]
+  flen: [32]
   std_op:
   formattype: 'frformat'
   rs1_op_data: *all_fregs
@@ -1833,7 +1833,7 @@ fsqrt.s:
   xlen: [32,64]
   isa: 
     - IF
-  flen: [32,64]
+  flen: [32]
   std_op:
   formattype: 'fsrformat'
   rs1_op_data: *all_fregs
@@ -1865,7 +1865,7 @@ fmadd.s:
   xlen: [32,64]
   isa: 
     - IF
-  flen: [32,64]
+  flen: [32]
   std_op:
   formattype: 'fr4format'
   rs1_op_data: *all_fregs
@@ -1901,7 +1901,7 @@ fmsub.s:
   xlen: [32,64]
   isa: 
     - IF
-  flen: [32,64]
+  flen: [32]
   std_op:
   formattype: 'fr4format'
   rs1_op_data: *all_fregs
@@ -1937,7 +1937,7 @@ fnmadd.s:
   xlen: [32,64]
   isa: 
     - IF
-  flen: [32,64]
+  flen: [32]
   std_op:
   formattype: 'fr4format'
   rs1_op_data: *all_fregs

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -986,7 +986,7 @@ class Generator():
 ############################################
 #This is modified to handle the offset values for floating points, and this formula is still returns an expected offsets for all floating extenstions
 ############################################
-                    offset += int((flen/8)+(xlen/8)+(abs(flen-xlen)/8))
+                    offset += int(max(flen,xlen)/4)
                     if self.fmt == 'frformat' or self.fmt == 'rformat':
                         val_offset += 2*(int(flen/8))
                     elif self.fmt == 'fsrformat':

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -983,6 +983,10 @@ class Generator():
                         flag = False
                     instr_dict[i]['offset'] = str(offset)
                     instr_dict[i]['val_offset'] = str(val_offset)
+############################################
+#This condition is intrroduced to fix the address misalign issue when we execute double precision instruction on RV32
+#This can further extedned based on the upcoming instructions on different XLEN
+############################################
                     if flen == 64 and xlen == 32:
                         offset += 8
                     else:

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -984,13 +984,9 @@ class Generator():
                     instr_dict[i]['offset'] = str(offset)
                     instr_dict[i]['val_offset'] = str(val_offset)
 ############################################
-#This condition is intrroduced to fix the address misalign issue when we execute double precision instruction on RV32
-#This can further extedned based on the upcoming instructions on different XLEN
+#This is modified to handle the offset values for floating points, and this formula is still returns an expected offsets for all floating extenstions
 ############################################
-                    if flen == 64 and xlen == 32:
-                        offset += 8
-                    else:
-                        offset += int((flen/8)+(xlen/8))
+                    offset += int((flen/8)+(xlen/8)+(abs(flen-xlen)/8))
                     if self.fmt == 'frformat' or self.fmt == 'rformat':
                         val_offset += 2*(int(flen/8))
                     elif self.fmt == 'fsrformat':

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -15,7 +15,7 @@ one_operand_finstructions = ["fsqrt.s","fmv.x.w","fcvt.wu.s","fcvt.w.s","fclass.
 two_operand_finstructions = ["fadd.s","fsub.s","fmul.s","fdiv.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fsgnj.s","fsgnjn.s","fsgnjx.s"]
 three_operand_finstructions = ["fmadd.s","fmsub.s","fnmadd.s","fnmsub.s"]
 
-one_operand_dinstructions = ["fsqrt.d","fclass.d","fcvt.w.d","fcvt.wu.d","fcvt.d.w","fcvt.d.wu"]
+one_operand_dinstructions = ["fsqrt.d","fclass.d","fcvt.w.d","fcvt.wu.d","fcvt.d.w","fcvt.d.wu","fcvt.d.s","fcvt.s.d"]
 two_operand_dinstructions = ["fadd.d","fsub.d","fmul.d","fdiv.d","fmax.d","fmin.d","feq.d","flt.d","fle.d","fsgnj.d","fsgnjn.d","fsgnjx.d"]
 three_operand_dinstructions = ["fmadd.d","fmsub.d","fnmadd.d","fnmsub.d"]
 from riscv_ctg.dsp_function import *
@@ -983,7 +983,10 @@ class Generator():
                         flag = False
                     instr_dict[i]['offset'] = str(offset)
                     instr_dict[i]['val_offset'] = str(val_offset)
-                    offset += int((flen/8)+(xlen/8))
+                    if flen == 64 and xlen == 32:
+                        offset += 8
+                    else:
+                        offset += int((flen/8)+(xlen/8))
                     if self.fmt == 'frformat' or self.fmt == 'rformat':
                         val_offset += 2*(int(flen/8))
                     elif self.fmt == 'fsrformat':


### PR DESCRIPTION
Hi,
This merge request had the below changes on CTG towards Floating point fixes. And the code changes are verified against below, on all of the given instructions across cover groups.

    RV64F
    RV32D
    RV32F
    RV64D

High level descriptions of changes made
_generator.py_
1. Added a condition to manipulate the offset with respect to FLEN
2. Addition of new instructions to the required conditions

_template.yaml_
1. Removal of additional FLEN value from the respective instructions block

Thanks
Prasanna T
ptprasanna@gmail.com