### PR TITLE
Support for pseudoinstructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.2] - 2022-15-04
+## [0.7.0] - 2022-2-05
+- Included support for pseudoinstructions
+
+## [0.6.2] - 2022-04-15
 - Added method to generate data patterns for bitmanip instructions.
 
 ## [0.6.1] - 2022-03-04

--- a/docs/source/pseudo_op_support.rst
+++ b/docs/source/pseudo_op_support.rst
@@ -1,0 +1,44 @@
+********************************
+Pseudo-Ops Support for RISCV-CTG
+********************************
+
+Coverpoints are defined in a CGF file under the ``opcode`` node in the CGF. This is a misnomer as ISAC and CTG
+deals with mnemonics of the instruction rather than the actual encoding. In order to deal with mnemonics of pseudo-Ops, 
+and its congruent base instruction definition, changes are brought to the CGF format.
+
+Format
+######
+The ``opcode`` field is renamed to ``mnemonics``. To support pseudo-instructions two new fields ``base_op`` and ``p_op_cond``
+are added to the covergroups. The ``base_op`` and ``p_op_cond`` are optional fields which specify the base operation and the
+condition over the different fields of the instruction which when satisfied results in the instruction being recognized as the
+pseudo-op mentioned in ``mnemonics``. As an example, ``zext.h`` is a pseudo-op of ``pack`` in RV32 and packw in RV64 with ``rs2``
+equal to ``x0``. Covergroup for ``zext.h`` pseudo-op can be expressed as follows: ::
+
+    zext.h_32:
+        config: 
+          - check ISA:=regex(.*RV32.*B.*)
+          - check ISA:=regex(.*RV32.*Zbb.*)
+        mnemonics: 
+          zext.h: 0
+        base_op: packw
+        p_op_cond: rs2 == x0
+        ...
+
+    zext.h_64:
+        config: 
+          - check ISA:=regex(.*RV64.*B.*)
+          - check ISA:=regex(.*RV64.*Zbb.*)
+        mnemonics: 
+          zext.h: 0
+        base_op: pack
+        p_op_cond: rs2 == x0
+        ...
+
+During CTG runtime, the ``base_op`` field is checked for in every covergroup. The template corresponding to the instruction found 
+in ``base_op`` node is extracted to generate the test. If ``base_op`` node does not exist, the instruction found in ``mnemonics``
+is used to extract the required template.
+
+Note
+####
+- The ``p_op_cond`` node is relevant only if the ``base_op`` node has been defined.
+- The ``mnemonics`` node is allowed to have multiple entries only if the ``base_op`` node is empty.

--- a/docs/source/pseudo_op_support.rst
+++ b/docs/source/pseudo_op_support.rst
@@ -36,7 +36,8 @@ equal to ``x0``. Covergroup for ``zext.h`` pseudo-op can be expressed as follows
 
 During CTG runtime, the ``base_op`` field is checked for in every covergroup. The template corresponding to the instruction found 
 in ``base_op`` node is extracted to generate the test. If ``base_op`` node does not exist, the instruction found in ``mnemonics``
-is used to extract the required template.
+is used to extract the required template. ``p_op_cond`` fields are not used as additional constraints for the corresponding pseudo-op.
+This is due to the assumption that test generation for a base-op encompasses all pseudo-ops associated with the base-op.
 
 Note
 ####

--- a/riscv_ctg/__init__.py
+++ b/riscv_ctg/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'incorebot@gmail.com'
-__version__ = '0.6.2'
+__version__ = '0.7.0'

--- a/riscv_ctg/ctg.py
+++ b/riscv_ctg/ctg.py
@@ -20,21 +20,26 @@ def create_test(usage_str, node,label,base_isa,max_inst):
     global xlen
 
     flen = 0
-    if 'opcode' not in node:
+    if 'mnemonics' not in node:
         return
     if 'ignore' in node:
         logger.info("Ignoring :" + str(label))
         if node['ignore']:
             return
-    for opcode in node['opcode']:
-        op_node=None
-        if opcode not in op_template:
-            for op,foo in op_template.items():
-                if op!='metadata' and foo['std_op'] is not None and opcode==foo['std_op']:
-                    op_node = foo
-                    break
-        else:
-            op_node = op_template[opcode]
+    if 'base_op' in node:
+        base_op = node['base_op'] 
+        if base_op in op_template:
+            op_node = op_template[base_op]
+    else:
+        for opcode in node['mnemonics']:
+            op_node=None
+            if opcode not in op_template:
+                for op,foo in op_template.items():
+                    if op!='metadata' and foo['std_op'] is not None and opcode==foo['std_op']:
+                        op_node = foo
+                        break
+            else:
+                op_node = op_template[opcode]
 
         if op_node is  None:
             logger.warning("Skipping :" + str(opcode))

--- a/riscv_ctg/ctg.py
+++ b/riscv_ctg/ctg.py
@@ -32,6 +32,7 @@ def create_test(usage_str, node,label,base_isa,max_inst):
         if xlen not in op_node['xlen']:
             logger.warning("Skipping {0} since its not supported in current XLEN:".format(opcode))
             return
+        flen = 0
         if 'flen' in op_node:
             if '.d' in opcode:
                 flen = 64
@@ -59,15 +60,14 @@ def create_test(usage_str, node,label,base_isa,max_inst):
         
         # Extract pseudo and base instructions
         base_op = node['base_op']
-        pseudop = node['mnemonics']
-
+        pseudop = list(node['mnemonics'].keys())[0]
         if base_op in op_template and pseudop in op_template:
             op_node = op_template[base_op]
-            pseudo_template = op_template[base_op]
-
+            pseudo_template = op_template[pseudop]
+            
             # Ovewrite/add nodes from pseudoinstruction template in base instruction template
             for key, val in pseudo_template.items():
-               op_node[key] = val
+                op_node[key] = val
 
             # Generate tests
             gen_test(op_node, pseudop)
@@ -115,4 +115,3 @@ def ctg(verbose, out, random ,xlen_arg, cgf_file,num_procs,base_isa, max_inst):
     pool = mp.Pool(num_procs)
     results = pool.starmap(create_test, [(usage_str, node,label,base_isa,max_inst) for label,node in cgf.items()])
     pool.close()
-

--- a/riscv_ctg/ctg.py
+++ b/riscv_ctg/ctg.py
@@ -54,8 +54,10 @@ def create_test(usage_str, node,label,base_isa,max_inst):
 
     # If base_op defined in covergroup, extract corresponding template
     # else go through the instructions defined in mnemonics label
+    op_node = None
     if 'base_op' in node and 'mnemonics' in node:
-
+        
+        # Extract pseudo and base instructions
         base_op = node['base_op']
         pseudop = node['mnemonics']
 
@@ -63,7 +65,7 @@ def create_test(usage_str, node,label,base_isa,max_inst):
             op_node = op_template[base_op]
             pseudo_template = op_template[base_op]
 
-            # Ovewrite nodes from pseudoinstruction template in base instruction template
+            # Ovewrite/add nodes from pseudoinstruction template in base instruction template
             for key, val in pseudo_template.items():
                op_node[key] = val
 
@@ -71,16 +73,11 @@ def create_test(usage_str, node,label,base_isa,max_inst):
             gen_test(op_node, pseudop)
     else:
         for opcode in node['mnemonics']:
-            op_node=None
-            if opcode not in op_template:
-                for op,foo in op_template.items():
-                    if op!='metadata' and foo['std_op'] is not None and opcode==foo['std_op']:
-                        op_node = foo
-                        break
-            else:
+            if opcode in op_template:
                 op_node = op_template[opcode]
-            # Generate tests
-            gen_test(op_node, opcode)
+                
+                # Generate tests
+                gen_test(op_node, opcode)
     
     # Return if there is no corresponding template 
     if op_node is None:

--- a/riscv_ctg/ctg.py
+++ b/riscv_ctg/ctg.py
@@ -54,12 +54,21 @@ def create_test(usage_str, node,label,base_isa,max_inst):
 
     # If base_op defined in covergroup, extract corresponding template
     # else go through the instructions defined in mnemonics label
-    if 'base_op' in node:
-        base_op = node['base_op'] 
-        if base_op in op_template:
+    if 'base_op' in node and 'mnemonics' in node:
+
+        base_op = node['base_op']
+        pseudop = node['mnemonics']
+
+        if base_op in op_template and pseudop in op_template:
             op_node = op_template[base_op]
+            pseudo_template = op_template[base_op]
+
+            # Ovewrite nodes from pseudoinstruction template in base instruction template
+            for key, val in pseudo_template.items():
+               op_node[key] = val
+
             # Generate tests
-            gen_test(op_node, base_op)
+            gen_test(op_node, pseudop)
     else:
         for opcode in node['mnemonics']:
             op_node=None

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -897,7 +897,7 @@ class Generator():
         for instr in instr_dict:
             unique = False
             skip_val = False
-            if instr['inst'] in cgf['opcode']:
+            if instr['inst'] in cgf['mnemonics']:
                 if 'rs1' in instr and 'rs2' in instr:
                     if instr['rs1'] == instr['rs2']:
                         skip_val = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.2
+current_version = 0.7.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_ctg',
-    version='0.6.2',
+    version='0.7.0',
     description="RISC-V CTG",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
This Pull Request adds support for pseudoinstructions while defining covergroups for test generation. The covergroup format is modified to comply with this feature addition. opcode field is dropped and mnemonics field is used to list instructions in the covergroup. Two new fields are added to specify the alternate definition of the pseudoinstruction in terms of its base instruction. The base instruction can be mentioned under the base_op node and the necessary conditions required to make it congruent to the pseudoinstruction can be mentioned under the p_op_cond node.

CTG relies on the use of `template.yaml` to define instruction template to generate tests. When a pseudoinstruction is encountered for test generation, the properties of base instruction template is inherited. The properties defined in pseudoinstruction template overwrites the properties defined in base instruction template. The resultant template is used to generate the tests for the instruction. 