### PR TITLE
Adding the cover-points definition of the SV48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2023-11-02
+- Added the `vm_sv48.cfg` for coverpoint definations for SV48
+
 ## [0.11.1] - 2023-08-15
 - Fixed hex values handling for K extensions
 - Fixed set indexing error during opcomb gen

--- a/sample_cgfs/vm_sv48.cgf
+++ b/sample_cgfs/vm_sv48.cgf
@@ -1,0 +1,3249 @@
+
+# For Licence details look at https://github.com/riscv-software-src/riscv-ctg/-/blob/master/LICENSE.incore
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C6)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_09:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_10:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_11:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_12:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_13: 
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D6)): 0                   # checks the PTE permission and level1 at which PTE is stored  
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_14:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_15:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_pte_16: 
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D6)): 0                   # checks the PTE permission and level1 at which PTE is stored  
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x087)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x087)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x087)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x087)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x087)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x087)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x087)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x087)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_09:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x097)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_10:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x097)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_11:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x097)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_12:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x097)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_13: 
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x097)): 0                   # checks the PTE permission and level1 at which PTE is stored  
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_14:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x097)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_15:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x097)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_access_bit_16: 
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x097)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C5)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0CD)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C5)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0CD)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C5)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0CD)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C5)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0CD)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_09:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D5)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_10:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0DD)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_11:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D5)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_12:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0DD)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_13: 
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D5)): 0                   # checks the PTE permission and level1 at which PTE is stored  
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_14:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0DD)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_15:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D5)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+RWX_reserved_16: 
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0DD)): 0                   # checks the PTE permission and level1 at which PTE is stored  
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------  
+
+pte_u_bit_set_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_set_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_set_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_set_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_set_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault    
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_set_06: 
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored  
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_set_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_set_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_set_09:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_set_10:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_set_11:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_set_12:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *---------------------------------------------------------------------------------------------------------------------- 
+
+pte_u_bit_unset_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault    
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_unset_02: 
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level1 at which PTE is stored  
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_unset_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_unset_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_unset_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_unset_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_unset_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_u_bit_unset_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------  
+
+dirty_bit_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault   
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x047)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit_02: 
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault 
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x047)): 0                   # checks the PTE permission and level1 at which PTE is stored  
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault 
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x047)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault 
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x047)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x057)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x057)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x057)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x057)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0x0FF) == 0x0C7) and (((rs2_val & 0X7FC00) != 0x0))): 0   # checks the PTE permission of level1 and that ppn0!=0 (misaligned) at which PTE is stored 
+                                                                                                
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0x0FF) == 0x0C9) and (((rs2_val & 0X7FC00) != 0x0))): 0  # checks the PTE permission of level1 and that ppn0!=0 (misaligned) at which PTE is stored 
+                                                                                                
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0x0FF) == 0x0C7) and (((rs2_val & 0XFFFFC00) != 0x0))): 0  # checks the PTE permission at level2 and that ppn0 & ppn1!=0 (misaligned) at which PTE is stored
+                                                                                                 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0x0FF) == 0x0C9) and (((rs2_val & 0XFFFFC00) != 0x0))): 0  # checks the PTE permission at level2 and that ppn0 & ppn1!=0 (misaligned) at which PTE is stored
+                                                                                               
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000009) and ((rs2_val & 0x0FF) == 0x0C7) and (((rs2_val & 0X1FFFFFFC00) != 0x0))): 0  # checks the PTE permission,level3 and that ppn0 ,ppn1 & ppn2!=0 (misaligned) at which PTE is stored 
+                                                                                                
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000009) and ((rs2_val & 0x0FF) == 0x0C9) and (((rs2_val & 0X1FFFFFFC00) != 0x0))): 0  # checks the PTE permission,level3 and that ppn0 ,ppn1 & ppn2!=0 (misaligned) at which PTE is stored 
+                                                                                                
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0x0FF) == 0x0D7) and (((rs2_val & 0X7FC00) != 0x0))): 0   # checks the PTE permission of level1 and that ppn0!=0 (misaligned) at which PTE is stored 
+                                                                                                
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0x0FF) == 0xD9) and (((rs2_val & 0X7FC00) != 0x0))): 0  # checks the PTE permission of level1 and that ppn0!=0 (misaligned) at which PTE is stored 
+                                                                                                
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage_09:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0x0FF) == 0x0D7) and (((rs2_val & 0XFFFFC00) != 0x0))): 0  # checks the PTE permission at level2 and that ppn0 & ppn1!=0 (misaligned) at which PTE is stored
+                                                                                                 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage_10:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0x0FF) == 0x0D9) and (((rs2_val & 0XFFFFC00) != 0x0))): 0  # checks the PTE permission at level2 and that ppn0 & ppn1!=0 (misaligned) at which PTE is stored
+                                                                                               
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage_11:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000009) and ((rs2_val & 0x0FF) == 0x0D7) and (((rs2_val & 0X1FFFFFFC00) != 0x0))): 0  # checks the PTE permission,level3 and that ppn0 ,ppn1 & ppn2!=0 (misaligned) at which PTE is stored 
+                                                                                                
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage_12:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000009) and ((rs2_val & 0x0FF) == 0x0D9) and (((rs2_val & 0X1FFFFFFC00) != 0x0))): 0  # checks the PTE permission,level3 and that ppn0 ,ppn1 & ppn2!=0 (misaligned) at which PTE is stored 
+                                                                                                
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_set_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x40000: 0                                                           # checks the mstatus.SUM == 1
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_set_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x40000: 0                                                           # checks the mstatus.SUM == 1
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_set_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x40000: 0                                                           # checks the mstatus.SUM == 1
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_set_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x40000: 0                                                           # checks the mstatus.SUM == 1
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_set_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x40000: 0                                                           # checks the mstatus.SUM == 1
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_set_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x40000: 0                                                           # checks the mstatus.SUM == 1
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_set_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x40000: 0                                                           # checks the mstatus.SUM == 1
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_set_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x40000: 0                                                           # checks the mstatus.SUM == 1
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_unset_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x00000: 0                                                           # checks the mstatus.SUM == 0
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_unset_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x00000: 0                                                           # checks the mstatus.SUM == 0
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_unset_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x00000: 0                                                           # checks the mstatus.SUM == 0
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_unset_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x00000: 0                                                           # checks the mstatus.SUM == 0
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_unset_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x00000: 0                                                           # checks the mstatus.SUM == 0
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_unset_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x00000: 0                                                           # checks the mstatus.SUM == 0
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_unset_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x00000: 0                                                           # checks the mstatus.SUM == 0
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pte_sum_unset_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x40000) == 0x00000: 0                                                           # checks the mstatus.SUM == 0
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x80000) == 0x00000: 0                                                           # checks the mstatus.MXR == 0
+    val_comb:
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x80000) == 0x00000: 0                                                           # checks the mstatus.MXR == 0
+    val_comb:
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x80000) == 0x00000: 0                                                           # checks the mstatus.MXR == 0
+    val_comb:
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x80000) == 0x00000: 0                                                           # checks the mstatus.MXR == 0
+    val_comb:
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+      (mstatus & 0x80000) == 0x00000: 0                                                           # checks the mstatus.MXR == 0
+    val_comb:
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+      (mstatus & 0x80000) == 0x00000: 0                                                           # checks the mstatus.MXR == 0
+    val_comb:
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+      (mstatus & 0x80000) == 0x00000: 0                                                           # checks the mstatus.MXR == 0
+    val_comb:
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+      (mstatus & 0x80000) == 0x00000: 0                                                           # checks the mstatus.MXR == 0
+    val_comb:
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+      (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+      (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+      (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+      (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+      (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+rwx_access_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+rwx_access_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+rwx_access_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+rwx_access_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val != 0xF): 0                                                                         # check if the rs2 does not matches the "store/AMO page fault
+      (rs2_val != 0xD): 0                                                                         # check if the rs2 does not matches the "load page fault
+      (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+rwx_access_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+rwx_access_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+rwx_access_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+rwx_access_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+rwx_access_09:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+rwx_access_10:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+rwx_access_11:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+rwx_access_12:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+non_leaf_pte_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+non_leaf_pte_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+non_leaf_pte_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+non_leaf_pte_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+non_leaf_pte_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+non_leaf_pte_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored       
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+non_leaf_pte_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+non_leaf_pte_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+non_leaf_pte_09:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+non_leaf_pte_10:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+non_leaf_pte_11: 
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+      (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored  
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+non_leaf_pte_12:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 : 0                                                                     # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+      (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr3 << 2)) and (rs1_val <= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr2 << 2)) and (rs1_val <= (pmpaddr2 << 2)) and ((pmpcfg0 & 0xFF0000) >> 16 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr2, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)  
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr2 << 2)) and ((pmpcfg0 & 0xFF0000) >> 16 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr2, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr1 << 2)) and (rs1_val <= (pmpaddr1 << 2)) and ((pmpcfg0 & 0xFF00) >> 8 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr1, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions) 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr1 << 2)) and ((pmpcfg0 & 0xFF00) >> 8 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr1, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions) 
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000008) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr4 << 2)) and (rs1_val <= (pmpaddr4 << 2)) and ((pmpcfg0 & 0xFF00000000) >> 32 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr4, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions) 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000008) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr4 << 2)) and ((pmpcfg0 & 0xFF00000000) >> 32 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr4, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions) 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_09:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr3 << 2)) and (rs1_val <= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_10:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_11:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr2 << 2)) and (rs1_val <= (pmpaddr2 << 2)) and ((pmpcfg0 & 0xFF0000) >> 16 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr2, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_12:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr2 << 2)) and ((pmpcfg0 & 0xFF0000) >> 16 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr2, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_13:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr1 << 2)) and (rs1_val <= (pmpaddr1 << 2)) and ((pmpcfg0 & 0xFF00) >> 8 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr1, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions) 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_14:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr1 << 2)) and ((pmpcfg0 & 0xFF00) >> 8 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr1, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions) 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_15:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000008) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr4 << 2)) and (rs1_val <= (pmpaddr4 << 2)) and ((pmpcfg0 & 0xFF00000000) >> 32 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr4, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions) 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte_16:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000008) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr4 << 2)) and ((pmpcfg0 & 0xFF00000000) >> 32 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr4, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions) 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_01:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_02:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr0 << 2)) and ((pmpcfg0 & 0xFF) == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_03:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions) 
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_04:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr0 << 2)) and ((pmpcfg0 & 0xFF) == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_05:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_06:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr0 << 2)) and ((pmpcfg0 & 0xFF) == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions) 
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_07:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_08:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800) == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                       # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr0 << 2)) and ((pmpcfg0 & 0xFF) == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_09:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_10:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr0 << 2)) and ((pmpcfg0 & 0xFF) == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_11:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_12:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr0 << 2)) and ((pmpcfg0 & 0xFF) == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_13:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_14:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr0 << 2)) and ((pmpcfg0 & 0xFF) == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions) 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_15:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+      (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+      (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa_16:
+    config:
+      - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+    mnemonics:
+      csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+      csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+      sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csr_comb:
+      (satp >> 60) == 0x9 and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv48 mode.
+      (mstatus & 0x1800)  == 0x0000 : 0                                                           # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    val_comb:
+      (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+      (((rs1_val >> 12 ) == 0x80000000008) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+      (rs1_val >= (pmpaddr0 << 2)) and ((pmpcfg0 & 0xFF) == 0x18): 0
+                                                                                                  # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                  # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+
+


### PR DESCRIPTION
Hi All,

This PR adds cover-point definitions for the set of self-checking assembly tests for the architectural verification of MMU SV39, These cover-points are hand-written and follows the test plan provided in the following [test-plan](https://docs.google.com/spreadsheets/d/1lJkbxCG268DHq8oeltyxMbUAf7iLQurFJhLDnbPn0gM/edit#gid=1303473646).

For a more comprehensive understanding of code coverage and verification results, please consult the generated report accessible through the provided [coverage report link](https://htmlpreview.github.io/?https://github.com/HAMZA-AFZAL404/riscv-ctg/blob/Coverage/Coverage_Report/coverage.html)

Best regards,
Hamza Afzal