### PR TITLE
Missing Coverage for the Hardcoded register Test Cases added

### DIFF
--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -12,6 +12,7 @@ from math import *
 import struct
 import sys
 import itertools
+import re
 
 one_operand_finstructions = ["fsqrt.s","fmv.x.w","fcvt.wu.s","fcvt.w.s","fclass.s","fcvt.l.s","fcvt.lu.s","fcvt.s.l","fcvt.s.lu"]
 two_operand_finstructions = ["fadd.s","fsub.s","fmul.s","fdiv.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fsgnj.s","fsgnjn.s","fsgnjx.s"]
@@ -271,10 +272,15 @@ class Generator():
         to ensure that all those registers occur atleast once in the respective
         operand/destination location in the instruction. These contraints are
         then supplied to the solver for solutions
-
+        
         If randomization is enabled we use the ``MinConflictsSolver`` solver to
         find solutions.
 
+        If harcoded registers are given in the cgf file, then for the conditions other
+        than the first one, there will be No Solution. To solve that problem, some code
+        is written which will find the required register in the condition and generate the
+        solution normally.
+        
         :param cgf: a covergroup in cgf format containing the set of coverpoints to be satisfied.
 
         :type cgf: dict
@@ -324,6 +330,18 @@ class Generator():
             count = 0
             solution = problem.getSolution()
             while (solution is None and count < 5):
+                pattern = r'(?:rs1|rs2|rd) == "(x\d+)"'
+                matches = re.findall(pattern, cond)
+                if not matches or any(int(match[1:]) > 31 for match in matches):
+                    result = None
+                else:
+                    result = matches
+                    for match in result:
+                        op_conds['rs1'].add(match)
+                        op_conds['rs2'].add(match)
+                        op_conds['rd'].add(match)
+                    op_comb.add(cond)
+                    break
                 solution = problem.getSolution()
                 count = count + 1
             if solution is None:


### PR DESCRIPTION
This PR is a solution for the [issue#306](https://github.com/riscv-non-isa/riscv-arch-test/issues/306) opened in `riscv-arch-test` on Jan 9, 2023.
## Test Cases:
The test cases posted at that time were:
`Note`: **Always follow the following format for the hardcoded registers for proper generation of tests**
```
     'rs1 == rd != rs2; rd != "x0"': 0
     'rs1 == rd != rs2; rd == "x0"': 0
     'rs1 == "x0" != rd': 0
     'rd == "x0" != rs1': 0
```
## Problem
The main problem was that it had missing coverage. When we use `RISCV - Compliance Test Generator` for the above test cases, it does not generates the test for the second and third test case.
## Reason for the Problem
The reason for the problem was in the **op_comb** function of **`generator.py`**. In that function, there is condition for removal of the constraints after they are used once given as:
```
for key in self.op_vars:
     op_tuple.append(solution[key])
     op_conds[key].discard(solution[key])
```
So, when the solution for the first test case:
```
    'rs1 == rs2 == rd == "x0"': 0
```
is generated, then `x0` is removed from the **op_conds**, so when it traverses through the main while loop again, it fails to find the constraint for `x0` and hences fails for the solution of test case:
```
     'rs1 == "x0" != rd': 0
     'rd == "x0" != rs1': 0
```
and it results in `None Solution` and hence, **missing coverage**.

## Solution
The solution for this problem was to add the constraint `x0` or any specific register depending upon the test case.
Following code was added and `re library` was used.
```
            while (solution is None and count < 5):
                pattern = r'(?:rs1|rs2|rd) == "(x\d+)"'
                matches = re.findall(pattern, cond)
                if not matches or any(int(match[1:]) > 31 for match in matches):
                    result = None
                else:
                    result = matches
                    for match in result:
                        op_conds['rs1'].add(match)
                        op_conds['rs2'].add(match)
                        op_conds['rd'].add(match)
                    op_comb.add(cond)
                    break
                solution = problem.getSolution()
                count = count + 1
```
Now, when for the first time, it fails to generate the solution, it enters this while loop, if **legal test case** is added, then it will add the register constraint in the `op_conds` and then continue the function again.

This solves the problem and therefore, 100% coverage is achieved.