### PR TITLE
Added rfmt_op_comb conditions described in issue#306 of riscv-arch-test

### DIFF
--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -220,11 +220,14 @@ datasets:
 
   rfmt_op_comb: &rfmt_op_comb
     'rs1 == rs2 != rd': 0
-    'rs1 == rd != rs2': 0
+    "rs1 == rd != rs2 and rd == 'x0'": 0
+    "rs1 == rd != rs2 and rd != 'x0'": 0
     'rs2 == rd != rs1': 0
     'rs1 == rs2 == rd': 0
+    "rs1 == 'x0' != rd": 0
+    "rd == 'x0' != rs1": 0
     'rs1 != rs2  and rs1 != rd and rs2 != rd': 0
-    
+
   r4fmt_op_comb: &r4fmt_op_comb
     'rs1 == rs2 == rs3 == rd': 0
     'rs1 == rs2 == rs3 != rd': 0


### PR DESCRIPTION
In this PR, I have added following conditions in label `rfmt_op_comb` of `dataset.cgf` so that they can produce appropriate tests for `div-01.S`. Merging this PR will solve [issue#306 of riscv-arch-test](https://github.com/riscv-non-isa/riscv-arch-test/issues/306)

`rs1 == rd != rs2 and rd != x0`
`rs1 == rd != rs2 and == x0`
`rs1 == x0 != rd`
`rd == x0 != rs1`