### PR TITLE
Add a dummy wrapper to start the tool

### DIFF
--- a/riscv_ctg.py
+++ b/riscv_ctg.py
@@ -1,0 +1,8 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+import re
+import sys
+from riscv_ctg.main import cli
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+    sys.exit(cli())


### PR DESCRIPTION
When adding new features to this repository we have no way to test the new features without installing the package.

Let's add a dummy wrapper that simply invokes riscv_ctg.main.cli() in order to be able to execute riscv_ctg without the need of installing the tool.