### PR TITLE
Add support for the Zicond ISA extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.4] - 2023-03-28
+- Adding Zicond support
+
 ## [0.10.3] - 2022-11-22
 - Fixed canary definition
 

--- a/riscv_ctg/__init__.py
+++ b/riscv_ctg/__init__.py
@@ -4,5 +4,5 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'incorebot@gmail.com'
-__version__ = '0.10.3'
+__version__ = '0.10.4'
 

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -10299,3 +10299,45 @@ unshfli:
     unshfli $rd, $rs1, $imm_val
     SREG $rd, $offset($swreg)
     RVMODEL_IO_ASSERT_GPR_EQ($testreg, $rd, $correctval)
+
+czero.eqz:
+  std_op:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [32,64]
+  isa:
+    - IZicond
+  operation: 'hex(int(rs2_val != 0) * rs1_val)'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+czero.nez:
+  std_op:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [32,64]
+  isa:
+    - IZicond
+  operation: 'hex(int(rs2_val == 0) * rs1_val)'
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)

--- a/sample_cgfs/zicond.cgf
+++ b/sample_cgfs/zicond.cgf
@@ -1,0 +1,37 @@
+czero.eqz:
+    config: 
+      - check ISA:=regex(.*Zicond.*)
+    opcode: 
+      czero.eqz: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        'sp_dataset(xlen)': 0
+        <<: [*rs1val_walking, *rs2val_walking]
+
+czero.nez:
+    config: 
+      - check ISA:=regex(.*Zicond.*)
+    opcode: 
+      czero.nez: 0
+    rs1: 
+      <<: *all_regs
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      abstract_comb:
+        'sp_dataset(xlen)': 0
+        <<: [*rs1val_walking, *rs2val_walking]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.3
+current_version = 0.10.4
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_ctg',
-    version='0.10.3',
+    version='0.10.4',
     description="RISC-V CTG",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
The upcoming Zicond ISA extension introduces two new instructions:
* czero.eqz
* czero.nez

This patch adds these instructions to template.yaml.

The Zicond ISA extension is documented here:
  https://github.com/riscv/riscv-zicond/blob/main/zicondops.adoc