### PR TITLE
Add support for standard Atomic (A) Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Only when a release to the main branch is done, the contents of the WIP-DEV are 
 versioned header while the `WIP-DEV` is left empty
 
 ## [WIP-DEV]
+- Added support of Standard Atomic (A) Extension (RV32 and RV64), excluding the LR/SC instruction.
 - Updating CONTRIBUTING.rst to capture the new git strategy adopted to follow a monthly release
   cadence.
 

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -10498,3 +10498,183 @@ amomaxu.w:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amoadd.d:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [64]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amoand.d:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [64]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amoswap.d:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [64]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amoxor.d:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [64]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amoor.d:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [64]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amomin.d:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [64]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amominu.d:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [64]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amomax.d:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [64]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+ 
+amomaxu.d:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [64]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -10318,3 +10318,183 @@ czero.nez:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amoadd.w:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [32]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amoand.w:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [32]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amoswap.w:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [32]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amoxor.w:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [32]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amoor.w:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [32]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amomin.w:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [32]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amominu.w:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [32]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amomax.w:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [32]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+ 
+amomaxu.w:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [32]
+  std_op:
+  isa: 
+    - IA
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  template: |-
+
+    // $comment
+    // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
+    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -10321,9 +10321,9 @@ czero.nez:
 
 amoadd.w:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
-  xlen: [32]
+  xlen: [32,64]
   std_op:
   isa: 
     - IA
@@ -10337,13 +10337,13 @@ amoadd.w:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amoand.w:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
-  xlen: [32]
+  xlen: [32,64]
   std_op:
   isa: 
     - IA
@@ -10357,13 +10357,13 @@ amoand.w:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amoswap.w:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
-  xlen: [32]
+  xlen: [32,64]
   std_op:
   isa: 
     - IA
@@ -10377,13 +10377,13 @@ amoswap.w:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amoxor.w:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
-  xlen: [32]
+  xlen: [32,64]
   std_op:
   isa: 
     - IA
@@ -10397,13 +10397,13 @@ amoxor.w:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amoor.w:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
-  xlen: [32]
+  xlen: [32,64]
   std_op:
   isa: 
     - IA
@@ -10417,13 +10417,13 @@ amoor.w:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amomin.w:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
-  xlen: [32]
+  xlen: [32,64]
   std_op:
   isa: 
     - IA
@@ -10437,13 +10437,13 @@ amomin.w:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amominu.w:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
-  xlen: [32]
+  xlen: [32,64]
   std_op:
   isa: 
     - IA
@@ -10457,13 +10457,13 @@ amominu.w:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amomax.w:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
-  xlen: [32]
+  xlen: [32,64]
   std_op:
   isa: 
     - IA
@@ -10477,13 +10477,13 @@ amomax.w:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
  
 amomaxu.w:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
-  xlen: [32]
+  xlen: [32,64]
   std_op:
   isa: 
     - IA
@@ -10497,11 +10497,11 @@ amomaxu.w:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amoadd.d:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
   xlen: [64]
   std_op:
@@ -10517,11 +10517,11 @@ amoadd.d:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amoand.d:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
   xlen: [64]
   std_op:
@@ -10537,11 +10537,11 @@ amoand.d:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amoswap.d:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
   xlen: [64]
   std_op:
@@ -10557,11 +10557,11 @@ amoswap.d:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amoxor.d:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
   xlen: [64]
   std_op:
@@ -10577,11 +10577,11 @@ amoxor.d:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amoor.d:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
   xlen: [64]
   std_op:
@@ -10597,11 +10597,11 @@ amoor.d:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amomin.d:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
   xlen: [64]
   std_op:
@@ -10617,11 +10617,11 @@ amomin.d:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amominu.d:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
   xlen: [64]
   std_op:
@@ -10637,11 +10637,11 @@ amominu.d:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
 
 amomax.d:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
   xlen: [64]
   std_op:
@@ -10657,11 +10657,11 @@ amomax.d:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)
  
 amomaxu.d:
   sig:
-    stride: 1
+    stride: 2
     sz: 'XLEN/8'
   xlen: [64]
   std_op:
@@ -10677,4 +10677,4 @@ amomaxu.d:
 
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
-    TEST_RR_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+    TEST_AMO_OP($inst, $rd, $rs1, $rs2, $rs1_val, $rs2_val, $swreg, $offset)

--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -224,7 +224,12 @@ datasets:
     'rs2 == rd != rs1': 0
     'rs1 == rs2 == rd': 0
     'rs1 != rs2  and rs1 != rd and rs2 != rd': 0
-    
+
+  ramofmt_op_comb: &ramofmt_op_comb
+    'rs1 == rd != rs2': 0
+    'rs2 == rd != rs1': 0
+    'rs1 != rs2  and rs1 != rd and rs2 != rd': 0
+
   r4fmt_op_comb: &r4fmt_op_comb
     'rs1 == rs2 == rs3 == rd': 0
     'rs1 == rs2 == rs3 != rd': 0

--- a/sample_cgfs/rv32ia.cgf
+++ b/sample_cgfs/rv32ia.cgf
@@ -120,9 +120,9 @@ amominu.w:
     op_comb: 
       <<: [*ramofmt_op_comb]
     val_comb:
-      <<: [*base_rs2val_unsgn]
+      <<: [*base_rs2val_sgn]
       abstract_comb:
-        <<: [*rs2val_walking_unsgn]
+        <<: [*rs2val_walking]
 
 amomax.w:
     config: 
@@ -156,6 +156,6 @@ amomaxu.w:
     op_comb: 
       <<: [*ramofmt_op_comb]
     val_comb:
-      <<: [*base_rs2val_unsgn]
+      <<: [*base_rs2val_sgn]
       abstract_comb:
-        <<: [*rs2val_walking_unsgn]
+        <<: [*rs2val_walking]

--- a/sample_cgfs/rv32ia.cgf
+++ b/sample_cgfs/rv32ia.cgf
@@ -10,7 +10,7 @@ amoadd.w:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -28,7 +28,7 @@ amoand.w:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -46,7 +46,7 @@ amoswap.w:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -64,7 +64,7 @@ amoxor.w:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -82,7 +82,7 @@ amoor.w:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -100,7 +100,7 @@ amomin.w:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -118,11 +118,11 @@ amominu.w:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
-      <<: [*base_rs2val_sgn]
+      <<: [*base_rs2val_unsgn]
       abstract_comb:
-        <<: [*rs2val_walking]
+        <<: [*rs2val_walking_unsgn]
 
 amomax.w:
     config: 
@@ -136,7 +136,7 @@ amomax.w:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -154,8 +154,8 @@ amomaxu.w:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
-      <<: [*base_rs2val_sgn]
+      <<: [*base_rs2val_unsgn]
       abstract_comb:
-        <<: [*rs2val_walking]
+        <<: [*rs2val_walking_unsgn]

--- a/sample_cgfs/rv32ia.cgf
+++ b/sample_cgfs/rv32ia.cgf
@@ -1,0 +1,161 @@
+amoadd.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoadd.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amoand.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoand.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amoswap.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoswap.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amoxor.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoxor.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amoor.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoor.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amomin.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amomin.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amominu.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amominu.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amomax.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amomax.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amomaxu.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amomaxu.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]

--- a/sample_cgfs/rv64ia.cgf
+++ b/sample_cgfs/rv64ia.cgf
@@ -1,0 +1,161 @@
+amoadd.d:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoadd.d: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amoand.d:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoand.d: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amoswap.d:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoswap.d: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amoxor.d:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoxor.d: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amoor.d:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoor.d: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amomin.d:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amomin.d: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amominu.d:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amominu.d: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amomax.d:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amomax.d: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amomaxu.d:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amomaxu.d: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*rfmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]

--- a/sample_cgfs/rv64ia.cgf
+++ b/sample_cgfs/rv64ia.cgf
@@ -1,3 +1,165 @@
+amoadd.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoadd.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*ramofmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amoand.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoand.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*ramofmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amoswap.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoswap.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*ramofmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amoxor.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoxor.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*ramofmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amoor.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amoor.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*ramofmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amomin.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amomin.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*ramofmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amominu.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amominu.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*ramofmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_unsgn]
+      abstract_comb:
+        <<: [*rs2val_walking_unsgn]
+
+amomax.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amomax.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*ramofmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs2val_walking]
+
+amomaxu.w:
+    config: 
+      - check ISA:=regex(.*I.*A.*)
+    mnemonics: 
+      amomaxu.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: [*ramofmt_op_comb]
+    val_comb:
+      <<: [*base_rs2val_unsgn]
+      abstract_comb:
+        <<: [*rs2val_walking_unsgn]
+
 amoadd.d:
     config: 
       - check ISA:=regex(.*I.*A.*)

--- a/sample_cgfs/rv64ia.cgf
+++ b/sample_cgfs/rv64ia.cgf
@@ -10,7 +10,7 @@ amoadd.d:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -28,7 +28,7 @@ amoand.d:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -46,7 +46,7 @@ amoswap.d:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -64,7 +64,7 @@ amoxor.d:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -82,7 +82,7 @@ amoor.d:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -100,7 +100,7 @@ amomin.d:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -118,11 +118,11 @@ amominu.d:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
-      <<: [*base_rs2val_sgn]
+      <<: [*base_rs2val_unsgn]
       abstract_comb:
-        <<: [*rs2val_walking]
+        <<: [*rs2val_walking_unsgn]
 
 amomax.d:
     config: 
@@ -136,7 +136,7 @@ amomax.d:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
       <<: [*base_rs2val_sgn]
       abstract_comb:
@@ -154,8 +154,8 @@ amomaxu.d:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: [*rfmt_op_comb]
+      <<: [*ramofmt_op_comb]
     val_comb:
-      <<: [*base_rs2val_sgn]
+      <<: [*base_rs2val_unsgn]
       abstract_comb:
-        <<: [*rs2val_walking]
+        <<: [*rs2val_walking_unsgn]

--- a/sample_cgfs/rv64ia.cgf
+++ b/sample_cgfs/rv64ia.cgf
@@ -120,9 +120,9 @@ amominu.w:
     op_comb: 
       <<: [*ramofmt_op_comb]
     val_comb:
-      <<: [*base_rs2val_unsgn]
+      <<: [*base_rs2val_sgn]
       abstract_comb:
-        <<: [*rs2val_walking_unsgn]
+        <<: [*rs2val_walking]
 
 amomax.w:
     config: 
@@ -156,9 +156,9 @@ amomaxu.w:
     op_comb: 
       <<: [*ramofmt_op_comb]
     val_comb:
-      <<: [*base_rs2val_unsgn]
+      <<: [*base_rs2val_sgn]
       abstract_comb:
-        <<: [*rs2val_walking_unsgn]
+        <<: [*rs2val_walking]
 
 amoadd.d:
     config: 
@@ -282,9 +282,9 @@ amominu.d:
     op_comb: 
       <<: [*ramofmt_op_comb]
     val_comb:
-      <<: [*base_rs2val_unsgn]
+      <<: [*base_rs2val_sgn]
       abstract_comb:
-        <<: [*rs2val_walking_unsgn]
+        <<: [*rs2val_walking]
 
 amomax.d:
     config: 
@@ -318,6 +318,6 @@ amomaxu.d:
     op_comb: 
       <<: [*ramofmt_op_comb]
     val_comb:
-      <<: [*base_rs2val_unsgn]
+      <<: [*base_rs2val_sgn]
       abstract_comb:
-        <<: [*rs2val_walking_unsgn]
+        <<: [*rs2val_walking]


### PR DESCRIPTION
This PR adds 

- The Template to generate tests for Atomic `A` instructions. (except for LR/SC instructions)
- Add cover group format (GCF) for `A` instructions. (except for LR/SC instructions)

Related riscv-arch-test suite PR: [#357](https://github.com/riscv-non-isa/riscv-arch-test/pull/357)