### PR TITLE
fix: global usage across MP threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2]
+- Fix errors related to global variables across processes.
+
 ## [0.7.1] - 2022-02-07
 - Fixed mistune version for doc build.
 

--- a/riscv_ctg/__init__.py
+++ b/riscv_ctg/__init__.py
@@ -4,5 +4,5 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'incorebot@gmail.com'
-__version__ = '0.7.1'
+__version__ = '0.7.2'
 

--- a/riscv_ctg/ctg.py
+++ b/riscv_ctg/ctg.py
@@ -14,12 +14,7 @@ from riscv_ctg.generator import Generator
 from math import *
 from riscv_ctg.__init__ import __version__
 
-def create_test(usage_str, node,label,base_isa,max_inst):
-    global op_template
-    global ramdomize
-    global out_dir
-    global xlen
-
+def create_test(usage_str, node,label,base_isa,max_inst, op_template, randomize, out_dir, xlen):
     flen = 0
     if 'mnemonics' not in node:
         logger.warning("mnemonics node not found in covergroup: " + str(label))
@@ -88,10 +83,6 @@ def create_test(usage_str, node,label,base_isa,max_inst):
         return
 
 def ctg(verbose, out, random ,xlen_arg, cgf_file,num_procs,base_isa, max_inst):
-    global op_template
-    global randomize
-    global out_dir
-    global xlen
     logger.level(verbose)
     logger.info('****** RISC-V Compliance Test Generator {0} *******'.format(__version__ ))
     logger.info('Copyright (c) 2020, InCore Semiconductors Pvt. Ltd.')
@@ -116,5 +107,5 @@ def ctg(verbose, out, random ,xlen_arg, cgf_file,num_procs,base_isa, max_inst):
     op_template = utils.load_yaml(const.template_file)
     cgf = expand_cgf(cgf_file,xlen)
     pool = mp.Pool(num_procs)
-    results = pool.starmap(create_test, [(usage_str, node,label,base_isa,max_inst) for label,node in cgf.items()])
+    results = pool.starmap(create_test, [(usage_str, node,label,base_isa,max_inst, op_template, randomize, out_dir, xlen) for label,node in cgf.items()])
     pool.close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.1
+current_version = 0.7.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_ctg',
-    version='0.7.1',
+    version='0.7.2',
     description="RISC-V CTG",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
Running a newly cloned version of riscv-ctg with `riscv_ctg -v debug -d gen-tests -r -cf ./sample_cgfs/dataset.cgf -cf ./sample_cgfs/rv32i.cgf -bi rv32i -p1 2> error.txt` errors out with this error: [error.txt](https://gist.github.com/Soumil-07/3bc9b9eefce8ac691a2d616a1aca8df1).

This is using Python 3.9.13 on an M1 Mac with ARM64 Python.

The problem appears to be the globals declared in these lines: https://github.com/riscv-software-src/riscv-ctg/blob/master/riscv_ctg/ctg.py#L18-L21

Global variables aren't shared across threads when using `multiprocessing`. I've reproduced the issue [here](https://gist.github.com/Soumil-07/9710f273aa84068b04638304f9defa7d)

I've fixed this by passing the global variables as parameters to `create_test` instead.
