### PR TITLE
Added rfmt_op_comb conditions described in issue#306 of riscv-arch-test

### DIFF
--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -220,11 +220,16 @@ datasets:
 
   rfmt_op_comb: &rfmt_op_comb
     'rs1 == rs2 != rd': 0
-    'rs1 == rd != rs2': 0
+    "rs1 == rd != rs2 and rd == 'x0'": 0
+    "rs1 == rd != rs2 and rd != 'x0'": 0
     'rs2 == rd != rs1': 0
     'rs1 == rs2 == rd': 0
+    "rs1 == 'x0' != rd": 0
+    "rd == 'x0' != rs1": 0
     'rs1 != rs2  and rs1 != rd and rs2 != rd': 0
-    
+    "rd == 'x0' and rd != rs1" : 0
+    "rd == 'x0' and rd != rs2" : 0
+
   r4fmt_op_comb: &r4fmt_op_comb
     'rs1 == rs2 == rs3 == rd': 0
     'rs1 == rs2 == rs3 != rd': 0


### PR DESCRIPTION
Coverage changes for Div-01.S
(rd != rs; rd == x0) case added in dataset.cgf