### PR TITLE
Add support for the Zfa ISA extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Please note the header `WIP-DEV` is to always remain indicating the changes done
 Only when a release to the main branch is done, the contents of the WIP-DEV are put under a
 versioned header while the `WIP-DEV` is left empty
 
+## [0.12.2] - 2024-03-06
+- Add Zfa support.
+
 ## [0.12.1] - 2024-02-27
 - Fix test.yml
 

--- a/riscv_ctg/__init__.py
+++ b/riscv_ctg/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'incorebot@gmail.com'
-__version__ = '0.12.1'
+__version__ = '0.12.2'

--- a/riscv_ctg/data/fd.yaml
+++ b/riscv_ctg/data/fd.yaml
@@ -1962,7 +1962,7 @@ fmvh.x.d:
     fcsr_val:$fcsr*/
     TEST_FPID_OP_NRM($inst, $rd, $rs1, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
 
-fmvh.d.x:
+fmvp.d.x:
   sig:
     stride: 2
     sz: 'SIGALIGN'

--- a/riscv_ctg/data/fd.yaml
+++ b/riscv_ctg/data/fd.yaml
@@ -2010,9 +2010,9 @@ fcvtmod.w.d:
   template: |-
     // $comment
     /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
-    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    val_offset:$val_offset; rmval:rtz; correctval:??; testreg:$testreg;
     fcsr_val:$fcsr*/
-    TEST_FPID_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
+    TEST_FPID_OP($inst, $rd, $rs1, rtz, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
 
 fltq.s:
   sig:

--- a/riscv_ctg/data/fd.yaml
+++ b/riscv_ctg/data/fd.yaml
@@ -1709,3 +1709,413 @@ fcvt.s.lu:
     fcsr_val: $fcsr*/
     TEST_FPIO_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
 
+#
+# Zfa extension
+#
+
+fminm.s:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IF_Zicsr_Zfa
+    - IFD_Zicsr_Zfa
+  flen: [32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_fregs
+  rs2_op_data: *all_fregs
+  rd_op_data: *all_fregs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset; fcsr: $fcsr;
+       correctval:??; testreg:$testreg
+    */
+    TEST_FPRR_OP_NRM($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fminm.d:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IFD_Zicsr_Zfa
+  flen: [64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_fregs
+  rs2_op_data: *all_fregs
+  rd_op_data: *all_fregs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset; fcsr: $fcsr;
+       correctval:??; testreg:$testreg
+    */
+    TEST_FPRR_OP_NRM($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fmaxm.s:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IF_Zicsr_Zfa
+    - IFD_Zicsr_Zfa
+  flen: [32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_fregs
+  rs2_op_data: *all_fregs
+  rd_op_data: *all_fregs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset; fcsr: $fcsr;
+       correctval:??; testreg:$testreg
+    */
+    TEST_FPRR_OP_NRM($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fmaxm.d:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IFD_Zicsr_Zfa
+  flen: [64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_fregs
+  rs2_op_data: *all_fregs
+  rd_op_data: *all_fregs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset;  fcsr: $fcsr;
+       correctval:??; testreg:$testreg
+    */
+    TEST_FPRR_OP_NRM($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fround.s:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IF_Zicsr_Zfa
+    - IFD_Zicsr_Zfa
+  flen: [32,64]
+  std_op:
+  formattype: 'fsrformat'
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  rs1_op_data: *all_fregs
+  rd_op_data: *all_fregs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr */
+    TEST_FPSR_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fround.d:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IFD_Zicsr_Zfa
+  flen: [64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_fregs
+  rd_op_data: *all_fregs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr */
+    TEST_FPSR_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+froundnx.s:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IF_Zicsr_Zfa
+    - IFD_Zicsr_Zfa
+  flen: [32,64]
+  std_op:
+  formattype: 'fsrformat'
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  rs1_op_data: *all_fregs
+  rd_op_data: *all_fregs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr */
+    TEST_FPSR_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+froundnx.d:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IFD_Zicsr_Zfa
+  flen: [64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_fregs
+  rd_op_data: *all_fregs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr */
+    TEST_FPSR_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fmvh.x.d:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32]
+  isa:
+    - IFD_Zicsr_Zfa
+  flen: [64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_fregs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; correctval:??; testreg:$testreg;
+    fcsr_val:$fcsr*/
+    TEST_FPID_OP_NRM($inst, $rd, $rs1, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fmvh.d.x:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: '4'
+    val_template: "'.word $val;'"
+    load_instr: "lw"
+  xlen: [32]
+  isa:
+    - IFD_Zicsr_Zfa
+  flen: [64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_fregs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr*/
+    TEST_FPIOIO_OP_NRM($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
+
+fcvtmod.w.d:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IFD_Zicsr_Zfa
+  flen: [64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_fregs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val:$fcsr*/
+    TEST_FPID_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
+
+fltq.s:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IF_Zicsr_Zfa
+    - IFD_Zicsr_Zfa
+  flen: [32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_fregs
+  rs2_op_data: *all_fregs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+    valaddr_reg:$valaddr_reg; val_offset:$val_offset; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr*/
+    TEST_FCMP_OP($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fltq.d:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IFD_Zicsr_Zfa
+  flen: [64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_fregs
+  rs2_op_data: *all_fregs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+    valaddr_reg:$valaddr_reg; val_offset:$val_offset; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr*/
+    TEST_FCMP_OP($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fleq.s:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IF_Zicsr_Zfa
+    - IFD_Zicsr_Zfa
+  flen: [32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_fregs
+  rs2_op_data: *all_fregs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+    valaddr_reg:$valaddr_reg; val_offset:$val_offset; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr*/
+    TEST_FCMP_OP($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fleq.d:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa:
+    - IFD_Zicsr_Zfa
+  flen: [64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_fregs
+  rs2_op_data: *all_fregs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+    valaddr_reg:$valaddr_reg; val_offset:$val_offset; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr*/
+    TEST_FCMP_OP($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)

--- a/riscv_ctg/data/fd.yaml
+++ b/riscv_ctg/data/fd.yaml
@@ -2001,7 +2001,7 @@ fcvtmod.w.d:
   isa:
     - IFD_Zicsr_Zfa
   flen: [64]
-  rm_val_data: '[7,0,1,2,3,4]'
+  rm_val_data: '[1]'
   fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
   std_op:
   formattype: 'fsrformat'

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -1037,11 +1037,22 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg)
       csrr flagreg, fcsr      ; \
       )
     
-//Tests for floating-point instructions with a single register operand and integer operand register
+//Tests for floating-point instructions with one GPR operand and a single FPR result
 //This variant does not take the rm field and set it while writing the instruction
 #define TEST_FPIO_OP_NRM( inst, destreg, freg, fcsr_val, correctval, valaddr_reg, val_offset, flagreg, swreg, testreg, load_instr) \
     TEST_CASE_F(testreg, destreg, correctval, swreg, flagreg, \
       LOAD_MEM_VAL(load_instr, valaddr_reg, freg, val_offset, testreg); \
+      LI(testreg, fcsr_val); csrw fcsr, testreg; \
+      inst destreg, freg; \
+      csrr flagreg, fcsr; \
+    )
+
+//Tests for floating-point instructions with two GPR operands and a single FPR result
+//This variant does not take the rm field and set it while writing the instruction
+#define TEST_FPIOIO_OP_NRM(inst, destreg, freg1, freg2, fcsr_val, correctval, valaddr_reg, val_offset, flagreg, swreg, testreg, load_instr) \
+    TEST_CASE_F(testreg, destreg, correctval, swreg, flagreg, \
+      LOAD_MEM_VAL(load_instr, valaddr_reg, freg1, val_offset, testreg); \
+      LOAD_MEM_VAL(load_instr, valaddr_reg, freg2, (val_offset+FREGWIDTH), testreg); \
       LI(testreg, fcsr_val); csrw fcsr, testreg; \
       inst destreg, freg; \
       csrr flagreg, fcsr; \

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -827,7 +827,7 @@ class Generator():
                     else:
                         var_dict['imm_val'] = toint(instr['imm_val'])
                 elif key == 'rm_val':
-                    var_dict['rm_val'] = toint(rm_dict[instr['rm_val']])
+                    var_dict['rm_val'] = rm_dict[instr['rm_val']]
                 else:
                     var_dict[key] = toint(instr[key])
             for key in self.op_vars:

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -14,13 +14,32 @@ import sys
 import itertools
 import re
 
+# F
 one_operand_finstructions = ["fsqrt.s","fmv.x.w","fcvt.wu.s","fcvt.w.s","fclass.s","fcvt.l.s","fcvt.lu.s","fcvt.s.l","fcvt.s.lu"]
 two_operand_finstructions = ["fadd.s","fsub.s","fmul.s","fdiv.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fsgnj.s","fsgnjn.s","fsgnjx.s"]
 three_operand_finstructions = ["fmadd.s","fmsub.s","fnmadd.s","fnmsub.s"]
+# Zfa/F:
+one_operand_finstructions += ["fround.s", "froundnx.s", "fcvtmod.w.d","fmvh.x.d"]
+two_operand_finstructions += ["fmaxm.s", "fminm.s", "fmvp.d.x", "fleq.s", "fltq.s"]
 
+# D
 one_operand_dinstructions = ["fsqrt.d","fclass.d","fcvt.w.d","fcvt.wu.d","fcvt.d.w","fcvt.d.wu","fcvt.d.s","fcvt.s.d"]
 two_operand_dinstructions = ["fadd.d","fsub.d","fmul.d","fdiv.d","fmax.d","fmin.d","feq.d","flt.d","fle.d","fsgnj.d","fsgnjn.d","fsgnjx.d"]
 three_operand_dinstructions = ["fmadd.d","fmsub.d","fnmadd.d","fnmsub.d"]
+# Zfa/D:
+one_operand_dinstructions += ["fround.d", "froundnx.d"]
+two_operand_dinstructions += ["fmaxm.d", "fminm.d", "fleq.d", "fltq.d"]
+
+
+def is_fp_instruction(insn):
+    '''
+    Takes an instruction string (e.g. 'fadd.s') and returns True if it is a FP instruction.
+    The function is compatible with all existing and future RISC-V ISA extensions.
+
+    :param insn: String representing an instruction (e.g. 'fadd.s', 'lw')
+    '''
+    return type(insn) == str and insn.lower()[0] == 'f'
+
 from riscv_ctg.dsp_function import *
 
 twos_xlen = lambda x: twos(x,xlen)
@@ -32,9 +51,10 @@ def toint(x: str):
         return int(x)
 
 def get_rm(opcode):
-    if any([x in opcode for x in
-        ['fsgnj','fle','flt','feq','fclass','fmv','flw','fsw','fld','fsd','fmin','fmax',
-            'fcvt.d.s', 'fcvt.d.w','fcvt.d.wu']]):
+    insns = ['fsgnj','fle','flt','feq','fclass','fmv','flw','fsw','fld','fsd','fmin','fmax',
+             'fcvt.d.s', 'fcvt.d.w','fcvt.d.wu']
+    insns += ['fminm', 'fmaxm']
+    if any([x in opcode for x in insns]):
         return []
     else:
         return ['rm_val']
@@ -833,7 +853,13 @@ class Generator():
             for key in self.op_vars:
                 var_dict[key] = instr[key]
 
-            instr_obj = instructionObject(None, instr['inst'], None)
+            insn = instr['inst']
+            # instructionObject() has an outdated list of instructions.
+            # Let's make it support all FP instructions until this is fixed.
+            # See https://github.com/riscv-software-src/riscv-isac/issues/69
+            if (is_fp_instruction(insn)):
+                insn = "fadd.s"
+            instr_obj = instructionObject(None, insn, None)
             ext_specific_vars = instr_obj.evaluate_instr_var("ext_specific_vars", {**var_dict, 'flen': self.flen, 'iflen': self.iflen}, None, {'fcsr': hex(var_dict.get('fcsr', 0))})
             if ext_specific_vars is not None:
                 var_dict.update(ext_specific_vars)

--- a/sample_cgfs/zfa/fcvtmod.w.d.cgf
+++ b/sample_cgfs/zfa/fcvtmod.w.d.cgf
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fcvtmod.w.d_b1:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fcvtmod.w.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 64, "fcvt.w.d", 1)': 0
+
+fcvtmod.w.d_b22:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fcvtmod.w.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b22(flen, 64, "fcvt.w.d", 1)': 0
+
+fcvtmod.w.d_b23:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fcvtmod.w.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b23(flen, 64, "fcvt.w.d", 1)': 0
+
+fcvtmod.w.d_b24:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fcvtmod.w.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b24(flen, 64, "fcvt.w.d", 1)': 0
+
+fcvtmod.w.d_b27:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fcvtmod.w.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b27(flen, 64, "fcvt.w.d", 1)': 0
+
+fcvtmod.w.d_b28:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fcvtmod.w.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b28(flen, 64, "fcvt.w.d", 1)': 0
+
+fcvtmod.w.d_b29:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fcvtmod.w.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b29(flen, 64, "fcvt.w.d", 1)': 0

--- a/sample_cgfs/zfa/fleq.d.cgf
+++ b/sample_cgfs/zfa/fleq.d.cgf
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fleq.d_b1:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fleq.d: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 64, "fle.d", 2)': 0
+
+fleq.d_b19:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fleq.d: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen, 64, "fle.d", 2)': 0

--- a/sample_cgfs/zfa/fleq.s.cgf
+++ b/sample_cgfs/zfa/fleq.s.cgf
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fleq_b1:
+    config:
+      - check ISA:=regex(.*I.*F.*Zfa.*)
+    mnemonics:
+      fleq.s: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 32, "fle.s", 2)': 0
+
+fleq_b19:
+    config:
+      - check ISA:=regex(.*I.*F.*Zfa.*)
+    mnemonics:
+      fleq.s: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen, 32, "fle.s", 2)': 0

--- a/sample_cgfs/zfa/fli.d.cgf
+++ b/sample_cgfs/zfa/fli.d.cgf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fli.d_b1:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fli.d: 0
+    rd:
+      <<: *all_fregs

--- a/sample_cgfs/zfa/fli.s.cgf
+++ b/sample_cgfs/zfa/fli.s.cgf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fli_b1:
+    config:
+      - check ISA:=regex(.*I.*F.*Zfa.*)
+    mnemonics:
+      fli.s: 0
+    rd:
+      <<: *all_fregs

--- a/sample_cgfs/zfa/fltq.d.cgf
+++ b/sample_cgfs/zfa/fltq.d.cgf
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fltq.d_b1:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fltq.d: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 64, "flt.d", 2)': 0
+
+fltq.d_b19:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fltq.d: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen, 64, "flt.d", 2)': 0

--- a/sample_cgfs/zfa/fltq.s.cgf
+++ b/sample_cgfs/zfa/fltq.s.cgf
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fltq_b1:
+    config:
+      - check ISA:=regex(.*I.*F.*Zfa.*)
+    mnemonics:
+      fltq.s: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 32, "flt.s", 2)': 0
+
+fltq_b19:
+    config:
+      - check ISA:=regex(.*I.*F.*Zfa.*)
+    mnemonics:
+      fltq.s: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    op_comb:
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen, 32, "flt.s", 2)': 0

--- a/sample_cgfs/zfa/fmaxm.d.cgf
+++ b/sample_cgfs/zfa/fmaxm.d.cgf
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fmaxm.d_b1:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fmaxm.d: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_fregs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 64, "fmax.d", 2)': 0
+
+fmaxm.d_b19:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fmaxm.d: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_fregs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen, 64, "fmax.d", 2)': 0

--- a/sample_cgfs/zfa/fmaxm.s.cgf
+++ b/sample_cgfs/zfa/fmaxm.s.cgf
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fmaxm_b1:
+    config:
+      - check ISA:=regex(.*I.*F.*Zfa.*)
+    mnemonics:
+      fmaxm.s: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_fregs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 32, "fmax.s", 2)': 0
+
+fmaxm_b19:
+    config:
+      - check ISA:=regex(.*I.*F.*Zfa.*)
+    mnemonics:
+      fmaxm.s: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_fregs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen, 32, "fmax.s", 2)': 0

--- a/sample_cgfs/zfa/fminm.d.cgf
+++ b/sample_cgfs/zfa/fminm.d.cgf
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fminm.d_b1:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fminm.d: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_fregs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 64, "fmin.d", 2)': 0
+
+fminm.d_b19:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fminm.d: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_fregs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen, 64, "fmin.d", 2)': 0

--- a/sample_cgfs/zfa/fminm.s.cgf
+++ b/sample_cgfs/zfa/fminm.s.cgf
@@ -1,0 +1,35 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fminm_b1:
+    config:
+      - check ISA:=regex(.*I.*F.*Zfa.*)
+    mnemonics:
+      fminm.s: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_fregs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 32, "fmin.s", 2)': 0
+
+fminm_b19:
+    config:
+      - check ISA:=regex(.*I.*F.*Zfa.*)
+    mnemonics:
+      fminm.s: 0
+    rs1:
+      <<: *all_fregs
+    rs2:
+      <<: *all_fregs
+    rd:
+      <<: *all_fregs
+    op_comb:
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen, 32, "fmin.s", 2)': 0

--- a/sample_cgfs/zfa/fmvh.x.d.cgf
+++ b/sample_cgfs/zfa/fmvh.x.d.cgf
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fmvh.x.d_b1:
+    config:
+      - check ISA:=regex(.*RV32.*I.*D.*Zfa.*)
+    mnemonics:
+      fmvh.x.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fmv.x.d", 1)': 0
+
+fmvh.x.d_b22:
+    config:
+      - check ISA:=regex(.*RV32.*I.*D.*Zfa.*)
+    mnemonics:
+      fmvh.x.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b22(flen,64, "fmv.x.d", 1)': 0
+
+fmvh.x.d_b23:
+    config:
+      - check ISA:=regex(.*RV32.*I.*D.*Zfa.*)
+    mnemonics:
+      fmvh.x.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b23(flen,64, "fmv.x.d", 1)': 0
+
+fmvh.x.d_b24:
+    config:
+      - check ISA:=regex(.*RV32.*I.*D.*Zfa.*)
+    mnemonics:
+      fmvh.x.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b24(flen,64, "fmv.x.d", 1)': 0
+
+fmvh.x.d_b27:
+    config:
+      - check ISA:=regex(.*RV32.*I.*D.*Zfa.*)
+    mnemonics:
+      fmvh.x.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b27(flen,64, "fmv.x.d", 1)': 0
+
+fmvh.x.d_b28:
+    config:
+      - check ISA:=regex(.*RV32.*I.*D.*Zfa.*)
+    mnemonics:
+      fmvh.x.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b28(flen,64, "fmv.x.d", 1)': 0
+
+fmvh.x.d_b29:
+    config:
+      - check ISA:=regex(.*RV32.*I.*D.*Zfa.*)
+    mnemonics:
+      fmvh.x.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b29(flen,64, "fmv.x.d", 1)': 0

--- a/sample_cgfs/zfa/fmvp.d.x.cgf
+++ b/sample_cgfs/zfa/fmvp.d.x.cgf
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fmvp.d.x_b25:
+    config:
+      - check ISA:=regex(.*RV32.*I.*D.*Zfa.*)
+    mnemonics:
+      fmvp.d.x: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_fregs
+    val_comb:
+      abstract_comb:
+        'ibm_b25(flen, 64, "fmv.d.x", 2)': 0
+
+fmvp.d.x_b26:
+    config:
+      - check ISA:=regex(.*RV32.*I.*D.*Zfa.*)
+    mnemonics:
+      fmvp.d.x: 0
+    rs1:
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd:
+      <<: *all_fregs
+    val_comb:
+      abstract_comb:
+        'ibm_b26(64, "fmv.d.x", 2)': 0
+
+

--- a/sample_cgfs/zfa/fround.d.cgf
+++ b/sample_cgfs/zfa/fround.d.cgf
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fround.d_b1:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      fround.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_fregs
+    op_comb:
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 64, "fsqrt.d", 1)': 0

--- a/sample_cgfs/zfa/fround.s.cgf
+++ b/sample_cgfs/zfa/fround.s.cgf
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+fround_b1:
+    config:
+      - check ISA:=regex(.*I.*F.*Zfa.*)
+    mnemonics:
+      fround.s: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_fregs
+    op_comb:
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 32, "fsqrt.s", 1)': 0

--- a/sample_cgfs/zfa/froundnx.d.cgf
+++ b/sample_cgfs/zfa/froundnx.d.cgf
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+froundns.d_b1:
+    config:
+      - check ISA:=regex(.*I.*D.*Zfa.*)
+    mnemonics:
+      froundns.d: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_fregs
+    op_comb:
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 64, "fsqrt.d", 1)': 0

--- a/sample_cgfs/zfa/froundnx.d.cgf
+++ b/sample_cgfs/zfa/froundnx.d.cgf
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-froundns.d_b1:
+froundnx.d_b1:
     config:
       - check ISA:=regex(.*I.*D.*Zfa.*)
     mnemonics:
-      froundns.d: 0
+      froundnx.d: 0
     rs1:
       <<: *all_fregs
     rd:

--- a/sample_cgfs/zfa/froundnx.s.cgf
+++ b/sample_cgfs/zfa/froundnx.s.cgf
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+froundns_b1:
+    config:
+      - check ISA:=regex(.*I.*F.*Zfa.*)
+    mnemonics:
+      froundns.s: 0
+    rs1:
+      <<: *all_fregs
+    rd:
+      <<: *all_fregs
+    op_comb:
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 32, "fsqrt.s", 1)': 0

--- a/sample_cgfs/zfa/froundnx.s.cgf
+++ b/sample_cgfs/zfa/froundnx.s.cgf
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-froundns_b1:
+froundnx_b1:
     config:
       - check ISA:=regex(.*I.*F.*Zfa.*)
     mnemonics:
-      froundns.s: 0
+      froundnx.s: 0
     rs1:
       <<: *all_fregs
     rd:


### PR DESCRIPTION
This patch introduces the RISC-V Zfa extension, which introduces additional floating-point extensions:
* fli (load-immediate) with pre-defined immediates
* fminm/fmaxm (like fmin/fmax but with different NaN behaviour)
* fround/froundmx (round to integer)
* fcvtmod.w.d (Modular Convert-to-Integer)
* fmv* to access high bits of float register bigger than XLEN
* Quiet comparison instructions (fleq/fltq)

Zfa defines its instructions in combination with the following extensions:
* single-precision floating-point (F)
* double-precision floating-point (D)
* quad-precision floating-point (Q)
* half-precision floating-point (Zfh)

Since riscv-ctg does not support the RISC-V quad-precision floating-point ISA extension (Q) as well as the RISC-V half-precision floating-point ISA extension (Zfh), this patch does not include the instructions that depend on these extensions. All other instructions are included in this patch.

The instruction descriptions (simple_cgfs/zfa/*) use different instructions as parameter for the coverpoint generator functions (e.g. fleq.s uses "fle.s") to circumvent documented limitations of these generator functions.

Technically there is no reason to adjust generator.py. All required information could be extracted from instruction descriptions. However, that is not the case, and the file also includes its own hard-coded assumptions, which have to be adjusted as well.

The Zfa specification can be found here:
  https://github.com/riscv/riscv-isa-manual/blob/master/src/zfa.tex