### PR TITLE
Fix template.yaml for compressed bitmanip instructions, Remove print statements from generator.py, Add corner case for division operations, Fix OpComb for amocas.d_32 and amocas.q

### DIFF
--- a/riscv_ctg/data/imc.yaml
+++ b/riscv_ctg/data/imc.yaml
@@ -744,6 +744,7 @@ sd:
   ea_align_data: '[0,1,2,3,4,5,6,7]'
   rs2_val_data: 'gen_sign_dataset(xlen)'
   imm_val_data: 'gen_sign_dataset(12)'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   template: |-
 
     // $comment
@@ -763,6 +764,7 @@ sw:
   formattype: 'sformat'
   ea_align_data: '[0,1,2,3]'
   rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   imm_val_data: 'gen_sign_dataset(12)'
   template: |-
 
@@ -783,6 +785,7 @@ sh:
   formattype: 'sformat'
   ea_align_data: '[0,1,2,3]'
   rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   imm_val_data: 'gen_sign_dataset(12)'
   template: |-
 
@@ -803,6 +806,7 @@ sb:
   formattype: 'sformat'
   ea_align_data: '[0,1,2,3]'
   rs2_val_data: 'gen_sign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   imm_val_data: 'gen_sign_dataset(12)'
   template: |-
 
@@ -823,6 +827,7 @@ ld:
   formattype: 'iformat'
   ea_align_data: '[0,1,2,3,4,5,6,7]'
   imm_val_data: 'gen_sign_dataset(12)'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   template: |-
 
     // $comment
@@ -842,6 +847,7 @@ lwu:
   formattype: 'iformat'
   ea_align_data: '[0,1,2,3]'
   imm_val_data: 'gen_sign_dataset(12)'
+  rs1_val_data: 'gen_usign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   template: |-
 
     // $comment
@@ -860,6 +866,7 @@ lw:
     - I
   formattype: 'iformat'
   ea_align_data: '[0,1,2,3]'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   imm_val_data: 'gen_sign_dataset(12)'
   template: |-
 
@@ -879,6 +886,7 @@ lhu:
     - I
   formattype: 'iformat'
   ea_align_data: '[0,1,2,3]'
+  rs1_val_data: 'gen_usign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   imm_val_data: 'gen_sign_dataset(12)'
   template: |-
 
@@ -898,6 +906,7 @@ lh:
     - I
   formattype: 'iformat'
   ea_align_data: '[0,1,2,3]'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   imm_val_data: 'gen_sign_dataset(12)'
   template: |-
 
@@ -918,6 +927,7 @@ lbu:
   formattype: 'iformat'
   ea_align_data: '[0,1,2,3]'
   imm_val_data: 'gen_sign_dataset(12)'
+  rs1_val_data: 'gen_usign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   template: |-
 
     // $comment
@@ -937,6 +947,7 @@ lb:
   formattype: 'iformat'
   ea_align_data: '[0,1,2,3]'
   imm_val_data: 'gen_sign_dataset(12)'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   template: |-
 
     // $comment
@@ -973,6 +984,7 @@ jalr:
     - I
   formattype: 'iformat'
   ea_align_data: '[0,1,2,3]'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen,True)'
   imm_val_data: 'gen_sign_dataset(12)'
   template: |-
 

--- a/riscv_ctg/data/imc.yaml
+++ b/riscv_ctg/data/imc.yaml
@@ -1077,7 +1077,7 @@ div:
     - IM
   formattype: 'rformat'
   operation:  'hex(int(abs(rs1_val)//abs(rs2_val))) if (rs1_val * rs2_val > 0) else hex(-int(abs(rs1_val)//abs(rs2_val))) if rs2_val != 0 else "0x"+("F"*int(xlen/4))'
-  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True) + 0x8000000000000000'
+  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   template: |-
 

--- a/riscv_ctg/data/imc.yaml
+++ b/riscv_ctg/data/imc.yaml
@@ -1595,6 +1595,7 @@ c.li:
   formattype: 'ciformat'
   operation : 'hex(sign_extend(imm_val,6))'
   imm_val_data: 'gen_sign_dataset(6)'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen)'
   template: |-
 
     // $comment
@@ -1709,6 +1710,7 @@ c.lwsp:
     - IC
   formattype: 'ciformat'
   imm_val_data: '[x*4 for x in gen_usign_dataset(6)]'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen)'
   template: |-
 
     // $comment
@@ -1830,6 +1832,7 @@ c.jal:
     - IC
   formattype: 'cbformat'
   imm_val_data: 'list(filter(lambda x: (x >=4 and x<2030) if x>0 else (x<=-4 and x> -2030 ),[x*2 for x in gen_sign_dataset(11)]))'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen)'
   template: |-
 
     // $comment
@@ -1846,11 +1849,13 @@ c.jr:
   isa: 
     - IC
   formattype: 'crformat'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen)'
   template: |-
 
     // $comment
-    // opcode: c.jr; op1:$rs1
-    TEST_CJR_OP($testreg, $rs1, $swreg, $offset)
+    // opcode: c.jr; op1:$rs1; op2:$rs2; op1val:$rs1_val; op2val:$rs2_val
+    TEST_CJR_OP($testreg, $rs1, $rs2, $swreg, $offset)
 
 c.jalr:
   sig:
@@ -1862,9 +1867,11 @@ c.jalr:
   isa: 
     - IC
   formattype: 'crformat'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen)'
   template: |-
 
     // $comment
-    // opcode:c.jalr; op1:$rs1
-    TEST_CJALR_OP($testreg, $rs1, $swreg, $offset)
+    // opcode: c.jr; op1:$rs1; op2:$rs2; op1val:$rs1_val; op2val:$rs2_val
+    TEST_CJR_OP($testreg, $rs1, $rs2, $swreg, $offset)
 

--- a/riscv_ctg/data/imc.yaml
+++ b/riscv_ctg/data/imc.yaml
@@ -1077,7 +1077,7 @@ div:
     - IM
   formattype: 'rformat'
   operation:  'hex(int(abs(rs1_val)//abs(rs2_val))) if (rs1_val * rs2_val > 0) else hex(-int(abs(rs1_val)//abs(rs2_val))) if rs2_val != 0 else "0x"+("F"*int(xlen/4))'
-  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True) + 0x8000000000000000'
   rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   template: |-
 

--- a/riscv_ctg/data/imc.yaml
+++ b/riscv_ctg/data/imc.yaml
@@ -1854,8 +1854,8 @@ c.jr:
   template: |-
 
     // $comment
-    // opcode: c.jr; op1:$rs1; op2:$rs2; op1val:$rs1_val; op2val:$rs2_val
-    TEST_CJR_OP($testreg, $rs1, $rs2, $swreg, $offset)
+    // opcode: c.jr; op1:$rs1
+    TEST_CJR_OP($testreg, $rs1, $swreg, $offset)
 
 c.jalr:
   sig:
@@ -1872,6 +1872,6 @@ c.jalr:
   template: |-
 
     // $comment
-    // opcode: c.jr; op1:$rs1; op2:$rs2; op1val:$rs1_val; op2val:$rs2_val
-    TEST_CJR_OP($testreg, $rs1, $rs2, $swreg, $offset)
+    // opcode: c.jalr; op1:$rs1
+    TEST_CJALR_OP($testreg, $rs1, $swreg, $offset)
 

--- a/riscv_ctg/data/imc.yaml
+++ b/riscv_ctg/data/imc.yaml
@@ -1077,7 +1077,7 @@ div:
     - IM
   formattype: 'rformat'
   operation:  'hex(int(abs(rs1_val)//abs(rs2_val))) if (rs1_val * rs2_val > 0) else hex(-int(abs(rs1_val)//abs(rs2_val))) if rs2_val != 0 else "0x"+("F"*int(xlen/4))'
-  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True) + [-(2**(xlen-1))]'
   rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   template: |-
 
@@ -1120,7 +1120,7 @@ rem:
   formattype: 'rformat'
   #  operation: 'hex(rs1_val if rs2_val==0 or (rs1_val<rs2_val and rs2_val<0) else (rs1_val % rs2_val) & (2**(xlen)-1))'
   operation: 'hex(rs1_val) if rs2_val == 0 else hex(int(abs(rs1_val) % abs(rs2_val))) if rs1_val > 0 else hex(-int(abs(rs1_val) % abs(rs2_val)))'
-  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True) + [-(2**(xlen-1))]'
   rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   template: |-
 

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -708,6 +708,8 @@ aes64ks1i:
   formattype: 'iformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  imm_val_data: 'gen_usign_dataset(ceil(log(xlen,2)))'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -836,6 +836,8 @@ rolw:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -10732,8 +10732,8 @@ amocas.w:
     - IZacas
   formattype: 'rformat'
   rs1_op_data: *all_regs_mx0
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
   rs1_val_data: 'gen_sign_dataset(xlen)'
   rs2_val_data: 'gen_sign_dataset(xlen)'
 
@@ -10755,8 +10755,8 @@ amocas.d_32:
   dcas_profile: 'pnp'
   formattype: 'dcasrformat'
   rs1_op_data: *all_regs_mx0
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
   rs1_val_data: 'gen_sign_dataset(64)'
   rs2_val_data: 'gen_sign_dataset(64)'
 
@@ -10776,8 +10776,8 @@ amocas.d_64:
     - IZacas
   formattype: 'rformat'
   rs1_op_data: *all_regs_mx0
-  rs2_op_data: *all_regs
-  rd_op_data: *all_regs
+  rs2_op_data: *pair_regs
+  rd_op_data: *pair_regs
   rs1_val_data: 'gen_sign_dataset(xlen)'
   rs2_val_data: 'gen_sign_dataset(xlen)'
 

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -15,6 +15,9 @@ aes32dsi:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
   xlen: [32]
   std_op:
   isa: 
@@ -35,6 +38,9 @@ aes32dsmi:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
   xlen: [32]
   std_op:
   isa: 
@@ -55,6 +61,9 @@ aes32esi:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
   xlen: [32]
   std_op:
   isa: 
@@ -75,6 +84,9 @@ aes32esmi:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
   xlen: [32]
   std_op:
   isa: 
@@ -95,6 +107,9 @@ sm4ed:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
   xlen: [32,64]
   std_op:
   isa: 
@@ -114,6 +129,9 @@ sm4ks:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
   xlen: [32,64]
   std_op:
   isa: 

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -9,7 +9,6 @@ metadata:
 
 aes32dsi:
   sig:
-    sig:
     stride: 1
     sz: 'XLEN/8'
   rs1_op_data: *all_regs

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -836,8 +836,8 @@ rolw:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
-  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
-  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs1_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
+  rs2_val_data: 'gen_sign_dataset(xlen) + gen_sp_dataset(xlen,True)'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -10842,7 +10842,7 @@ c.sb:
   template: |-
 
     // $comment
-    // opcode:$inst; op1:$rs1; op2:$rs2; op2val:$rs2_val; immval:$imm_val
+    // opcode: $inst; op1:$rs1; op2:$rs2; op2val:$rs2_val; immval:$imm_val
     TEST_STORE($swreg,$testreg,$index,$rs1,$rs2,$rs2_val,$imm_val,$offset,$inst,0)
 
 c.sh:
@@ -10862,7 +10862,7 @@ c.sh:
   template: |-
 
     // $comment
-    // opcode:$inst; op1:$rs1; op2:$rs2; op2val:$rs2_val; immval:$imm_val
+    // opcode: $inst; op1:$rs1; op2:$rs2; op2val:$rs2_val; immval:$imm_val
     TEST_STORE($swreg,$testreg,$index,$rs1,$rs2,$rs2_val,$imm_val,$offset,$inst,0)
 
 c.sext.b:
@@ -10877,7 +10877,7 @@ c.sext.b:
   rs1_op_data: *c_regs
   rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
   template: |-
- 
+
     // $comment
     // opcode: $inst ; op1=dest:$rs1 ; op1val:$rs1_val;
     TEST_CRD_OP($inst, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
@@ -10894,7 +10894,7 @@ c.sext.h:
   rs1_op_data: *c_regs
   rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)+[65408]'
   template: |-
- 
+
     // $comment
     // opcode: $inst ; op1=dest:$rs1 ; op1val:$rs1_val;
     TEST_CRD_OP($inst, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
@@ -10911,7 +10911,7 @@ c.zext.b:
   rs1_op_data: *c_regs
   rs1_val_data: 'gen_usign_dataset(xlen)+[128]'
   template: |-
- 
+
     // $comment
     // opcode: $inst ; op1=dest:$rs1 ; op1val:$rs1_val;
     TEST_CRD_OP($inst, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
@@ -10928,7 +10928,7 @@ c.zext.h:
   rs1_op_data: *c_regs
   rs1_val_data: 'gen_usign_dataset(xlen)+[65408]'
   template: |-
- 
+
     // $comment
     // opcode: $inst ; op1=dest:$rs1 ; op1val:$rs1_val;
     TEST_CRD_OP($inst, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
@@ -10945,7 +10945,7 @@ c.zext.w:
   rs1_op_data: *c_regs
   rs1_val_data: 'gen_usign_dataset(xlen)+[65408]'
   template: |-
- 
+
     // $comment
     // opcode: $inst ; op1=dest:$rs1 ; op1val:$rs1_val;
     TEST_CRD_OP($inst, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)
@@ -10962,7 +10962,7 @@ c.not:
   rs1_op_data: *c_regs
   rs1_val_data: 'gen_usign_dataset(xlen)+[65408]'
   template: |-
- 
+
     // $comment
     // opcode: $inst ; op1=dest:$rs1 ; op1val:$rs1_val;
     TEST_CRD_OP($inst, $rs1, $correctval, $rs1_val, $swreg, $offset, $testreg)

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -521,6 +521,8 @@ pack:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
   template: |-
 
     // $comment
@@ -560,6 +562,8 @@ packh:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
   template: |-
 
     // $comment
@@ -616,6 +620,8 @@ aes64ds:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
   template: |-
 
     // $comment
@@ -636,6 +642,8 @@ aes64dsm:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
   template: |-
 
     // $comment
@@ -656,6 +664,8 @@ aes64es:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
   template: |-
 
     // $comment
@@ -676,6 +686,8 @@ aes64esm:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
   template: |-
 
     // $comment
@@ -899,6 +911,8 @@ packw:
   rs1_op_data: *all_regs
   rs2_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -2574,6 +2574,7 @@ bclri:
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_val_data: 'zerotoxlen(xlen)+[-1]'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
   template: |-
 
     // $comment
@@ -2682,6 +2683,7 @@ bexti:
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_val_data: 'zerotoxlen(xlen)+gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
   template: |-
 
     // $comment
@@ -2792,6 +2794,7 @@ binvi:
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_val_data: 'zerotoxlen(xlen)+gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
   template: |-
 
     // $comment
@@ -10131,6 +10134,7 @@ bseti:
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
   rs1_val_data: 'zerotoxlen(xlen)'
+  imm_val_data: 'gen_imm_dataset(ceil(log(xlen,2)))'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -10713,8 +10713,8 @@ amocas.d_32:
   dcas_profile: 'pnp'
   formattype: 'dcasrformat'
   rs1_op_data: *all_regs_mx0
-  rs2_op_data: *rv32rv64pair_regs
-  rd_op_data: *rv32rv64pair_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
   rs1_val_data: 'gen_sign_dataset(64)'
   rs2_val_data: 'gen_sign_dataset(64)'
 
@@ -10757,8 +10757,8 @@ amocas.q:
   dcas_profile: 'pnp'
   formattype: 'dcasrformat'
   rs1_op_data: *all_regs_mx0
-  rs2_op_data: *rv32rv64pair_regs
-  rd_op_data: *rv32rv64pair_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
   rs1_val_data: 'gen_sign_dataset(128)'
   rs2_val_data: 'gen_sign_dataset(128)'
 

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -472,6 +472,7 @@ zip:
   formattype: 'kformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
   template: |-
 
     // $comment
@@ -495,6 +496,7 @@ unzip:
   formattype: 'kformat'
   rs1_op_data: *all_regs
   rd_op_data: *all_regs
+  rs1_val_data: 'gen_sign_dataset(xlen)+gen_usign_dataset(xlen)'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -6668,7 +6668,9 @@ uradd64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 kadd64:
-  stride: 3
+  sig:
+    stride: 3
+    sz: 'XLEN/8'
   xlen: [32,64]
   std_op:
   isa: 
@@ -6689,7 +6691,9 @@ kadd64:
     TEST_PK64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $rs1, $swreg, $offset, $testreg)
 
 ukadd64:
-  stride: 3
+  sig:
+    stride: 3
+    sz: 'XLEN/8'
   xlen: [32,64]
   std_op:
   isa: 
@@ -6779,7 +6783,9 @@ ursub64:
     TEST_P64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $swreg, $offset, $testreg)
 
 ksub64:
-  stride: 3
+  sig:
+    stride: 3
+    sz: 'XLEN/8'
   xlen: [32,64]
   std_op:
   isa: 
@@ -6800,7 +6806,9 @@ ksub64:
     TEST_PK64_PPP_OP($inst, $rd, $rd_hi, $rs1, $rs1_hi, $rs2, $rs2_hi, $correctval, $correctval_hi, $rs1_val, $rs1_val_hi, $rs2_val, $rs2_val_hi, $rs1, $swreg, $offset, $testreg)
 
 uksub64:
-  stride: 3
+  sig:
+    stride: 3
+    sz: 'XLEN/8'
   xlen: [32,64]
   std_op:
   isa: 
@@ -6923,7 +6931,9 @@ umsr64:
     TEST_P64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $swreg, $offset, $testreg)
 
 kmar64:
-  stride: 3
+  sig:
+    stride: 3
+    sz: 'XLEN/8'
   xlen: [32,64]
   std_op:
   isa: 
@@ -6946,7 +6956,9 @@ kmar64:
     TEST_PK64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $rs1, $swreg, $offset, $testreg)
 
 kmsr64:
-  stride: 3
+  sig:
+    stride: 3
+    sz: 'XLEN/8'
   xlen: [32,64]
   std_op:
   isa: 
@@ -6969,7 +6981,9 @@ kmsr64:
     TEST_PK64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $rs1, $swreg, $offset, $testreg)
 
 ukmar64:
-  stride: 3
+  sig:
+    stride: 3
+    sz: 'XLEN/8'
   xlen: [32,64]
   std_op:
   isa: 
@@ -6992,7 +7006,9 @@ ukmar64:
     TEST_PK64_PNN_OP($inst, $rd, $rd_hi, $rs1, $rs2, $correctval, $correctval_hi, $rs1_val, $rs2_val, $rs1, $swreg, $offset, $testreg)
 
 ukmsr64:
-  stride: 3
+  sig:
+    stride: 3
+    sz: 'XLEN/8'
   xlen: [32,64]
   std_op:
   isa: 

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -1254,14 +1254,14 @@ class Generator():
                 if 'val' in field and field != 'correctval' and field != 'valaddr_reg' and \
                     field != 'val_section' and field != 'val_offset' and field != 'rm_val':
                     value = (instr_dict[i][field]).strip()
-                    print(value)
+                    #print(value)
                     if '0x' in value:
                         value = '0x' + value[2:].zfill(int(self.xlen/4))
                         value = struct.unpack(size, bytes.fromhex(value[2:]))[0]
                     else:
                         value = int(value)
 #                    value = '0x' + struct.pack(size,value).hex()
-                    print("test",hex(value))
+                    #print("test",hex(value))
                     instr_dict[i][field] = hex(value)
         return instr_dict
 

--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -293,6 +293,9 @@ datasets:
     'rs1_val < 0 and rs2_val > 0': 0
     'rs1_val == rs2_val': 0
     'rs1_val != rs2_val': 0
+
+  div_corner_case: &div_corner_case
+    'rs1_val == -(2**(xlen-1)) and rs2_val == -0x01': 0
   
   rfmt_val_comb_unsgn: &rfmt_val_comb_unsgn
     'rs1_val > 0 and rs2_val > 0': 0

--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -293,9 +293,6 @@ datasets:
     'rs1_val < 0 and rs2_val > 0': 0
     'rs1_val == rs2_val': 0
     'rs1_val != rs2_val': 0
-
-  div_corner_case: &div_corner_case
-    'rs1_val == -0x8000000000000000 and rs2_val == -0x01': 0
   
   rfmt_val_comb_unsgn: &rfmt_val_comb_unsgn
     'rs1_val > 0 and rs2_val > 0': 0

--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -291,9 +291,11 @@ datasets:
     'rs1_val > 0 and rs2_val < 0': 0
     'rs1_val < 0 and rs2_val < 0': 0
     'rs1_val < 0 and rs2_val > 0': 0
-    'rs1_val == -0x8000000000000000 and rs2_val == -0x01': 0
     'rs1_val == rs2_val': 0
     'rs1_val != rs2_val': 0
+
+  div_corner_case: &div_corner_case
+    'rs1_val == -0x8000000000000000 and rs2_val == -0x01': 0
   
   rfmt_val_comb_unsgn: &rfmt_val_comb_unsgn
     'rs1_val > 0 and rs2_val > 0': 0

--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -251,12 +251,22 @@ datasets:
   sfmt_op_comb: &sfmt_op_comb
     'rs1 == rs2': 0
     'rs1 != rs2': 0
+
+  r0fmt_op_comb: &r0fmt_op_comb
+    'rs1 == 0': 0
+    'rs1 != 0': 0
   
   base_rs1val_sgn: &base_rs1val_sgn
     'rs1_val == (-2**(xlen-1))': 0
     'rs1_val == 0': 0
     'rs1_val == (2**(xlen-1)-1)': 0
     'rs1_val == 1': 0
+
+  base_rs1val_sgn_rs2val_zero: &base_rs1val_sgn_rs2val_zero
+    'rs1_val == (-2**(xlen-1)) and rs2_val == 0': 0
+    'rs1_val == 0 and rs2_val == 0': 0
+    'rs1_val == (2**(xlen-1)-1) and rs2_val == 0': 0
+    'rs1_val == 1 and rs2_val == 0': 0
   
   base_rs2val_sgn: &base_rs2val_sgn
     'rs2_val == (-2**(xlen-1))': 0

--- a/sample_cgfs/rv32e_b.cgf
+++ b/sample_cgfs/rv32e_b.cgf
@@ -138,10 +138,10 @@ clz:
     val_comb:
       abstract_comb:
         <<: [*rs1val_walking_unsgn]
-        'leading_zeros("rs1_val", xlen, False)': 0
-        'leading_ones("rs1_val", xlen, False)': 0
-        'trailing_zeros("rs1_val", xlen, False)': 0
-        'trailing_ones("rs1_val", xlen, False)': 0
+        'leading_zeros(xlen, ["rs1_val"], [xlen], 11)': 0
+        'leading_ones(xlen, ["rs1_val"], [xlen], 10)': 0
+        'trailing_zeros(xlen, ["rs1_val"], [xlen], 12)': 0
+        'trailing_ones(xlen, ["rs1_val"], [xlen], 13)': 0
 
 ctz:
     config: 
@@ -157,10 +157,10 @@ ctz:
     val_comb:
       abstract_comb:
         <<: [*rs1val_walking_unsgn]
-        'leading_zeros("rs1_val", xlen, False)': 0
-        'leading_ones("rs1_val", xlen, False)': 0
-        'trailing_zeros("rs1_val", xlen, False)': 0
-        'trailing_ones("rs1_val", xlen, False)': 0
+        'leading_zeros(xlen, ["rs1_val"], [xlen], 11)': 0
+        'leading_ones(xlen, ["rs1_val"], [xlen], 10)': 0
+        'trailing_zeros(xlen, ["rs1_val"], [xlen], 12)': 0
+        'trailing_ones(xlen, ["rs1_val"], [xlen], 13)': 0
         
 cpop:
     config: 
@@ -176,10 +176,10 @@ cpop:
     val_comb:
       abstract_comb:
         <<: [*rs1val_walking_unsgn]
-        'leading_zeros("rs1_val", xlen, False)': 0
-        'leading_ones("rs1_val", xlen, False)': 0
-        'trailing_zeros("rs1_val", xlen, False)': 0
-        'trailing_ones("rs1_val", xlen, False)': 0
+        'leading_zeros(xlen, ["rs1_val"], [xlen], 11)': 0
+        'leading_ones(xlen, ["rs1_val"], [xlen], 10)': 0
+        'trailing_zeros(xlen, ["rs1_val"], [xlen], 12)': 0
+        'trailing_ones(xlen, ["rs1_val"], [xlen], 13)': 0
         
 max:
     config: 
@@ -537,8 +537,8 @@ bclr:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'xlenlim("rs1_val", xlen)': 0
-        'xlenlim("rs2_val", xlen )': 0
+#        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs2_val", xlen )': 0
         'walking_ones("rs1_val", ceil(log(xlen, 2)), False)': 0
         'walking_ones("rs2_val", ceil(log(xlen, 2)), False)': 0
         'leading_ones(32, ["rs1_val", "rs2_val"], [32,5])': 0
@@ -561,7 +561,7 @@ bclri:
       <<: *ifmt_op_comb
     val_comb:
       abstract_comb:      
-        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs1_val", xlen)': 0
         'leading_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'trailing_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'leading_zeros(32, ["rs1_val", "imm_val"], [32,5])': 0
@@ -583,8 +583,8 @@ bext:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'xlenlim("rs1_val", xlen)': 0
-        'xlenlim("rs2_val", xlen )': 0
+#        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs2_val", xlen )': 0
         'walking_ones("rs1_val", ceil(log(xlen, 2)), False)': 0
         'walking_ones("rs2_val", ceil(log(xlen, 2)), False)': 0
         'leading_ones(32, ["rs1_val", "rs2_val"], [32,5])': 0
@@ -607,7 +607,7 @@ bexti:
       <<: *ifmt_op_comb
     val_comb:
       abstract_comb:      
-        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs1_val", xlen)': 0
         'leading_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'trailing_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'leading_zeros(32, ["rs1_val", "imm_val"], [32,5])': 0
@@ -629,8 +629,8 @@ binv:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'xlenlim("rs1_val", xlen)': 0
-        'xlenlim("rs2_val", xlen )': 0
+#        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs2_val", xlen )': 0
         'walking_ones("rs1_val", ceil(log(xlen, 2)), False)': 0
         'walking_ones("rs2_val", ceil(log(xlen, 2)), False)': 0
         'leading_ones(32, ["rs1_val", "rs2_val"], [32,5])': 0
@@ -653,7 +653,7 @@ binvi:
       <<: *ifmt_op_comb
     val_comb:
       abstract_comb:      
-        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs1_val", xlen)': 0
         'leading_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'trailing_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'leading_zeros(32, ["rs1_val", "imm_val"], [32,5])': 0
@@ -674,8 +674,8 @@ bset:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'xlenlim("rs1_val", xlen)': 0
-        'xlenlim("rs2_val", xlen )': 0
+#        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs2_val", xlen )': 0
         'walking_ones("rs1_val", ceil(log(xlen, 2)), False)': 0
         'walking_ones("rs2_val", ceil(log(xlen, 2)), False)': 0
         'leading_ones(32, ["rs1_val", "rs2_val"], [32,5])': 0
@@ -698,7 +698,7 @@ bseti:
       <<: *ifmt_op_comb
     val_comb:
       abstract_comb:      
-        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs1_val", xlen)': 0
         'leading_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'trailing_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'leading_zeros(32, ["rs1_val", "imm_val"], [32,5])': 0

--- a/sample_cgfs/rv32ec.cgf
+++ b/sample_cgfs/rv32ec.cgf
@@ -136,38 +136,7 @@ clui:
   opcode: 
     c.lui: 0
   rd:
-    x0: 0
-    x1: 0
-    x3: 0
-    x4: 0
-    x5: 0
-    x6: 0
-    x7: 0
-    x8: 0
-    x9: 0
-    x10: 0
-    x11: 0
-    x12: 0
-    x13: 0
-    x14: 0
-    x15: 0
-    x16: 0
-    x17: 0
-    x18: 0
-    x19: 0
-    x20: 0
-    x21: 0
-    x22: 0
-    x23: 0
-    x24: 0
-    x25: 0
-    x26: 0
-    x27: 0
-    x28: 0
-    x29: 0
-    x30: 0
-    x31: 0
-
+    <<: *rv32e_regs_mx2
   val_comb:
     'rs1_val > 0 and imm_val > 32': 0
     'rs1_val > 0 and imm_val < 32 and imm_val !=0 ': 0
@@ -401,6 +370,13 @@ cjr:
     c.jr: 0
   rs1:
     <<: *rv32e_regs_mx0
+  op_comb:
+    <<: *sfmt_op_comb
+  val_comb:
+    <<: *base_rs1val_sgn_rs2val_zero
+    abstract_comb:
+      'sp_dataset(xlen)': 0
+      <<: *rs1val_walking
 
 cmv:
     config: 
@@ -444,6 +420,13 @@ cjalr:
     c.jalr: 0
   rs1:
     <<: *rv32e_regs_mx0
+  op_comb:
+    <<: *sfmt_op_comb
+  val_comb:
+    <<: *base_rs1val_sgn_rs2val_zero
+    abstract_comb:
+      'sp_dataset(xlen)': 0
+      <<: *rs1val_walking
 
 cswsp:
     config: 
@@ -461,4 +444,3 @@ cswsp:
           'walking_ones("imm_val",6,False, scale_func = lambda x: x*4)': 0
           'walking_zeros("imm_val",6,False, scale_func = lambda x: x*4)': 0
           'alternate("imm_val",6, False,scale_func = lambda x: x*4)': 0
-

--- a/sample_cgfs/rv32i_b.cgf
+++ b/sample_cgfs/rv32i_b.cgf
@@ -138,10 +138,10 @@ clz:
     val_comb:
       abstract_comb:
         <<: [*rs1val_walking_unsgn]
-        'leading_zeros("rs1_val", xlen, False)': 0
-        'leading_ones("rs1_val", xlen, False)': 0
-        'trailing_zeros("rs1_val", xlen, False)': 0
-        'trailing_ones("rs1_val", xlen, False)': 0
+        'leading_zeros(xlen, ["rs1_val"], [xlen], 11)': 0
+        'leading_ones(xlen, ["rs1_val"], [xlen], 10)': 0
+        'trailing_zeros(xlen, ["rs1_val"], [xlen], 12)': 0
+        'trailing_ones(xlen, ["rs1_val"], [xlen], 13)': 0
 
 ctz:
     config: 
@@ -157,10 +157,10 @@ ctz:
     val_comb:
       abstract_comb:
         <<: [*rs1val_walking_unsgn]
-        'leading_zeros("rs1_val", xlen, False)': 0
-        'leading_ones("rs1_val", xlen, False)': 0
-        'trailing_zeros("rs1_val", xlen, False)': 0
-        'trailing_ones("rs1_val", xlen, False)': 0
+        'leading_zeros(xlen, ["rs1_val"], [xlen], 11)': 0
+        'leading_ones(xlen, ["rs1_val"], [xlen], 10)': 0
+        'trailing_zeros(xlen, ["rs1_val"], [xlen], 12)': 0
+        'trailing_ones(xlen, ["rs1_val"], [xlen], 13)': 0
         
 cpop:
     config: 
@@ -176,10 +176,10 @@ cpop:
     val_comb:
       abstract_comb:
         <<: [*rs1val_walking_unsgn]
-        'leading_zeros("rs1_val", xlen, False)': 0
-        'leading_ones("rs1_val", xlen, False)': 0
-        'trailing_zeros("rs1_val", xlen, False)': 0
-        'trailing_ones("rs1_val", xlen, False)': 0
+        'leading_zeros(xlen, ["rs1_val"], [xlen], 11)': 0
+        'leading_ones(xlen, ["rs1_val"], [xlen], 10)': 0
+        'trailing_zeros(xlen, ["rs1_val"], [xlen], 12)': 0
+        'trailing_ones(xlen, ["rs1_val"], [xlen], 13)': 0
         
 max:
     config: 
@@ -537,8 +537,8 @@ bclr:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'xlenlim("rs1_val", xlen)': 0
-        'xlenlim("rs2_val", xlen )': 0
+#        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs2_val", xlen )': 0
         'walking_ones("rs1_val", ceil(log(xlen, 2)), False)': 0
         'walking_ones("rs2_val", ceil(log(xlen, 2)), False)': 0
         'leading_ones(32, ["rs1_val", "rs2_val"], [32,5])': 0
@@ -561,7 +561,7 @@ bclri:
       <<: *ifmt_op_comb
     val_comb:
       abstract_comb:      
-        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs1_val", xlen)': 0
         'leading_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'trailing_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'leading_zeros(32, ["rs1_val", "imm_val"], [32,5])': 0
@@ -583,8 +583,8 @@ bext:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'xlenlim("rs1_val", xlen)': 0
-        'xlenlim("rs2_val", xlen )': 0
+#        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs2_val", xlen )': 0
         'walking_ones("rs1_val", ceil(log(xlen, 2)), False)': 0
         'walking_ones("rs2_val", ceil(log(xlen, 2)), False)': 0
         'leading_ones(32, ["rs1_val", "rs2_val"], [32,5])': 0
@@ -607,7 +607,7 @@ bexti:
       <<: *ifmt_op_comb
     val_comb:
       abstract_comb:      
-        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs1_val", xlen)': 0
         'leading_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'trailing_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'leading_zeros(32, ["rs1_val", "imm_val"], [32,5])': 0
@@ -629,8 +629,8 @@ binv:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'xlenlim("rs1_val", xlen)': 0
-        'xlenlim("rs2_val", xlen )': 0
+#        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs2_val", xlen )': 0
         'walking_ones("rs1_val", ceil(log(xlen, 2)), False)': 0
         'walking_ones("rs2_val", ceil(log(xlen, 2)), False)': 0
         'leading_ones(32, ["rs1_val", "rs2_val"], [32,5])': 0
@@ -653,7 +653,7 @@ binvi:
       <<: *ifmt_op_comb
     val_comb:
       abstract_comb:      
-        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs1_val", xlen)': 0
         'leading_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'trailing_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'leading_zeros(32, ["rs1_val", "imm_val"], [32,5])': 0
@@ -674,8 +674,8 @@ bset:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'xlenlim("rs1_val", xlen)': 0
-        'xlenlim("rs2_val", xlen )': 0
+#        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs2_val", xlen )': 0
         'walking_ones("rs1_val", ceil(log(xlen, 2)), False)': 0
         'walking_ones("rs2_val", ceil(log(xlen, 2)), False)': 0
         'leading_ones(32, ["rs1_val", "rs2_val"], [32,5])': 0
@@ -698,7 +698,7 @@ bseti:
       <<: *ifmt_op_comb
     val_comb:
       abstract_comb:      
-        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs1_val", xlen)': 0
         'leading_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'trailing_ones(32, ["rs1_val", "imm_val"], [32,5])': 0
         'leading_zeros(32, ["rs1_val", "imm_val"], [32,5])': 0

--- a/sample_cgfs/rv32i_zcb.cgf
+++ b/sample_cgfs/rv32i_zcb.cgf
@@ -147,6 +147,8 @@ cnot:
       c.not: 0
     rs1: 
       <<: *c_regs
+    op_comb:
+      <<: *r0fmt_op_comb
     val_comb:
       'rs1_val == 0': 0
       'rs1_val == 0x800': 0

--- a/sample_cgfs/rv32ic.cgf
+++ b/sample_cgfs/rv32ic.cgf
@@ -401,6 +401,13 @@ cjr:
     c.jr: 0
   rs1:
     <<: *all_regs_mx0
+  op_comb:
+    <<: *sfmt_op_comb
+  val_comb:
+    <<: *base_rs1val_sgn_rs2val_zero
+    abstract_comb:
+      'sp_dataset(xlen)': 0
+      <<: *rs1val_walking
 
 cmv:
     config: 
@@ -444,6 +451,13 @@ cjalr:
     c.jalr: 0
   rs1:
     <<: *all_regs_mx0
+  op_comb:
+    <<: *sfmt_op_comb
+  val_comb:
+    <<: *base_rs1val_sgn_rs2val_zero
+    abstract_comb:
+      'sp_dataset(xlen)': 0
+      <<: *rs1val_walking
 
 cswsp:
     config: 

--- a/sample_cgfs/rv32im.cgf
+++ b/sample_cgfs/rv32im.cgf
@@ -91,7 +91,7 @@ div:
     op_comb: 
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn, *div_corner_case]
       abstract_comb:
         'sp_dataset(xlen)': 0
         <<: [*rs1val_walking, *rs2val_walking]
@@ -129,7 +129,7 @@ rem:
     op_comb: 
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn, *div_corner_case]
       abstract_comb:
         'sp_dataset(xlen)': 0
         <<: [*rs1val_walking, *rs2val_walking]

--- a/sample_cgfs/rv32im.cgf
+++ b/sample_cgfs/rv32im.cgf
@@ -91,7 +91,7 @@ div:
     op_comb: 
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn, *div_corner_case]
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
       abstract_comb:
         'sp_dataset(xlen)': 0
         <<: [*rs1val_walking, *rs2val_walking]

--- a/sample_cgfs/rv32im.cgf
+++ b/sample_cgfs/rv32im.cgf
@@ -91,7 +91,7 @@ div:
     op_comb: 
       <<: *rfmt_op_comb
     val_comb:
-      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn]
+      <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn, *div_corner_case]
       abstract_comb:
         'sp_dataset(xlen)': 0
         <<: [*rs1val_walking, *rs2val_walking]

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -4004,11 +4004,11 @@ kslraw.u:
     op_comb:
       <<: *rfmt_op_comb
     val_comb:
+      'rs1_w0_val == rs2_w0_val': 0
+      'rs1_w0_val != rs2_w0_val': 0
       abstract_comb:
         'simd_base_val("rs1", xlen, 32, signed=False)': 0
         'simd_base_val("rs2", xlen, 32, signed=True)': 0
-        'rs1_val == rs2_val': 0
-        'rs1_val != rs2_val': 0
 
 ksllw:
     config:

--- a/sample_cgfs/rv32zacas.cgf
+++ b/sample_cgfs/rv32zacas.cgf
@@ -7,9 +7,9 @@ amocas.w:
     rs1: 
       <<: *all_regs_mx0
     rs2: 
-      <<: *all_regs
+      <<: *pair_regs
     rd: 
-      <<: *all_regs
+      <<: *pair_regs
     op_comb: 
       <<: *zacas_op_comb
     val_comb:

--- a/sample_cgfs/rv64i_b.cgf
+++ b/sample_cgfs/rv64i_b.cgf
@@ -234,10 +234,10 @@ clz:
     val_comb:
       abstract_comb:
         <<: [*rs1val_walking_unsgn]
-        'leading_zeros("rs1_val", xlen, False)': 0
-        'leading_ones("rs1_val", xlen, False)': 0
-        'trailing_zeros("rs1_val", xlen, False)': 0
-        'trailing_ones("rs1_val", xlen, False)': 0
+        'leading_zeros(xlen, ["rs1_val"], [xlen], 11)': 0
+        'leading_ones(xlen, ["rs1_val"], [xlen], 10)': 0
+        'trailing_zeros(xlen, ["rs1_val"], [xlen], 12)': 0
+        'trailing_ones(xlen, ["rs1_val"], [xlen], 13)': 0
 
         
 clzw:
@@ -254,10 +254,10 @@ clzw:
     val_comb:
       abstract_comb:
         <<: [*rs1val_walking_unsgn]
-        'leading_zeros("rs1_val", xlen, False)': 0
-        'leading_ones("rs1_val", xlen, False)': 0
-        'trailing_zeros("rs1_val", xlen, False)': 0
-        'trailing_ones("rs1_val", xlen, False)': 0
+        'leading_zeros(xlen, ["rs1_val"], [xlen], 11)': 0
+        'leading_ones(xlen, ["rs1_val"], [xlen], 10)': 0
+        'trailing_zeros(xlen, ["rs1_val"], [xlen], 12)': 0
+        'trailing_ones(xlen, ["rs1_val"], [xlen], 13)': 0
         
 ctz:
     config: 
@@ -273,10 +273,10 @@ ctz:
     val_comb:
       abstract_comb:
         <<: [*rs1val_walking_unsgn]
-        'leading_zeros("rs1_val", xlen, False)': 0
-        'leading_ones("rs1_val", xlen, False)': 0
-        'trailing_zeros("rs1_val", xlen, False)': 0
-        'trailing_ones("rs1_val", xlen, False)': 0
+        'leading_zeros(xlen, ["rs1_val"], [xlen], 11)': 0
+        'leading_ones(xlen, ["rs1_val"], [xlen], 10)': 0
+        'trailing_zeros(xlen, ["rs1_val"], [xlen], 12)': 0
+        'trailing_ones(xlen, ["rs1_val"], [xlen], 13)': 0
         
 ctzw:
     config: 
@@ -292,10 +292,10 @@ ctzw:
     val_comb:
       abstract_comb:
         <<: [*rs1val_walking_unsgn]
-        'leading_zeros("rs1_val", xlen, False)': 0
-        'leading_ones("rs1_val", xlen, False)': 0
-        'trailing_zeros("rs1_val", xlen, False)': 0
-        'trailing_ones("rs1_val", xlen, False)': 0
+        'leading_zeros(xlen, ["rs1_val"], [xlen], 11)': 0
+        'leading_ones(xlen, ["rs1_val"], [xlen], 10)': 0
+        'trailing_zeros(xlen, ["rs1_val"], [xlen], 12)': 0
+        'trailing_ones(xlen, ["rs1_val"], [xlen], 13)': 0
 
         
 cpop:
@@ -312,10 +312,10 @@ cpop:
     val_comb:
       abstract_comb:
         <<: [*rs1val_walking_unsgn]
-        'leading_zeros("rs1_val", xlen, False)': 0
-        'leading_ones("rs1_val", xlen, False)': 0
-        'trailing_zeros("rs1_val", xlen, False)': 0
-        'trailing_ones("rs1_val", xlen, False)': 0
+        'leading_zeros(xlen, ["rs1_val"], [xlen], 11)': 0
+        'leading_ones(xlen, ["rs1_val"], [xlen], 10)': 0
+        'trailing_zeros(xlen, ["rs1_val"], [xlen], 12)': 0
+        'trailing_ones(xlen, ["rs1_val"], [xlen], 13)': 0
         
 cpopw:
     config: 
@@ -331,10 +331,10 @@ cpopw:
     val_comb:
       abstract_comb:
         <<: [*rs1val_walking_unsgn]
-        'leading_zeros("rs1_val", xlen, False)': 0
-        'leading_ones("rs1_val", xlen, False)': 0
-        'trailing_zeros("rs1_val", xlen, False)': 0
-        'trailing_ones("rs1_val", xlen, False)': 0
+        'leading_zeros(xlen, ["rs1_val"], [xlen], 11)': 0
+        'leading_ones(xlen, ["rs1_val"], [xlen], 10)': 0
+        'trailing_zeros(xlen, ["rs1_val"], [xlen], 12)': 0
+        'trailing_ones(xlen, ["rs1_val"], [xlen], 13)': 0
         
 max:
     config: 
@@ -764,8 +764,8 @@ bclr:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'xlenlim("rs1_val", xlen)': 0
-        'xlenlim("rs2_val", xlen )': 0
+#        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs2_val", xlen )': 0
         'walking_ones("rs1_val", ceil(log(xlen, 2)), False)': 0
         'walking_ones("rs2_val", ceil(log(xlen, 2)), False)': 0
         'leading_ones(64, ["rs1_val", "rs2_val"], [32,5])': 0
@@ -788,7 +788,7 @@ bclri:
       <<: *ifmt_op_comb
     val_comb:
       abstract_comb:      
-        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs1_val", xlen)': 0
         'leading_ones(64, ["rs1_val", "imm_val"], [32,5])': 0
         'trailing_ones(64, ["rs1_val", "imm_val"], [32,5])': 0
         'leading_zeros(64, ["rs1_val", "imm_val"], [32,5])': 0
@@ -810,8 +810,8 @@ bext:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'xlenlim("rs1_val", xlen)': 0
-        'xlenlim("rs2_val", xlen )': 0
+#        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs2_val", xlen )': 0
         'walking_ones("rs1_val", ceil(log(xlen, 2)), False)': 0
         'walking_ones("rs2_val", ceil(log(xlen, 2)), False)': 0
         'leading_ones(64, ["rs1_val", "rs2_val"], [32,5])': 0
@@ -834,7 +834,7 @@ bexti:
       <<: *ifmt_op_comb
     val_comb:
       abstract_comb:      
-        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs1_val", xlen)': 0
         'leading_ones(64, ["rs1_val", "imm_val"], [32,5])': 0
         'trailing_ones(64, ["rs1_val", "imm_val"], [32,5])': 0
         'leading_zeros(64, ["rs1_val", "imm_val"], [32,5])': 0
@@ -856,8 +856,8 @@ binv:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'xlenlim("rs1_val", xlen)': 0
-        'xlenlim("rs2_val", xlen )': 0
+#        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs2_val", xlen )': 0
         'walking_ones("rs1_val", ceil(log(xlen, 2)), False)': 0
         'walking_ones("rs2_val", ceil(log(xlen, 2)), False)': 0
         'leading_ones(64, ["rs1_val", "rs2_val"], [32,5])': 0
@@ -880,7 +880,7 @@ binvi:
       <<: *ifmt_op_comb
     val_comb:
       abstract_comb:      
-        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs1_val", xlen)': 0
         'leading_ones(64, ["rs1_val", "imm_val"], [32,5])': 0
         'trailing_ones(64, ["rs1_val", "imm_val"], [32,5])': 0
         'leading_zeros(64, ["rs1_val", "imm_val"], [32,5])': 0
@@ -901,8 +901,8 @@ bset:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:
-        'xlenlim("rs1_val", xlen)': 0
-        'xlenlim("rs2_val", xlen )': 0
+#        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs2_val", xlen )': 0
         'walking_ones("rs1_val", ceil(log(xlen, 2)), False)': 0
         'walking_ones("rs2_val", ceil(log(xlen, 2)), False)': 0
         'leading_ones(64, ["rs1_val", "rs2_val"], [32,5])': 0
@@ -926,7 +926,7 @@ bseti:
       <<: *ifmt_op_comb
     val_comb:
       abstract_comb:      
-        'xlenlim("rs1_val", xlen)': 0
+#        'xlenlim("rs1_val", xlen)': 0
         'leading_ones(64, ["rs1_val", "imm_val"], [32,5])': 0
         'trailing_ones(64, ["rs1_val", "imm_val"], [32,5])': 0
         'leading_zeros(64, ["rs1_val", "imm_val"], [32,5])': 0

--- a/sample_cgfs/rv64i_k.cgf
+++ b/sample_cgfs/rv64i_k.cgf
@@ -140,8 +140,9 @@ xperm8:
       <<: *rfmt_op_comb
     val_comb:
       abstract_comb:      
-        'uniform_random(20, 100, ["rs1_val","rs2_val"], [64, 64],False)': 0
-        'walikng_ones(64, ["rs1_val","rs2_val"], [64,64])': 0
+        'uniform_random(20, 100, ["rs1_val","rs2_val"], [64, 64])': 0
+        'walking_ones("rs1_val", 64, False)': 0
+        'walking_ones("rs2_val", 64, False)': 0
         'trailing_ones(64, ["rs1_val","rs2_val"], [64,64],False)': 0
         'leading_zeros(64, ["rs1_val","rs2_val"], [64,64],False)': 0
         'trailing_zeros(64, ["rs1_val","rs2_val"], [64,64],False)': 0

--- a/sample_cgfs/rv64i_zcb.cgf
+++ b/sample_cgfs/rv64i_zcb.cgf
@@ -162,6 +162,8 @@ cnot:
       c.not: 0
     rs1: 
       <<: *c_regs
+    op_comb:
+      <<: *r0fmt_op_comb
     val_comb:
       'rs1_val == 0': 0
       'rs1_val == 0x800': 0

--- a/sample_cgfs/rv64ic.cgf
+++ b/sample_cgfs/rv64ic.cgf
@@ -493,6 +493,13 @@ cjr:
     c.jr: 0
   rs1:
     <<: *all_regs_mx0
+  op_comb:
+    <<: *sfmt_op_comb
+  val_comb:
+    <<: *base_rs1val_sgn_rs2val_zero
+    abstract_comb:
+      'sp_dataset(xlen)': 0
+      <<: *rs1val_walking
 
 cmv:
     config: 
@@ -536,7 +543,14 @@ cjalr:
     c.jalr: 0
   rs1:
     <<: *all_regs_mx0
-
+  op_comb:
+    <<: *sfmt_op_comb
+  val_comb:
+    <<: *base_rs1val_sgn_rs2val_zero
+    abstract_comb:
+      'sp_dataset(xlen)': 0
+      <<: *rs1val_walking
+      
 cswsp:
     config: 
       - check ISA:=regex(.*I.*C.*)

--- a/sample_cgfs/rv64zacas.cgf
+++ b/sample_cgfs/rv64zacas.cgf
@@ -7,9 +7,9 @@ amocas.w:
     rs1: 
       <<: *all_regs_mx0
     rs2: 
-      <<: *all_regs
+      <<: *pair_regs
     rd: 
-      <<: *all_regs
+      <<: *pair_regs
     op_comb: 
       <<: *zacas_op_comb
     val_comb:
@@ -25,9 +25,9 @@ amocas.d_64:
     rs1: 
       <<: *all_regs_mx0
     rs2: 
-      <<: *all_regs
+      <<: *pair_regs
     rd: 
-      <<: *all_regs
+      <<: *pair_regs
     op_comb: 
       <<: *zacas_op_comb
     val_comb:


### PR DESCRIPTION
1. Running the dev branch gave a yaml scanner error- fixed indentations in template.yaml
2. Removed random print statements from generator.py
3. Solution for the corner case of division was not found- replaced 0x8000000000000000 with  -(2**(XLEN-1)) in dataset.cgf and also added it to rs1_val_data in imc.yaml
4. Corner case of division was added to all rfmt_op_comb which was tested for other instructions apart from division- removed the case from rfmt_op_comb, added a new covergroup with this case to test div and rem instructions only
5. Solution for Op Combination could not be found for amocas.d_32 and amocas.q instructions in the Zacas extension- replaced rv32rv64pair_regs with all_regs for rs2_op_data and rd_op_data in template.yaml
6. rv32ic.cgf did not write tests for c.jr and c.jalr instructions- added op_comb and val_comb for these instructions in rv32ic.cgf
7. rv32i_zcb.cgf did not write tests for the cnot instruction- added op_comb for cnot in rv32i_zcb.cgf
8. rs1_val was not defined for [c.li](http://c.li/), c.lwsp, c.jal, c.jr, c,jalr- added rs1_val_data for these instructions in imc.yaml