### PR TITLE
Add unratified Zacas extension

### DIFF
--- a/riscv_ctg/cross_comb.py
+++ b/riscv_ctg/cross_comb.py
@@ -51,7 +51,8 @@ INSTR_FORMAT = {
     'pphrrformat' : '$instr $rd, $rs1, $rs2',
     'ppbrrformat' : '$instr $rd, $rs1, $rs2',
     'prrformat'   : '$instr ',
-    'prrrformat'  : '$instr'
+    'prrrformat'  : '$instr',
+    'dcasrformat'   : '$instr '
 }
 '''Dictionary to store instruction formats'''
 

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -5,6 +5,7 @@ metadata:
   all_regs_mx0: &all_regs_mx0 "['x'+str(x) for x in range(1,32 if 'e' not in base_isa else 16)]"
   c_regs: &c_regs "['x'+str(x) for x in range(8,16)]"
   pair_regs: &pair_regs "['x'+str(x) for x in range(2,32 if 'e' not in base_isa else 16, 2 if xlen == 32 else 1)]"
+  rv32rv64pair_regs: &rv32rv64pair_regs "['x'+str(x) for x in range(2,30 if 'e' not in base_isa else 16, 2)]"
 
 aes32dsi:
   sig:
@@ -10341,3 +10342,91 @@ czero.nez:
     // $comment
     // opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val;  op2val:$rs2_val
     TEST_RR_OP($inst, $rd, $rs1, $rs2, $correctval, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
+
+amocas.w:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [32,64]
+  std_op:
+  isa:
+    - IZacas
+  formattype: 'rformat'
+  rs1_op_data: *all_regs_mx0
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; dest:$rd; addr:$rs1; src:$rs2; swap_val:$rs2_val; swreg:$swreg; $offset
+    TEST_CAS_OP($inst, $rd, $rs1, $rs2, $rs2_val, $swreg, $offset);
+
+amocas.d_32:
+  sig:
+    stride: 2
+    sz: 'XLEN/8'
+  xlen: [32]
+  std_op:
+  isa:
+   - IZacas
+  bit_width: 64
+  dcas_profile: 'pnp'
+  formattype: 'dcasrformat'
+  rs1_op_data: *all_regs_mx0
+  rs2_op_data: *rv32rv64pair_regs
+  rd_op_data: *rv32rv64pair_regs
+  rs1_val_data: 'gen_sign_dataset(64)'
+  rs2_val_data: 'gen_sign_dataset(64)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; dest($rd, $rd_hi) addr:$rs1; src:($rs2, $rs2_hi); swap_val:($rs2_val, $rs2_val_hi); swreg:$swreg; $offset
+    TEST_DCAS_OP(amocas.d, $rd, $rd_hi, $rs1, $rs2, $rs2_hi, $rs2_val, $rs2_val_hi, $swreg, $offset);
+
+amocas.d_64:
+  sig:
+    stride: 1
+    sz: 'XLEN/8'
+  xlen: [64]
+  std_op:
+  isa:
+    - IZacas
+  formattype: 'rformat'
+  rs1_op_data: *all_regs_mx0
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; dest:$rd; addr:$rs1; src:$rs2; swap_val:$rs2_val; swreg:$swreg; $offset
+    TEST_CAS_OP(amocas.d, $rd, $rs1, $rs2, $rs2_val, $swreg, $offset);
+
+amocas.q:
+  sig:
+    stride: 2
+    sz: 'XLEN/8'
+  xlen: [64]
+  std_op:
+  isa:
+   - IZacas
+  bit_width: 128
+  dcas_profile: 'pnp'
+  formattype: 'dcasrformat'
+  rs1_op_data: *all_regs_mx0
+  rs2_op_data: *rv32rv64pair_regs
+  rd_op_data: *rv32rv64pair_regs
+  rs1_val_data: 'gen_sign_dataset(128)'
+  rs2_val_data: 'gen_sign_dataset(128)'
+
+  template: |-
+
+    // $comment
+    // opcode: $inst ; dest($rd, $rd_hi) addr:$rs1; src:($rs2, $rs2_hi); swap_val:($rs2_val, $rs2_val_hi), swreg:$swreg, $offset
+    TEST_DCAS_OP($inst, $rd, $rd_hi, $rs1, $rs2, $rs2_hi, $rs2_val, $rs2_val_hi, $swreg, $offset);

--- a/riscv_ctg/dsp_function.py
+++ b/riscv_ctg/dsp_function.py
@@ -175,9 +175,14 @@ def gen_pair_reg_data(instr_dict, xlen, _bit_width, p64_profile):
     else:
         bit_width1, bit_width2 = _bit_width, _bit_width
 
-    rs1_width = 64 if len(p64_profile) >= 3 and p64_profile[1]=='p' else xlen
-    rs2_width = 64 if len(p64_profile) >= 3 and p64_profile[2]=='p' else xlen
-    rd_width  = 64 if len(p64_profile) >= 3 and p64_profile[0]=='p' else xlen
+    if xlen == 32:
+        rs1_width = 64 if len(p64_profile) >= 3 and p64_profile[1]=='p' else xlen
+        rs2_width = 64 if len(p64_profile) >= 3 and p64_profile[2]=='p' else xlen
+        rd_width  = 64 if len(p64_profile) >= 3 and p64_profile[0]=='p' else xlen
+    else:
+        rs1_width = 128 if len(p64_profile) >= 3 and p64_profile[1]=='p' else xlen
+        rs2_width = 128 if len(p64_profile) >= 3 and p64_profile[2]=='p' else xlen
+        rd_width  = 128 if len(p64_profile) >= 3 and p64_profile[0]=='p' else xlen
 
     for instr in instr_dict:
         if 'rs1' in instr:

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -71,7 +71,8 @@ OPS = {
     'pphrrformat': ['rs1', 'rs2', 'rd'],
     'ppbrrformat': ['rs1', 'rs2', 'rd'],
     'prrformat': ['rs1', 'rs2', 'rd'],
-    'prrrformat': ['rs1', 'rs2', 'rs3', 'rd']
+    'prrrformat': ['rs1', 'rs2', 'rs3', 'rd'],
+    'dcasrformat': ['rs1', 'rs2', 'rd']
 }
 ''' Dictionary mapping instruction formats to operands used by those formats '''
 
@@ -117,7 +118,8 @@ VALS = {
     'pphrrformat': '["rs1_val"] + simd_val_vars("rs2", xlen, 16)',
     'ppbrrformat': '["rs1_val"] + simd_val_vars("rs2", xlen, 8)',
     'prrformat': '["rs1_val", "rs2_val"]',
-    'prrrformat': "['rs1_val', 'rs2_val' , 'rs3_val']"
+    'prrrformat': "['rs1_val', 'rs2_val' , 'rs3_val']",
+    'dcasrformat': '["rs1_val", "rs2_val"]'
 }
 ''' Dictionary mapping instruction formats to operand value variables used by those formats '''
 
@@ -868,6 +870,14 @@ class Generator():
             elif 'bit_width' in self.opnode:
                 concat_simd_data(final_instr, self.xlen, self.opnode['bit_width'])
 
+        '''
+        Zacas introduces double xlen cas operations that need paired source and destination registers
+        '''
+        if any('Zacas' in isa for isa in self.opnode['isa']):
+            if 'dcas_profile' in self.opnode:
+                gen_pair_reg_data(final_instr, self.xlen, self.opnode['bit_width'], self.opnode['dcas_profile'])
+
+
         return final_instr
 
     def valreg(self,instr_dict):
@@ -896,6 +906,9 @@ class Generator():
             if self.xlen == 32 and 'p64_profile' in self.opnode:
                 p64_profile = self.opnode['p64_profile']
                 paired_regs = self.opnode['p64_profile'].count('p')
+            if 'dcas_profile' in self.opnode:
+                dcas_profile = self.opnode['dcas_profile']
+                paired_regs = self.opnode['dcas_profile'].count('p')
 
             regset = e_regset if 'e' in self.base_isa else default_regset
             total_instr = len(instr_dict)
@@ -1016,6 +1029,9 @@ class Generator():
         if self.xlen == 32 and 'p64_profile' in self.opnode:
             p64_profile = self.opnode['p64_profile']
             paired_regs = self.opnode['p64_profile'].count('p')
+        if 'dcas_profile' in self.opnode:
+            dcas_profile = self.opnode['dcas_profile']
+            paired_regs = self.opnode['dcas_profile'].count('p')
 
         regset = e_regset if 'e' in self.base_isa else default_regset
         total_instr = len(instr_dict)
@@ -1102,6 +1118,9 @@ class Generator():
         if self.xlen == 32 and 'p64_profile' in self.opnode:
             p64_profile = self.opnode['p64_profile']
             paired_regs = p64_profile.count('p')
+        if 'dcas_profile' in self.opnode:
+            dcas_profile = self.opnode['dcas_profile']
+            paired_regs = dcas_profile.count('p')
 
         for instr in instr_dict:
             if 'rs1' in instr and instr['rs1'] in available_reg:
@@ -1154,6 +1173,11 @@ class Generator():
             if len(p64_profile) >= 3 and p64_profile[0]=='p':
                 for i in range(len(instr_dict)):
                     instr_dict[i]['correctval_hi'] = '0'
+        if 'dcas_profile' in self.opnode:
+            dcas_profile = self.opnode['dcas_profile']
+            if len(dcas_profile) >= 3 and dcas_profile[0]=='p':
+                for i in range(len(instr_dict)):
+                    instr_dict[i]['correctval_hi'] = '0'
         if self.fmt in ['caformat','crformat']:
             normalise = lambda x,y: 0 if y['rs1']=='x0' else x
         else:
@@ -1180,6 +1204,10 @@ class Generator():
         if any('IP' in isa for isa in self.opnode['isa']):
             # instr_dict is already in the desired format for instructions that perform SIMD operations, or Zpsfoperand instructions in RV32.
             if 'bit_width' in self.opnode or (self.xlen == 32 and 'p64_profile' in self.opnode):
+                return instr_dict
+        if any('Zacas' in isa for isa in self.opnode['isa']):
+            # instr_dict is already in the desired format for Zacas dcas instructions
+            if 'bit_width' in self.opnode or 'dcas_profile' in self.opnode:
                 return instr_dict
 
         for i in range(len(instr_dict)):
@@ -1259,9 +1287,10 @@ class Generator():
 
         if any('IP' in isa for isa in self.opnode['isa']):
             code.append("RVTEST_VXSAT_ENABLE()")
-
         if self.xlen == 32 and 'p64_profile' in self.opnode:
             p64_profile = self.opnode['p64_profile']
+        if 'dcas_profile' in self.opnode:
+            dcas_profile = self.opnode['dcas_profile']
 
         n = 0
         is_int_src = any([self.opcode.endswith(x) for x in ['.x','.w','.l','.wu','.lu']])

--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -488,3 +488,52 @@ datasets:
     'walking_ones("rs2_val", 64, signed=False)': 0
     'walking_zeros("rs2_val", 64, signed=False)': 0
     'alternate("rs2_val",64, signed=False)': 0
+
+  rvp128_rs1val_sgn: &rvp128_rs1val_sgn
+    'rs1_val == 0': 0
+    'rs1_val == 1': 0
+
+  rvp128_rs2val_sgn: &rvp128_rs2val_sgn
+    'rs2_val == 0': 0
+    'rs2_val == 1': 0
+
+  rvp128_rs1val_walking_sgn: &rvp128_rs1val_walking_sgn
+    'walking_ones("rs1_val", 128)': 0
+    'walking_zeros("rs1_val", 128)': 0
+    'alternate("rs1_val",128)': 0
+
+  rvp128_rs2val_walking_sgn: &rvp128_rs2val_walking_sgn
+    'walking_ones("rs2_val", 128)': 0
+    'walking_zeros("rs2_val", 128)': 0
+    'alternate("rs2_val",128)': 0
+
+  zacas_op_comb: &zacas_op_comb
+    'rs1 != rs2  and rs1 != rd and rs2 != rd': 0
+
+  zacas_dcas_rs1val_sgn: &zacas_dcas_rs1val_sgn
+    'rs1_val == 0': 0
+    'rs1_val == 1': 0
+
+  zacas_dcas_rs2val_sgn: &zacas_dcas_rs2val_sgn
+    'rs2_val == 0': 0
+    'rs2_val == 1': 0
+
+  zacas128_rs1val_walking_sgn: &zacas128_rs1val_walking_sgn
+    'walking_ones("rs1_val", 128)': 0
+    'walking_zeros("rs1_val", 128)': 0
+    'alternate("rs1_val",128)': 0
+
+  zacas128_rs2val_walking_sgn: &zacas128_rs2val_walking_sgn
+    'walking_ones("rs2_val", 128)': 0
+    'walking_zeros("rs2_val", 128)': 0
+    'alternate("rs2_val",128)': 0
+
+  zacas64_rs1val_walking_sgn: &zacas64_rs1val_walking_sgn
+    'walking_ones("rs1_val", 64)': 0
+    'walking_zeros("rs1_val", 64)': 0
+    'alternate("rs1_val",64)': 0
+
+  zacas64_rs2val_walking_sgn: &zacas64_rs2val_walking_sgn
+    'walking_ones("rs2_val", 64)': 0
+    'walking_zeros("rs2_val", 64)': 0
+    'alternate("rs2_val",64)': 0

--- a/sample_cgfs/rv32zacas.cgf
+++ b/sample_cgfs/rv32zacas.cgf
@@ -1,0 +1,36 @@
+# cover group format file for Zacas extension
+amocas.w:
+    config: 
+      - check ISA:=regex(.*Zacas.*)
+    opcode: 
+      amocas.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *zacas_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn, *base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+amocas.d_32:
+    config:
+      - check ISA:=regex(.*Zacas.*)
+    opcode:
+      amocas.d_32: 0
+    rs1:
+      <<: *all_regs_mx0
+    rs2:
+      <<: *pair_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *zacas_op_comb
+    val_comb:
+      <<: [*zacas_dcas_rs1val_sgn, *zacas_dcas_rs2val_sgn, *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*zacas64_rs1val_walking_sgn, *zacas64_rs2val_walking_sgn]

--- a/sample_cgfs/rv64zacas.cgf
+++ b/sample_cgfs/rv64zacas.cgf
@@ -1,0 +1,54 @@
+# cover group format file for Zacas extension
+amocas.w:
+    config: 
+      - check ISA:=regex(.*Zacas.*)
+    opcode: 
+      amocas.w: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *zacas_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn, *base_rs2val_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+amocas.d_64:
+    config: 
+      - check ISA:=regex(.*Zacas.*)
+    opcode: 
+      amocas.d_64: 0
+    rs1: 
+      <<: *all_regs_mx0
+    rs2: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *zacas_op_comb
+    val_comb:
+      <<: [*base_rs1val_sgn, *base_rs2val_sgn, *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*rs1val_walking, *rs2val_walking]
+
+amocas.q:
+    config:
+      - check ISA:=regex(.*Zacas.*)
+    opcode:
+      amocas.q: 0
+    rs1:
+      <<: *all_regs_mx0
+    rs2:
+      <<: *pair_regs
+    rd:
+      <<: *pair_regs
+    op_comb:
+      <<: *zacas_op_comb
+    val_comb:
+      <<: [*zacas_dcas_rs1val_sgn, *zacas_dcas_rs2val_sgn, *rfmt_val_comb_sgn]
+      abstract_comb:
+        <<: [*zacas128_rs1val_walking_sgn, *zacas128_rs2val_walking_sgn]


### PR DESCRIPTION
This PR adds support for the unratified fast-track Zacas extension that introduces the following instructions:
amocas.w for RV32 and RV64
amocas.d for RV32 and RV64
amocas.q for RV64 only
The specification is here: https://github.com/riscv/riscv-zacas