### PR TITLE
Add yaml file for CI, other fixes

### DIFF
--- a/.github/workflows/test-1.yml
+++ b/.github/workflows/test-1.yml
@@ -1,0 +1,80 @@
+name: test-1
+on:
+  pull_request:
+    branches:
+        -master
+        -dev
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+  
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r riscv_ctg/requirements.txt
+          pip install --editable .
+          
+
+      - name: Run RISC-V CTG for all CGF files except FP
+        run: |
+          set -e
+          for cgf_file in ./sample_cgfs/*.cgf; do
+          if [ "$cgf_file" != "./sample_cgfs/dataset.cgf" ]; then
+              if [[ "$cgf_file" == *rv32e* ]]; then
+                cmd="riscv_ctg -r -d ./tests -bi rv32e -cf sample_cgfs/dataset.cgf -cf \"$cgf_file\" -v warning -p \$(nproc)"
+                echo $cmd
+                eval $cmd || { echo "Error executing command: $cmd"; exit 1; }
+              elif [[ "$cgf_file" == *rv32* && "$cgf_file" != *rv32e* ]]; then
+                cmd="riscv_ctg -r -d ./tests -bi rv32i -cf sample_cgfs/dataset.cgf -cf \"$cgf_file\" -v warning -p \$(nproc)"
+                echo $cmd
+                eval $cmd || { echo "Error executing command: $cmd"; exit 1; }
+              elif [[ "$cgf_file" == *rv64* ]]; then
+                cmd="riscv_ctg -r -d ./tests -bi rv64i -cf sample_cgfs/dataset.cgf -cf \"$cgf_file\" -v warning -p \$(nproc)"
+                echo $cmd
+                eval $cmd || { echo "Error executing command: $cmd"; exit 1; }
+              else
+                for arch in rv32i rv64i; do
+                  cmd="riscv_ctg -r -d ./tests -bi $arch -cf sample_cgfs/dataset.cgf -cf \"$cgf_file\" -v warning -p \$(nproc)"
+                  echo $cmd
+                  eval $cmd || { echo "Error executing command: $cmd"; exit 1; }
+                done
+              fi
+          fi
+          done
+
+  check-version:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: version check
+        run: |
+          export CHNGVER=$(grep -P -o '(?<=## \[).*(?=\])' -m1 CHANGELOG.md); 
+          echo "CHANGELOG VERSION: $CHNGVER"
+          export INITVER=$(grep -P "__version__ = '.*?'" riscv_ctg/__init__.py | awk '{print $3}'|sed "s/'//g"); 
+          echo "INIT VERSION: $INITVER"
+          if [ "$CHNGVER" = "$INITVER" ]; then
+              echo "Versions are equal in Changelog and init.py."
+          else
+              echo "Versions are not equal in Changelog and init.py."
+          exit 1
+          fi
+          export TAGVER=${{ steps.get-latest-tag.outputs.tag }}; 
+          echo "TAG VERSION: $TAGVER"
+          if [ "$CHNGVER" = "$TAGVER" ]; then
+              echo "No changelog update."
+              exit 1
+          else
+              echo "Changelog updated."
+          fi
+
+       

--- a/.github/workflows/test-1.yml
+++ b/.github/workflows/test-1.yml
@@ -1,4 +1,4 @@
-name: test-2
+name: test-1
 on:
   pull_request:
     branches:

--- a/.github/workflows/test-1.yml
+++ b/.github/workflows/test-1.yml
@@ -1,4 +1,4 @@
-name: test-1
+name: test-2
 on:
   pull_request:
     branches:
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            cgf_files: ["./sample_cgfs/*.cgf"]
+            architecture: ["rv32e", "rv32i", "rv64i", "rv32i_64i"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -23,24 +27,51 @@ jobs:
           pip install --editable .
           
 
-      - name: Run RISC-V CTG for all CGF files except FP
+      - name: Run RISC-V CTG for RV32E
         run: |
           set -e
           for cgf_file in ./sample_cgfs/*.cgf; do
           if [ "$cgf_file" != "./sample_cgfs/dataset.cgf" ]; then
-              if [[ "$cgf_file" == *rv32e* ]]; then
+              if [[ "$cgf_file" == *rv32e* ]] && [ "${{matrix.architecture}}" == "rv32e" ] ; then
                 cmd="riscv_ctg -r -d ./tests -bi rv32e -cf sample_cgfs/dataset.cgf -cf \"$cgf_file\" -v warning -p \$(nproc)"
                 echo $cmd
                 eval $cmd || { echo "Error executing command: $cmd"; exit 1; }
-              elif [[ "$cgf_file" == *rv32* && "$cgf_file" != *rv32e* ]]; then
+              fi
+          fi
+          done
+
+      - name: Run RISC-V CTG for RV32I
+        run: |
+          set -e
+          for cgf_file in ./sample_cgfs/*.cgf; do
+          if [ "$cgf_file" != "./sample_cgfs/dataset.cgf" ]; then
+              if [[ "$cgf_file" != *rv32e* ]] && [[ "cgf_file" == *rv32* ]] && [ "${{matrix.architecture}}" == "rv32i" ] ; then
                 cmd="riscv_ctg -r -d ./tests -bi rv32i -cf sample_cgfs/dataset.cgf -cf \"$cgf_file\" -v warning -p \$(nproc)"
                 echo $cmd
                 eval $cmd || { echo "Error executing command: $cmd"; exit 1; }
-              elif [[ "$cgf_file" == *rv64* ]]; then
+              fi
+          fi
+          done
+
+      - name: Run RISC-V CTG for RV64I
+        run: |
+          set -e
+          for cgf_file in ./sample_cgfs/*.cgf; do
+          if [ "$cgf_file" != "./sample_cgfs/dataset.cgf" ]; then
+              if [[ "$cgf_file" == *rv64* ]] && [ "${{matrix.architecture}}" == "rv64i" ] ; then
                 cmd="riscv_ctg -r -d ./tests -bi rv64i -cf sample_cgfs/dataset.cgf -cf \"$cgf_file\" -v warning -p \$(nproc)"
                 echo $cmd
                 eval $cmd || { echo "Error executing command: $cmd"; exit 1; }
-              else
+              fi
+          fi
+          done
+
+      - name: Run RISC-V CTG for RV64I and RV32I
+        run: |
+          set -e
+          for cgf_file in ./sample_cgfs/*.cgf; do
+          if [ "$cgf_file" != "./sample_cgfs/dataset.cgf" ]; then
+              if [[ "$cgf_file" != *rv32e* ]] && [[ "$cgf_file" != *rv32* ]] && [[ "$cgf_file" != *rv64* ]] && [ "${{matrix.architecture}}" == "rv32i_64i" ] ; then
                 for arch in rv32i rv64i; do
                   cmd="riscv_ctg -r -d ./tests -bi $arch -cf sample_cgfs/dataset.cgf -cf \"$cgf_file\" -v warning -p \$(nproc)"
                   echo $cmd

--- a/riscv_ctg/data/imc.yaml
+++ b/riscv_ctg/data/imc.yaml
@@ -1740,6 +1740,7 @@ c.ldsp:
     - IC
   formattype: 'ciformat'
   imm_val_data: '[x*8 for x in gen_usign_dataset(6)]'
+  rs1_val_data: 'gen_sign_dataset(xlen)+ gen_sp_dataset(xlen)'
   template: |-
 
     // $comment

--- a/riscv_ctg/data/template.yaml
+++ b/riscv_ctg/data/template.yaml
@@ -12477,6 +12477,7 @@ sspushpopchk_u:
   isa:
     - I_Zicfiss_Zicsr
   formattype: 'rformat'
+  rs1_val_data: 'gen_sign_dataset(xlen)'
   rs2_val_data: 'gen_sign_dataset(xlen)'
   template: |-
     // $comment
@@ -12491,6 +12492,7 @@ sspushpopchk_s:
   isa:
     - I_Zicfiss_Zicsr
   formattype: 'rformat'
+  rs1_val_data: 'gen_sign_dataset(xlen)'
   rs2_val_data: 'gen_sign_dataset(xlen)'
   template: |-
     // $comment
@@ -12505,6 +12507,7 @@ c.sspushpopchk_u:
   isa:
     - IC_Zicfiss_Zicsr
   formattype: 'crformat'
+  rs1_val_data: 'gen_sign_dataset(xlen)'
   rs2_val_data: 'gen_sign_dataset(xlen)'
   template: |-
     // $comment
@@ -12519,6 +12522,7 @@ c.sspushpopchk_s:
   isa:
     - IC_Zicfiss_Zicsr
   formattype: 'crformat'
+  rs1_val_data: 'gen_sign_dataset(xlen)'
   rs2_val_data: 'gen_sign_dataset(xlen)'
   template: |-
     // $comment
@@ -12625,6 +12629,8 @@ ssrdp_s:
   std_op:
   isa:
     - I_Zicfiss_Zicsr
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
   formattype: 'rformat'
   template: |-
     // $comment
@@ -12644,6 +12650,8 @@ ssrdp_u:
   std_op:
   isa:
     - I_Zicfiss_Zicsr
+  rs1_val_data: 'gen_sign_dataset(xlen)'
+  rs2_val_data: 'gen_sign_dataset(xlen)'
   formattype: 'rformat'
   template: |-
     // $comment

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -294,6 +294,7 @@ class Generator():
         logger.debug(self.opcode + ' : Generating OpComb')
         solutions = []
         op_conds = {}
+        opcomb_value = cgf.get("op_comb")
         if "op_comb" in cgf:
             op_comb = set(cgf["op_comb"])
         else:
@@ -333,21 +334,26 @@ class Generator():
                 problem.addConstraint(AllDifferentConstraint())
             count = 0
             solution = problem.getSolution()
-            while (solution is None and count < 5):
-#                pattern = r'(?:rs1|rs2|rd) == "(x\d+)"'
-#                matches = re.findall(pattern, cond)
-#                if not matches or any(int(match[1:]) > 31 for match in matches):
-#                    result = None
-#                else:
-#                    result = matches
-#                    for match in result:
-#                        op_conds['rs1'].add(match)
-#                        op_conds['rs2'].add(match)
-#                        op_conds['rd'].add(match)
-#                    op_comb.add(cond)
-#                    break
+            while solution is None and count < 5:
+                if opcomb_value:
+                    for i in opcomb_value:
+                        opcomb_match = re.search(r'x\d{1,2}', i)
+                        if opcomb_match is not None:
+                            pattern = r'(?:rs1|rs2|rd) == "(x\d+)"'
+                            matches = re.findall(pattern, cond)
+                            if not matches or any(int(match[1:]) > 31 for match in matches):
+                                result = None
+                            else:
+                                result = matches
+                                for match in result:
+                                    op_conds['rs1'].add(match)
+                                    op_conds['rs2'].add(match)
+                                    op_conds['rd'].add(match)
+                                op_comb.add(cond)
+                                break
                 solution = problem.getSolution()
                 count = count + 1
+
             if solution is None:
                 if individual:
                     if nodiff:

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -334,18 +334,18 @@ class Generator():
             count = 0
             solution = problem.getSolution()
             while (solution is None and count < 5):
-                pattern = r'(?:rs1|rs2|rd) == "(x\d+)"'
-                matches = re.findall(pattern, cond)
-                if not matches or any(int(match[1:]) > 31 for match in matches):
-                    result = None
-                else:
-                    result = matches
-                    for match in result:
-                        op_conds['rs1'].add(match)
-                        op_conds['rs2'].add(match)
-                        op_conds['rd'].add(match)
-                    op_comb.add(cond)
-                    break
+#                pattern = r'(?:rs1|rs2|rd) == "(x\d+)"'
+#                matches = re.findall(pattern, cond)
+#                if not matches or any(int(match[1:]) > 31 for match in matches):
+#                    result = None
+#                else:
+#                    result = matches
+#                    for match in result:
+#                        op_conds['rs1'].add(match)
+#                        op_conds['rs2'].add(match)
+#                        op_conds['rd'].add(match)
+#                    op_comb.add(cond)
+#                    break
                 solution = problem.getSolution()
                 count = count + 1
             if solution is None:
@@ -358,7 +358,6 @@ class Generator():
                 else:
                     individual = True
                 continue
-
             op_tuple = []
             for key in self.op_vars:
                 op_tuple.append(solution[key])

--- a/riscv_ctg/main.py
+++ b/riscv_ctg/main.py
@@ -10,7 +10,7 @@ from riscv_ctg.constants import env,gen_sign_dataset,gen_usign_dataset
 from riscv_isac.cgf_normalize import expand_cgf
 @click.command()
 @click.version_option(prog_name="RISC-V Compliance Test Generator",version=__version__)
-@click.option('--verbose', '-v', default='error', help='Set verbose level', type=click.Choice(['info','error','debug'],case_sensitive=False))
+@click.option('--verbose', '-v', default='error', help='Set verbose level', type=click.Choice(['info','error','debug','warning'],case_sensitive=False))
 @click.option('--out-dir', '-d', default='./', type=click.Path(resolve_path=True,writable=True), help='Output directory path')
 @click.option('--randomize','-r', default=False , is_flag='True', help='Randomize Outputs.')
 @click.option('--cgf','-cf',multiple=True,type=click.Path(exists=True,resolve_path=True,readable=True),help="Path to the cgf file(s). Multiple allowed.")

--- a/sample_cgfs/dataset.cgf
+++ b/sample_cgfs/dataset.cgf
@@ -225,6 +225,12 @@ datasets:
     'rs1 == rs2 == rd': 0
     'rs1 != rs2  and rs1 != rd and rs2 != rd': 0
 
+  div_hardcoded_opcomb: &div_hardcoded_opcomb
+    'rs1 == rd != rs2 and rd != "x0"': 0
+    'rs1 == rd != rs2 and rd == "x0"': 0
+    'rs1 == "x0" != rd': 0
+    'rd == "x0" != rs1': 0
+
   ramofmt_op_comb: &ramofmt_op_comb
     'rs1 == rd != rs2': 0
     'rs2 == rd != rs1': 0

--- a/sample_cgfs/rv32e.cgf
+++ b/sample_cgfs/rv32e.cgf
@@ -3,13 +3,13 @@
 fence:
   config: 
     - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     fence: 0
 
 addi:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       addi: 0
     rs1: 
       <<: *rv32e_regs
@@ -26,7 +26,7 @@ addi:
 slti:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       slti: 0
     rs1: 
       <<: *rv32e_regs
@@ -43,7 +43,7 @@ slti:
 sltiu:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       sltiu: 0
     rs1: 
       <<: *rv32e_regs
@@ -60,7 +60,7 @@ sltiu:
 andi:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       andi: 0
     rs1: 
       <<: *rv32e_regs
@@ -77,7 +77,7 @@ andi:
 ori:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       ori: 0
     rs1: 
       <<: *rv32e_regs
@@ -94,7 +94,7 @@ ori:
 xori:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       xori: 0
     rs1: 
       <<: *rv32e_regs
@@ -111,7 +111,7 @@ xori:
 slli:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       slli: 0
     rs1: 
       <<: *rv32e_regs
@@ -131,7 +131,7 @@ slli:
 srai:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       srai: 0
     rs1: 
       <<: *rv32e_regs
@@ -151,7 +151,7 @@ srai:
 srli:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       srli: 0
     rs1: 
       <<: *rv32e_regs
@@ -171,7 +171,7 @@ srli:
 add:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       add: 0
     rs1: 
       <<: *rv32e_regs
@@ -190,7 +190,7 @@ add:
 sub:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       sub: 0
     rs1: 
       <<: *rv32e_regs
@@ -209,7 +209,7 @@ sub:
 slt:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       slt: 0
     rs1: 
       <<: *rv32e_regs
@@ -228,7 +228,7 @@ slt:
 sltu:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       sltu: 0
     rs1: 
       <<: *rv32e_regs
@@ -247,7 +247,7 @@ sltu:
 and:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       and: 0
     rs1: 
       <<: *rv32e_regs
@@ -266,7 +266,7 @@ and:
 or:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       or: 0
     rs1: 
       <<: *rv32e_regs
@@ -285,7 +285,7 @@ or:
 xor:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       xor: 0
     rs1: 
       <<: *rv32e_regs
@@ -304,7 +304,7 @@ xor:
 sll:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       sll: 0
     rs1: 
       <<: *rv32e_regs
@@ -326,7 +326,7 @@ sll:
 srl:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       srl: 0
     rs1: 
       <<: *rv32e_regs
@@ -348,7 +348,7 @@ srl:
 sra:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       sra: 0
     rs1: 
       <<: *rv32e_regs
@@ -370,7 +370,7 @@ sra:
 beq:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       beq: 0
     rs1: 
       <<: *rv32e_regs
@@ -387,7 +387,7 @@ beq:
 bge:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       bge: 0
     rs1: 
       <<: *rv32e_regs
@@ -404,7 +404,7 @@ bge:
 bgeu:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       bgeu: 0
     rs1: 
       <<: *rv32e_regs
@@ -421,7 +421,7 @@ bgeu:
 blt:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       blt: 0
     rs1: 
       <<: *rv32e_regs
@@ -438,7 +438,7 @@ blt:
 bltu:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       bltu: 0
     rs1: 
       <<: *rv32e_regs
@@ -455,7 +455,7 @@ bltu:
 bne:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       bne: 0
     rs1: 
       <<: *rv32e_regs
@@ -472,7 +472,7 @@ bne:
 lhu-align:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       lhu: 0
     rs1: 
       <<: *rv32e_regs_mx0
@@ -496,7 +496,7 @@ lhu-align:
 lh-align:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       lh: 0
     rs1: 
       <<: *rv32e_regs_mx0
@@ -520,7 +520,7 @@ lh-align:
 lbu-align:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       lbu: 0
     rs1: 
       <<: *rv32e_regs_mx0
@@ -552,7 +552,7 @@ lbu-align:
 lb-align:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       lb: 0
     rs1: 
       <<: *rv32e_regs_mx0
@@ -584,7 +584,7 @@ lb-align:
 lw-align:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       lw: 0
     rs1: 
       <<: *rv32e_regs_mx0
@@ -605,7 +605,7 @@ lw-align:
 sh-align:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       sh: 0
     rs1: 
       <<: *rv32e_regs_mx0
@@ -632,7 +632,7 @@ sh-align:
 sb-align:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       sb: 0
     rs1: 
       <<: *rv32e_regs_mx0
@@ -667,7 +667,7 @@ sb-align:
 sw-align:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       sw: 0
     rs1: 
       <<: *rv32e_regs_mx0
@@ -690,7 +690,7 @@ sw-align:
 auipc:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       auipc: 0
     rd: 
       <<: *rv32e_regs
@@ -707,7 +707,7 @@ auipc:
 lui:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       lui: 0
     rd: 
       <<: *rv32e_regs
@@ -724,7 +724,7 @@ lui:
 jal:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       jal: 0
     rd: 
       <<: *rv32e_regs
@@ -737,7 +737,7 @@ jal:
 jalr:
     config: 
       - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       jalr: 0
     rs1:
       <<: *rv32e_regs_mx0

--- a/sample_cgfs/rv32e_fencei.cgf
+++ b/sample_cgfs/rv32e_fencei.cgf
@@ -1,6 +1,6 @@
 fencei:
   config: 
     - check ISA:=regex(.*E.*Zifencei.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     fence.i: 0
 

--- a/sample_cgfs/rv32e_priv.cgf
+++ b/sample_cgfs/rv32e_priv.cgf
@@ -3,7 +3,7 @@ misalign-lh:
   config:
     - check ISA:=regex(.*E.*); check hw_data_misaligned_support:=True ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     lh: 0
   val_comb:
     'ea_align == 1': 0
@@ -13,7 +13,7 @@ misalign-lhu:
     - check ISA:=regex(.*E.*); check hw_data_misaligned_support:=True ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True ;def RVTEST_E = True
   cond: check ISA:=regex(.*E.*Zicsr.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     lhu: 0
   val_comb:
     'ea_align == 1': 0
@@ -24,7 +24,7 @@ misalign-lw:
     - check ISA:=regex(.*E.*); check hw_data_misaligned_support:=True ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True ;def RVTEST_E = True
   cond: check ISA:=regex(.*E.*Zicsr.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     lw: 0
   val_comb:
     'ea_align == 1': 0
@@ -36,7 +36,7 @@ misalign-sh:
     - check ISA:=regex(.*E.*); check hw_data_misaligned_support:=True ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True ;def RVTEST_E = True
   cond: check ISA:=regex(.*E.*Zicsr.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     sh: 0
   val_comb:
     'ea_align == 1': 0
@@ -46,7 +46,7 @@ misalign-sw:
     - check ISA:=regex(.*E.*); check hw_data_misaligned_support:=True ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True ;def RVTEST_E = True
   cond: check ISA:=regex(.*E.*Zicsr.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     sw: 0
   val_comb:
     'ea_align == 1': 0
@@ -58,7 +58,7 @@ misalign2-jalr:
     - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True ;def RVTEST_E = True
   cond: check ISA:=regex(.*E.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     jalr: 0
   val_comb:
     'imm_val%2 == 1 and ea_align == 2': 0
@@ -67,7 +67,7 @@ misalign2-jalr:
 misalign1-jalr:
   config: 
     - check ISA:=regex(.*E.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     jalr: 0
   val_comb:
     'imm_val%2 == 1 and ea_align == 1': 0
@@ -78,7 +78,7 @@ misalign-jal:
     - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True ;def RVTEST_E = True
   cond: check ISA:=regex(.*E.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     jal: 0
   val_comb:
     'ea_align == 2': 0
@@ -88,7 +88,7 @@ misalign-bge:
     - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True ;def RVTEST_E = True
   cond: check ISA:=regex(.*E.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     bge: 0
   val_comb:
     ' rs1_val>rs2_val and ea_align == 2': 0
@@ -98,7 +98,7 @@ misalign-bgeu:
     - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True ;def RVTEST_E = True 
   cond: check ISA:=regex(.*E.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     bgeu: 0
   val_comb:
     ' rs1_val>rs2_val and ea_align == 2': 0
@@ -108,7 +108,7 @@ misalign-blt:
     - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True ;def RVTEST_E = True
   cond: check ISA:=regex(.*E.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     blt: 0
   val_comb:
     ' rs1_val<rs2_val and ea_align == 2': 0
@@ -118,7 +118,7 @@ misalign-bltu:
     - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True ;def RVTEST_E = True
   cond: check ISA:=regex(.*E.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     bltu: 0
   val_comb:
     ' rs1_val<rs2_val and ea_align == 2': 0
@@ -128,7 +128,7 @@ misalign-bne:
     - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True ;def RVTEST_E = True
   cond: check ISA:=regex(.*E.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     bne: 0
   val_comb:
     ' rs1_val!=rs2_val and ea_align == 2': 0
@@ -138,7 +138,7 @@ misalign-beq:
     - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
     - check ISA:=regex(.*E.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True ;def RVTEST_E = True
   cond: check ISA:=regex(.*E.*) ;def RVTEST_E = True
-  opcode:
+  mnemonics:
     beq: 0
   val_comb:
     ' rs1_val==rs2_val and ea_align == 2': 0

--- a/sample_cgfs/rv32ec.cgf
+++ b/sample_cgfs/rv32ec.cgf
@@ -3,13 +3,13 @@
 cebreak:
   config: 
     - check ISA:=regex(.*E.*Zicsr.*.C*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     c.ebreak: 0
 
 caddi4spn:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.addi4spn: 0
     rd:
       <<: *c_regs
@@ -24,7 +24,7 @@ caddi4spn:
 clw:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.lw: 0
     rs1: 
       <<: *c_regs
@@ -45,7 +45,7 @@ clw:
 csw:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.sw: 0
     rs1: 
       <<: *c_regs
@@ -67,7 +67,7 @@ csw:
 cnop:
     config: 
       - check ISA:=regex(.*E.*C.*)  ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.nop: 0
     val_comb:
       abstract_comb:
@@ -76,7 +76,7 @@ cnop:
 caddi:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.addi: 0
     rd:
       <<: *rv32e_regs_mx0
@@ -89,7 +89,7 @@ caddi:
 cjal:
   config: 
       - check ISA:=regex(.*RV32.*E.*C.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     c.jal: 0
   val_comb:
     'imm_val > 0': 0
@@ -102,7 +102,7 @@ cjal:
 cli:
   config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     c.li: 0
   rd:
     <<: *rv32e_regs
@@ -116,7 +116,7 @@ cli:
 caddi16sp:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.addi16sp: 0
     rd:
       x2: 0
@@ -133,7 +133,7 @@ caddi16sp:
 clui:
   config: 
     - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     c.lui: 0
   rd:
     <<: *rv32e_regs_mx2
@@ -150,7 +150,7 @@ clui:
 csrli:
   config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     c.srli: 0
   rs1:
     <<: *c_regs
@@ -172,7 +172,7 @@ csrli:
 csrai:
   config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     c.srai: 0
   rs1:
     <<: *c_regs
@@ -194,7 +194,7 @@ csrai:
 candi:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.andi: 0
     rs1:
       <<: *c_regs
@@ -207,7 +207,7 @@ candi:
 csub:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.sub: 0
     rs1:
       <<: *c_regs
@@ -224,7 +224,7 @@ csub:
 cxor:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.xor: 0
     rs1:
       <<: *c_regs
@@ -241,7 +241,7 @@ cxor:
 cor:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.or: 0
     rs1:
       <<: *c_regs
@@ -258,7 +258,7 @@ cor:
 cand:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.and: 0
     rs1:
       <<: *c_regs
@@ -277,7 +277,7 @@ cand:
 cj:
   config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     c.j: 0
   val_comb:
     'imm_val > 0': 0
@@ -290,7 +290,7 @@ cj:
 cbeqz:
   config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     c.beqz: 0
   rs1:
     <<: *c_regs
@@ -309,7 +309,7 @@ cbeqz:
 cbnez:
   config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     c.bnez: 0
   rs1:
     <<: *c_regs
@@ -328,7 +328,7 @@ cbnez:
 cslli:
   config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     c.slli: 0
   rd:
     <<: *c_regs
@@ -350,7 +350,7 @@ cslli:
 clwsp:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.lwsp: 0
     rd: 
       <<: *rv32e_regs_mx0
@@ -366,7 +366,7 @@ clwsp:
 cjr:
   config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     c.jr: 0
   rs1:
     <<: *rv32e_regs_mx0
@@ -381,7 +381,7 @@ cjr:
 cmv:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.mv: 0
     rs2:
       <<: *rv32e_regs_mx0
@@ -399,7 +399,7 @@ cmv:
 cadd:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.add: 0
     rs1:
       <<: *rv32e_regs
@@ -416,7 +416,7 @@ cadd:
 cjalr:
   config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-  opcode: 
+  mnemonics: 
     c.jalr: 0
   rs1:
     <<: *rv32e_regs_mx0
@@ -431,7 +431,7 @@ cjalr:
 cswsp:
     config: 
       - check ISA:=regex(.*E.*C.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       c.swsp: 0
     rs2: 
       <<: *rv32e_regs_mx2

--- a/sample_cgfs/rv32em.cgf
+++ b/sample_cgfs/rv32em.cgf
@@ -3,7 +3,7 @@
 mul:
     config: 
       - check ISA:=regex(.*E.*M.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       mul: 0
     rs1: 
       <<: *rv32e_regs
@@ -22,7 +22,7 @@ mul:
 mulh:
     config: 
       - check ISA:=regex(.*E.*M.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       mulh: 0
     rs1: 
       <<: *rv32e_regs
@@ -41,7 +41,7 @@ mulh:
 mulhu:
     config: 
       - check ISA:=regex(.*E.*M.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       mulhu: 0
     rs1: 
       <<: *rv32e_regs
@@ -60,7 +60,7 @@ mulhu:
 mulhsu:
     config: 
       - check ISA:=regex(.*E.*M.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       mulhsu: 0
     rs1: 
       <<: *rv32e_regs
@@ -80,7 +80,7 @@ mulhsu:
 div:
     config: 
       - check ISA:=regex(.*E.*M.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       div: 0
     rs1: 
       <<: *rv32e_regs
@@ -99,7 +99,7 @@ div:
 divu:
     config: 
       - check ISA:=regex(.*E.*M.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       divu: 0
     rs1: 
       <<: *rv32e_regs
@@ -118,7 +118,7 @@ divu:
 rem:
     config: 
       - check ISA:=regex(.*E.*M.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       rem: 0
     rs1: 
       <<: *rv32e_regs
@@ -137,7 +137,7 @@ rem:
 remu:
     config: 
       - check ISA:=regex(.*E.*M.*) ;def RVTEST_E = True
-    opcode: 
+    mnemonics: 
       remu: 0
     rs1: 
       <<: *rv32e_regs

--- a/sample_cgfs/rv32i.cgf
+++ b/sample_cgfs/rv32i.cgf
@@ -3,13 +3,13 @@
 fence:
   config: 
     - check ISA:=regex(.*I.*)
-  opcode: 
+  mnemonics: 
     fence: 0
 
 addi:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       addi: 0
     rs1: 
       <<: *all_regs
@@ -26,7 +26,7 @@ addi:
 slti:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       slti: 0
     rs1: 
       <<: *all_regs
@@ -43,7 +43,7 @@ slti:
 sltiu:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sltiu: 0
     rs1: 
       <<: *all_regs
@@ -60,7 +60,7 @@ sltiu:
 andi:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       andi: 0
     rs1: 
       <<: *all_regs
@@ -77,7 +77,7 @@ andi:
 ori:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       ori: 0
     rs1: 
       <<: *all_regs
@@ -94,7 +94,7 @@ ori:
 xori:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       xori: 0
     rs1: 
       <<: *all_regs
@@ -111,7 +111,7 @@ xori:
 slli:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       slli: 0
     rs1: 
       <<: *all_regs
@@ -131,7 +131,7 @@ slli:
 srai:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       srai: 0
     rs1: 
       <<: *all_regs
@@ -151,7 +151,7 @@ srai:
 srli:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       srli: 0
     rs1: 
       <<: *all_regs
@@ -171,7 +171,7 @@ srli:
 add:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       add: 0
     rs1: 
       <<: *all_regs
@@ -190,7 +190,7 @@ add:
 sub:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sub: 0
     rs1: 
       <<: *all_regs
@@ -209,7 +209,7 @@ sub:
 slt:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       slt: 0
     rs1: 
       <<: *all_regs
@@ -228,7 +228,7 @@ slt:
 sltu:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sltu: 0
     rs1: 
       <<: *all_regs
@@ -247,7 +247,7 @@ sltu:
 and:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       and: 0
     rs1: 
       <<: *all_regs
@@ -266,7 +266,7 @@ and:
 or:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       or: 0
     rs1: 
       <<: *all_regs
@@ -285,7 +285,7 @@ or:
 xor:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       xor: 0
     rs1: 
       <<: *all_regs
@@ -304,7 +304,7 @@ xor:
 sll:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sll: 0
     rs1: 
       <<: *all_regs
@@ -326,7 +326,7 @@ sll:
 srl:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       srl: 0
     rs1: 
       <<: *all_regs
@@ -348,7 +348,7 @@ srl:
 sra:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sra: 0
     rs1: 
       <<: *all_regs
@@ -370,7 +370,7 @@ sra:
 beq:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       beq: 0
     rs1: 
       <<: *all_regs
@@ -387,7 +387,7 @@ beq:
 bge:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       bge: 0
     rs1: 
       <<: *all_regs
@@ -404,7 +404,7 @@ bge:
 bgeu:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       bgeu: 0
     rs1: 
       <<: *all_regs
@@ -421,7 +421,7 @@ bgeu:
 blt:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       blt: 0
     rs1: 
       <<: *all_regs
@@ -438,7 +438,7 @@ blt:
 bltu:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       bltu: 0
     rs1: 
       <<: *all_regs
@@ -455,7 +455,7 @@ bltu:
 bne:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       bne: 0
     rs1: 
       <<: *all_regs
@@ -472,7 +472,7 @@ bne:
 lhu-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       lhu: 0
     rs1: 
       <<: *all_regs_mx0
@@ -496,7 +496,7 @@ lhu-align:
 lh-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       lh: 0
     rs1: 
       <<: *all_regs_mx0
@@ -520,7 +520,7 @@ lh-align:
 lbu-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       lbu: 0
     rs1: 
       <<: *all_regs_mx0
@@ -552,7 +552,7 @@ lbu-align:
 lb-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       lb: 0
     rs1: 
       <<: *all_regs_mx0
@@ -584,7 +584,7 @@ lb-align:
 lw-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       lw: 0
     rs1: 
       <<: *all_regs_mx0
@@ -605,7 +605,7 @@ lw-align:
 sh-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sh: 0
     rs1: 
       <<: *all_regs_mx0
@@ -632,7 +632,7 @@ sh-align:
 sb-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sb: 0
     rs1: 
       <<: *all_regs_mx0
@@ -667,7 +667,7 @@ sb-align:
 sw-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sw: 0
     rs1: 
       <<: *all_regs_mx0
@@ -690,7 +690,7 @@ sw-align:
 auipc:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       auipc: 0
     rd: 
       <<: *all_regs
@@ -707,7 +707,7 @@ auipc:
 lui:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       lui: 0
     rd: 
       <<: *all_regs
@@ -724,7 +724,7 @@ lui:
 jal:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       jal: 0
     rd: 
       <<: *all_regs
@@ -737,7 +737,7 @@ jal:
 jalr:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       jalr: 0
     rs1:
       <<: *all_regs_mx0

--- a/sample_cgfs/rv32i_fencei.cgf
+++ b/sample_cgfs/rv32i_fencei.cgf
@@ -1,6 +1,6 @@
 fencei:
   config: 
     - check ISA:=regex(.*I.*Zifencei.*)
-  opcode: 
+  mnemonics: 
     fence.i: 0
 

--- a/sample_cgfs/rv32i_priv.cgf
+++ b/sample_cgfs/rv32i_priv.cgf
@@ -1,13 +1,13 @@
 ecall:
   config: 
     - check ISA:=regex(.*I.*); def rvtest_mtrap_routine=True 
-  opcode: 
+  mnemonics: 
     ecall: 0
 
 ebreak:
   config: 
     - check ISA:=regex(.*I.*); def rvtest_mtrap_routine=True 
-  opcode: 
+  mnemonics: 
     ebreak: 0
 
 misalign-lh:
@@ -15,7 +15,7 @@ misalign-lh:
   config:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
-  opcode:
+  mnemonics:
     lh: 0
   val_comb:
     'ea_align == 1': 0
@@ -25,7 +25,7 @@ misalign-lhu:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
   cond: check ISA:=regex(.*I.*Zicsr.*)
-  opcode:
+  mnemonics:
     lhu: 0
   val_comb:
     'ea_align == 1': 0
@@ -36,7 +36,7 @@ misalign-lw:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
   cond: check ISA:=regex(.*I.*Zicsr.*)
-  opcode:
+  mnemonics:
     lw: 0
   val_comb:
     'ea_align == 1': 0
@@ -48,7 +48,7 @@ misalign-sh:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
   cond: check ISA:=regex(.*I.*Zicsr.*)
-  opcode:
+  mnemonics:
     sh: 0
   val_comb:
     'ea_align == 1': 0
@@ -58,7 +58,7 @@ misalign-sw:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
   cond: check ISA:=regex(.*I.*Zicsr.*)
-  opcode:
+  mnemonics:
     sw: 0
   val_comb:
     'ea_align == 1': 0
@@ -70,7 +70,7 @@ misalign2-jalr:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     jalr: 0
   val_comb:
     'imm_val%2 == 1 and ea_align == 2': 0
@@ -79,7 +79,7 @@ misalign2-jalr:
 misalign1-jalr:
   config: 
     - check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     jalr: 0
   val_comb:
     'imm_val%2 == 1 and ea_align == 1': 0
@@ -90,7 +90,7 @@ misalign-jal:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     jal: 0
   val_comb:
     'ea_align == 2': 0
@@ -100,7 +100,7 @@ misalign-bge:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     bge: 0
   val_comb:
     ' rs1_val>rs2_val and ea_align == 2': 0
@@ -110,7 +110,7 @@ misalign-bgeu:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     bgeu: 0
   val_comb:
     ' rs1_val>rs2_val and ea_align == 2': 0
@@ -120,7 +120,7 @@ misalign-blt:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     blt: 0
   val_comb:
     ' rs1_val<rs2_val and ea_align == 2': 0
@@ -130,7 +130,7 @@ misalign-bltu:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     bltu: 0
   val_comb:
     ' rs1_val<rs2_val and ea_align == 2': 0
@@ -140,7 +140,7 @@ misalign-bne:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     bne: 0
   val_comb:
     ' rs1_val!=rs2_val and ea_align == 2': 0
@@ -150,7 +150,7 @@ misalign-beq:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     beq: 0
   val_comb:
     ' rs1_val==rs2_val and ea_align == 2': 0

--- a/sample_cgfs/rv32ic.cgf
+++ b/sample_cgfs/rv32ic.cgf
@@ -3,13 +3,13 @@
 cebreak:
   config: 
     - check ISA:=regex(.*I.*Zicsr.*.C*)
-  opcode: 
+  mnemonics: 
     c.ebreak: 0
 
 caddi4spn:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.addi4spn: 0
     rd:
       <<: *c_regs
@@ -24,7 +24,7 @@ caddi4spn:
 clw:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.lw: 0
     rs1: 
       <<: *c_regs
@@ -45,7 +45,7 @@ clw:
 csw:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.sw: 0
     rs1: 
       <<: *c_regs
@@ -67,7 +67,7 @@ csw:
 cnop:
     config: 
       - check ISA:=regex(.*I.*C.*) 
-    opcode: 
+    mnemonics: 
       c.nop: 0
     val_comb:
       abstract_comb:
@@ -76,7 +76,7 @@ cnop:
 caddi:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.addi: 0
     rd:
       <<: *all_regs_mx0
@@ -89,7 +89,7 @@ caddi:
 cjal:
   config: 
       - check ISA:=regex(.*RV32.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.jal: 0
   val_comb:
     'imm_val > 0': 0
@@ -102,7 +102,7 @@ cjal:
 cli:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.li: 0
   rd:
     <<: *all_regs
@@ -116,7 +116,7 @@ cli:
 caddi16sp:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.addi16sp: 0
     rd:
       x2: 0
@@ -133,7 +133,7 @@ caddi16sp:
 clui:
   config: 
     - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.lui: 0
   rd:
     x0: 0
@@ -181,7 +181,7 @@ clui:
 csrli:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.srli: 0
   rs1:
     <<: *c_regs
@@ -203,7 +203,7 @@ csrli:
 csrai:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.srai: 0
   rs1:
     <<: *c_regs
@@ -225,7 +225,7 @@ csrai:
 candi:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.andi: 0
     rs1:
       <<: *c_regs
@@ -238,7 +238,7 @@ candi:
 csub:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.sub: 0
     rs1:
       <<: *c_regs
@@ -255,7 +255,7 @@ csub:
 cxor:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.xor: 0
     rs1:
       <<: *c_regs
@@ -272,7 +272,7 @@ cxor:
 cor:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.or: 0
     rs1:
       <<: *c_regs
@@ -289,7 +289,7 @@ cor:
 cand:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.and: 0
     rs1:
       <<: *c_regs
@@ -308,7 +308,7 @@ cand:
 cj:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.j: 0
   val_comb:
     'imm_val > 0': 0
@@ -321,7 +321,7 @@ cj:
 cbeqz:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.beqz: 0
   rs1:
     <<: *c_regs
@@ -340,7 +340,7 @@ cbeqz:
 cbnez:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.bnez: 0
   rs1:
     <<: *c_regs
@@ -359,7 +359,7 @@ cbnez:
 cslli:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.slli: 0
   rd:
     <<: *c_regs
@@ -381,7 +381,7 @@ cslli:
 clwsp:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.lwsp: 0
     rd: 
       <<: *all_regs_mx0
@@ -397,7 +397,7 @@ clwsp:
 cjr:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.jr: 0
   rs1:
     <<: *all_regs_mx0
@@ -412,7 +412,7 @@ cjr:
 cmv:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.mv: 0
     rs2:
       <<: *all_regs_mx0
@@ -430,7 +430,7 @@ cmv:
 cadd:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.add: 0
     rs1:
       <<: *all_regs
@@ -447,7 +447,7 @@ cadd:
 cjalr:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.jalr: 0
   rs1:
     <<: *all_regs_mx0
@@ -462,7 +462,7 @@ cjalr:
 cswsp:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.swsp: 0
     rs2: 
       <<: *all_regs_mx2

--- a/sample_cgfs/rv32im.cgf
+++ b/sample_cgfs/rv32im.cgf
@@ -89,7 +89,7 @@ div:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: *rfmt_op_comb
+      <<: [*rfmt_op_comb , *div_hardcoded_opcomb]
     val_comb:
       <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn, *div_corner_case]
       abstract_comb:
@@ -108,7 +108,7 @@ divu:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: *rfmt_op_comb
+      <<: [*rfmt_op_comb , *div_hardcoded_opcomb]
     val_comb:
       <<: [*base_rs1val_unsgn , *base_rs2val_unsgn , *rfmt_val_comb_unsgn]
       abstract_comb:
@@ -127,7 +127,7 @@ rem:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: *rfmt_op_comb
+      <<: [*rfmt_op_comb , *div_hardcoded_opcomb]
     val_comb:
       <<: [*base_rs1val_sgn , *base_rs2val_sgn , *rfmt_val_comb_sgn, *div_corner_case]
       abstract_comb:
@@ -146,7 +146,7 @@ remu:
     rd: 
       <<: *all_regs
     op_comb: 
-      <<: *rfmt_op_comb
+      <<: [*rfmt_op_comb , *div_hardcoded_opcomb]
     val_comb:
       <<: [*base_rs1val_unsgn , *base_rs2val_unsgn , *rfmt_val_comb_unsgn]
       abstract_comb:

--- a/sample_cgfs/rv32im.cgf
+++ b/sample_cgfs/rv32im.cgf
@@ -3,7 +3,7 @@
 mul:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       mul: 0
     rs1: 
       <<: *all_regs
@@ -22,7 +22,7 @@ mul:
 mulh:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       mulh: 0
     rs1: 
       <<: *all_regs
@@ -41,7 +41,7 @@ mulh:
 mulhu:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       mulhu: 0
     rs1: 
       <<: *all_regs
@@ -60,7 +60,7 @@ mulhu:
 mulhsu:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       mulhsu: 0
     rs1: 
       <<: *all_regs
@@ -80,7 +80,7 @@ mulhsu:
 div:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       div: 0
     rs1: 
       <<: *all_regs
@@ -99,7 +99,7 @@ div:
 divu:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       divu: 0
     rs1: 
       <<: *all_regs
@@ -118,7 +118,7 @@ divu:
 rem:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       rem: 0
     rs1: 
       <<: *all_regs
@@ -137,7 +137,7 @@ rem:
 remu:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       remu: 0
     rs1: 
       <<: *all_regs

--- a/sample_cgfs/rv32ip.cgf
+++ b/sample_cgfs/rv32ip.cgf
@@ -3,7 +3,7 @@
 add16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       add16: 0
     rs1:
       <<: *all_regs
@@ -22,7 +22,7 @@ add16:
 radd16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       radd16: 0
     rs1:
       <<: *all_regs
@@ -41,7 +41,7 @@ radd16:
 uradd16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uradd16: 0
     rs1:
       <<: *all_regs
@@ -60,7 +60,7 @@ uradd16:
 kadd16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kadd16: 0
     rs1:
       <<: *all_regs
@@ -79,7 +79,7 @@ kadd16:
 ukadd16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukadd16: 0
     rs1:
       <<: *all_regs
@@ -98,7 +98,7 @@ ukadd16:
 sub16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sub16: 0
     rs1:
       <<: *all_regs
@@ -117,7 +117,7 @@ sub16:
 rsub16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rsub16: 0
     rs1:
       <<: *all_regs
@@ -137,7 +137,7 @@ rsub16:
 ursub16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ursub16: 0
     rs1:
       <<: *all_regs
@@ -156,7 +156,7 @@ ursub16:
 ksub16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ksub16: 0
     rs1:
       <<: *all_regs
@@ -175,7 +175,7 @@ ksub16:
 uksub16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uksub16: 0
     rs1:
       <<: *all_regs
@@ -194,7 +194,7 @@ uksub16:
 cras16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       cras16: 0
     rs1:
       <<: *all_regs
@@ -213,7 +213,7 @@ cras16:
 rcras16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rcras16: 0
     rs1:
       <<: *all_regs
@@ -232,7 +232,7 @@ rcras16:
 urcras16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       urcras16: 0
     rs1:
       <<: *all_regs
@@ -251,7 +251,7 @@ urcras16:
 kcras16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kcras16: 0
     rs1:
       <<: *all_regs
@@ -270,7 +270,7 @@ kcras16:
 ukcras16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukcras16: 0
     rs1:
       <<: *all_regs
@@ -289,7 +289,7 @@ ukcras16:
 crsa16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       crsa16: 0
     rs1:
       <<: *all_regs
@@ -308,7 +308,7 @@ crsa16:
 rcrsa16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rcrsa16: 0
     rs1:
       <<: *all_regs
@@ -327,7 +327,7 @@ rcrsa16:
 urcrsa16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       urcrsa16: 0
     rs1:
       <<: *all_regs
@@ -346,7 +346,7 @@ urcrsa16:
 kcrsa16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kcrsa16: 0
     rs1:
       <<: *all_regs
@@ -365,7 +365,7 @@ kcrsa16:
 ukcrsa16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukcrsa16: 0
     rs1:
       <<: *all_regs
@@ -384,7 +384,7 @@ ukcrsa16:
 stas16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       stas16: 0
     rs1:
       <<: *all_regs
@@ -403,7 +403,7 @@ stas16:
 rstas16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rstas16: 0
     rs1:
       <<: *all_regs
@@ -422,7 +422,7 @@ rstas16:
 urstas16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       urstas16: 0
     rs1:
       <<: *all_regs
@@ -441,7 +441,7 @@ urstas16:
 kstas16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kstas16: 0
     rs1:
       <<: *all_regs
@@ -460,7 +460,7 @@ kstas16:
 ukstas16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukstas16: 0
     rs1:
       <<: *all_regs
@@ -479,7 +479,7 @@ ukstas16:
 stsa16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       stsa16: 0
     rs1:
       <<: *all_regs
@@ -498,7 +498,7 @@ stsa16:
 rstsa16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rstsa16: 0
     rs1:
       <<: *all_regs
@@ -517,7 +517,7 @@ rstsa16:
 urstsa16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       urstsa16: 0
     rs1:
       <<: *all_regs
@@ -536,7 +536,7 @@ urstsa16:
 kstsa16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kstsa16: 0
     rs1:
       <<: *all_regs
@@ -555,7 +555,7 @@ kstsa16:
 ukstsa16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukstsa16: 0
     rs1:
       <<: *all_regs
@@ -574,7 +574,7 @@ ukstsa16:
 add8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       add8: 0
     rs1:
       <<: *all_regs
@@ -593,7 +593,7 @@ add8:
 radd8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       radd8: 0
     rs1:
       <<: *all_regs
@@ -612,7 +612,7 @@ radd8:
 uradd8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uradd8: 0
     rs1:
       <<: *all_regs
@@ -631,7 +631,7 @@ uradd8:
 kadd8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kadd8: 0
     rs1:
       <<: *all_regs
@@ -650,7 +650,7 @@ kadd8:
 ukadd8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       ukadd8: 0
     rs1: 
       <<: *all_regs
@@ -669,7 +669,7 @@ ukadd8:
 sub8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sub8: 0
     rs1:
       <<: *all_regs
@@ -688,7 +688,7 @@ sub8:
 rsub8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rsub8: 0
     rs1:
       <<: *all_regs
@@ -707,7 +707,7 @@ rsub8:
 ursub8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ursub8: 0
     rs1:
       <<: *all_regs
@@ -726,7 +726,7 @@ ursub8:
 ksub8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ksub8: 0
     rs1:
       <<: *all_regs
@@ -745,7 +745,7 @@ ksub8:
 uksub8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uksub8: 0
     rs1:
       <<: *all_regs
@@ -764,7 +764,7 @@ uksub8:
 sra16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sra16: 0
     rs1:
       <<: *all_regs
@@ -784,7 +784,7 @@ sra16:
 srai16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srai16: 0
     rs1:
       <<: *all_regs
@@ -800,7 +800,7 @@ srai16:
 sra16.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sra16.u: 0
     rs1:
       <<: *all_regs
@@ -820,7 +820,7 @@ sra16.u:
 srai16.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srai16.u: 0
     rs1:
       <<: *all_regs
@@ -836,7 +836,7 @@ srai16.u:
 srl16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srl16: 0
     rs1:
       <<: *all_regs
@@ -856,7 +856,7 @@ srl16:
 srli16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srli16: 0
     rs1:
       <<: *all_regs
@@ -872,7 +872,7 @@ srli16:
 srl16.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srl16.u: 0
     rs1:
       <<: *all_regs
@@ -892,7 +892,7 @@ srl16.u:
 srli16.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srli16.u: 0
     rs1:
       <<: *all_regs
@@ -908,7 +908,7 @@ srli16.u:
 sll16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sll16: 0
     rs1:
       <<: *all_regs
@@ -928,7 +928,7 @@ sll16:
 slli16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       slli16: 0
     rs1:
       <<: *all_regs
@@ -944,7 +944,7 @@ slli16:
 ksll16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ksll16: 0
     rs1:
       <<: *all_regs
@@ -964,7 +964,7 @@ ksll16:
 kslli16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kslli16: 0
     rs1:
       <<: *all_regs
@@ -980,7 +980,7 @@ kslli16:
 kslra16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kslra16: 0
     rs1:
       <<: *all_regs
@@ -1000,7 +1000,7 @@ kslra16:
 kslra16.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kslra16.u: 0
     rs1:
       <<: *all_regs
@@ -1020,7 +1020,7 @@ kslra16.u:
 sra8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sra8: 0
     rs1:
       <<: *all_regs
@@ -1040,7 +1040,7 @@ sra8:
 srai8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srai8: 0
     rs1:
       <<: *all_regs
@@ -1056,7 +1056,7 @@ srai8:
 sra8.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sra8.u: 0
     rs1:
       <<: *all_regs
@@ -1076,7 +1076,7 @@ sra8.u:
 srai8.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srai8.u: 0
     rs1:
       <<: *all_regs
@@ -1092,7 +1092,7 @@ srai8.u:
 srl8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srl8: 0
     rs1:
       <<: *all_regs
@@ -1112,7 +1112,7 @@ srl8:
 srli8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srli8: 0
     rs1:
       <<: *all_regs
@@ -1128,7 +1128,7 @@ srli8:
 srl8.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srl8.u: 0
     rs1:
       <<: *all_regs
@@ -1148,7 +1148,7 @@ srl8.u:
 srli8.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srli8.u: 0
     rs1:
       <<: *all_regs
@@ -1164,7 +1164,7 @@ srli8.u:
 sll8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sll8: 0
     rs1:
       <<: *all_regs
@@ -1184,7 +1184,7 @@ sll8:
 slli8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       slli8: 0
     rs1:
       <<: *all_regs
@@ -1200,7 +1200,7 @@ slli8:
 ksll8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ksll8: 0
     rs1:
       <<: *all_regs
@@ -1220,7 +1220,7 @@ ksll8:
 kslli8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kslli8: 0
     rs1:
       <<: *all_regs
@@ -1236,7 +1236,7 @@ kslli8:
 kslra8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kslra8: 0
     rs1:
       <<: *all_regs
@@ -1256,7 +1256,7 @@ kslra8:
 kslra8.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kslra8.u: 0
     rs1:
       <<: *all_regs
@@ -1276,7 +1276,7 @@ kslra8.u:
 cmpeq16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       cmpeq16: 0
     rs1:
       <<: *all_regs
@@ -1295,7 +1295,7 @@ cmpeq16:
 scmplt16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       scmplt16: 0
     rs1:
       <<: *all_regs
@@ -1314,7 +1314,7 @@ scmplt16:
 scmple16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       scmple16: 0
     rs1:
       <<: *all_regs
@@ -1333,7 +1333,7 @@ scmple16:
 ucmplt16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ucmplt16: 0
     rs1:
       <<: *all_regs
@@ -1352,7 +1352,7 @@ ucmplt16:
 ucmple16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ucmple16: 0
     rs1:
       <<: *all_regs
@@ -1371,7 +1371,7 @@ ucmple16:
 cmpeq8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       cmpeq8: 0
     rs1:
       <<: *all_regs
@@ -1390,7 +1390,7 @@ cmpeq8:
 scmplt8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       scmplt8: 0
     rs1:
       <<: *all_regs
@@ -1409,7 +1409,7 @@ scmplt8:
 scmple8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       scmple8: 0
     rs1:
       <<: *all_regs
@@ -1428,7 +1428,7 @@ scmple8:
 ucmplt8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ucmplt8: 0
     rs1:
       <<: *all_regs
@@ -1447,7 +1447,7 @@ ucmplt8:
 ucmple8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ucmple8: 0
     rs1:
       <<: *all_regs
@@ -1466,7 +1466,7 @@ ucmple8:
 smul16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smul16: 0
     rs1:
       <<: *all_regs
@@ -1485,7 +1485,7 @@ smul16:
 smulx16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smulx16: 0
     rs1:
       <<: *all_regs
@@ -1504,7 +1504,7 @@ smulx16:
 umul16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       umul16: 0
     rs1:
       <<: *all_regs
@@ -1523,7 +1523,7 @@ umul16:
 umulx16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       umulx16: 0
     rs1:
       <<: *all_regs
@@ -1542,7 +1542,7 @@ umulx16:
 khm16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       khm16: 0
     rs1:
       <<: *all_regs
@@ -1561,7 +1561,7 @@ khm16:
 khmx16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       khmx16: 0
     rs1:
       <<: *all_regs
@@ -1580,7 +1580,7 @@ khmx16:
 smul8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smul8: 0
     rs1:
       <<: *all_regs
@@ -1599,7 +1599,7 @@ smul8:
 smulx8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smulx8: 0
     rs1:
       <<: *all_regs
@@ -1618,7 +1618,7 @@ smulx8:
 umul8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       umul8: 0
     rs1:
       <<: *all_regs
@@ -1637,7 +1637,7 @@ umul8:
 umulx8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       umulx8: 0
     rs1:
       <<: *all_regs
@@ -1656,7 +1656,7 @@ umulx8:
 khm8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       khm8: 0
     rs1:
       <<: *all_regs
@@ -1675,7 +1675,7 @@ khm8:
 khmx8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       khmx8: 0
     rs1:
       <<: *all_regs
@@ -1694,7 +1694,7 @@ khmx8:
 smin16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smin16: 0
     rs1:
       <<: *all_regs
@@ -1713,7 +1713,7 @@ smin16:
 umin16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       umin16: 0
     rs1:
       <<: *all_regs
@@ -1732,7 +1732,7 @@ umin16:
 smax16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smax16: 0
     rs1:
       <<: *all_regs
@@ -1751,7 +1751,7 @@ smax16:
 umax16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       umax16: 0
     rs1:
       <<: *all_regs
@@ -1770,7 +1770,7 @@ umax16:
 sclip16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sclip16: 0
     rs1:
       <<: *all_regs
@@ -1786,7 +1786,7 @@ sclip16:
 uclip16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uclip16: 0
     rs1:
       <<: *all_regs
@@ -1802,7 +1802,7 @@ uclip16:
 kabs16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kabs16: 0
     rs1:
       <<: *all_regs
@@ -1815,7 +1815,7 @@ kabs16:
 clrs16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       clrs16: 0
     rs1:
       <<: *all_regs
@@ -1828,7 +1828,7 @@ clrs16:
 clz16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       clz16: 0
     rs1:
       <<: *all_regs
@@ -1842,7 +1842,7 @@ clz16:
 # swap16:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       swap16: 0
 #     rs1:
 #       <<: *all_regs
@@ -1855,7 +1855,7 @@ clz16:
 smin8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smin8: 0
     rs1:
       <<: *all_regs
@@ -1874,7 +1874,7 @@ smin8:
 umin8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       umin8: 0
     rs1:
       <<: *all_regs
@@ -1893,7 +1893,7 @@ umin8:
 smax8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smax8: 0
     rs1:
       <<: *all_regs
@@ -1912,7 +1912,7 @@ smax8:
 umax8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       umax8: 0
     rs1:
       <<: *all_regs
@@ -1931,7 +1931,7 @@ umax8:
 kabs8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kabs8: 0
     rs1:
       <<: *all_regs
@@ -1944,7 +1944,7 @@ kabs8:
 sclip8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sclip8: 0
     rs1:
       <<: *all_regs
@@ -1960,7 +1960,7 @@ sclip8:
 uclip8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uclip8: 0
     rs1:
       <<: *all_regs
@@ -1976,7 +1976,7 @@ uclip8:
 clrs8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       clrs8: 0
     rs1:
       <<: *all_regs
@@ -1989,7 +1989,7 @@ clrs8:
 clz8:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       clz8: 0
     rs1:
       <<: *all_regs
@@ -2003,7 +2003,7 @@ clz8:
 # swap8:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       swap8: 0
 #     rs1:
 #       <<: *all_regs
@@ -2016,7 +2016,7 @@ clz8:
 sunpkd810:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sunpkd810: 0
     rs1:
       <<: *all_regs
@@ -2029,7 +2029,7 @@ sunpkd810:
 sunpkd820:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sunpkd820: 0
     rs1:
       <<: *all_regs
@@ -2042,7 +2042,7 @@ sunpkd820:
 sunpkd830:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sunpkd830: 0
     rs1:
       <<: *all_regs
@@ -2055,7 +2055,7 @@ sunpkd830:
 sunpkd831:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sunpkd831: 0
     rs1:
       <<: *all_regs
@@ -2068,7 +2068,7 @@ sunpkd831:
 sunpkd832:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sunpkd832: 0
     rs1:
       <<: *all_regs
@@ -2081,7 +2081,7 @@ sunpkd832:
 zunpkd810:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       zunpkd810: 0
     rs1:
       <<: *all_regs
@@ -2094,7 +2094,7 @@ zunpkd810:
 zunpkd820:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       zunpkd820: 0
     rs1:
       <<: *all_regs
@@ -2107,7 +2107,7 @@ zunpkd820:
 zunpkd830:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       zunpkd830: 0
     rs1:
       <<: *all_regs
@@ -2120,7 +2120,7 @@ zunpkd830:
 zunpkd831:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       zunpkd831: 0
     rs1:
       <<: *all_regs
@@ -2133,7 +2133,7 @@ zunpkd831:
 zunpkd832:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       zunpkd832: 0
     rs1:
       <<: *all_regs
@@ -2147,7 +2147,7 @@ zunpkd832:
 # pkbb16:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       pkbb16: 0
 #     rs1:
 #       <<: *all_regs
@@ -2166,7 +2166,7 @@ zunpkd832:
 pkbt16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       pkbt16: 0
     rs1:
       <<: *all_regs
@@ -2185,7 +2185,7 @@ pkbt16:
 pktb16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       pktb16: 0
     rs1:
       <<: *all_regs
@@ -2205,7 +2205,7 @@ pktb16:
 # pktt16:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       pktt16: 0
 #     rs1:
 #       <<: *all_regs
@@ -2225,7 +2225,7 @@ pktb16:
 smmul:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smmul: 0
     rs1:
       <<: *all_regs
@@ -2243,7 +2243,7 @@ smmul:
 smmul.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smmul.u: 0
     rs1:
       <<: *all_regs
@@ -2261,7 +2261,7 @@ smmul.u:
 kmmac:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmac: 0
     rs1:
       <<: *all_regs
@@ -2279,7 +2279,7 @@ kmmac:
 kmmac.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmac.u: 0
     rs1:
       <<: *all_regs
@@ -2297,7 +2297,7 @@ kmmac.u:
 kmmsb:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmsb: 0
     rs1:
       <<: *all_regs
@@ -2315,7 +2315,7 @@ kmmsb:
 kmmsb.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmsb.u: 0
     rs1:
       <<: *all_regs
@@ -2333,7 +2333,7 @@ kmmsb.u:
 kwmmul:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kwmmul: 0
     rs1:
       <<: *all_regs
@@ -2351,7 +2351,7 @@ kwmmul:
 kwmmul.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kwmmul.u: 0
     rs1:
       <<: *all_regs
@@ -2372,7 +2372,7 @@ kwmmul.u:
 smmwb:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smmwb: 0
     rs1:
       <<: *all_regs
@@ -2390,7 +2390,7 @@ smmwb:
 smmwb.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smmwb.u: 0
     rs1:
       <<: *all_regs
@@ -2408,7 +2408,7 @@ smmwb.u:
 smmwt:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smmwt: 0
     rs1:
       <<: *all_regs
@@ -2426,7 +2426,7 @@ smmwt:
 smmwt.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smmwt.u: 0
     rs1:
       <<: *all_regs
@@ -2445,7 +2445,7 @@ smmwt.u:
 kmmawb:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmawb: 0
     rs1:
       <<: *all_regs
@@ -2463,7 +2463,7 @@ kmmawb:
 kmmawb.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmawb.u: 0
     rs1:
       <<: *all_regs
@@ -2481,7 +2481,7 @@ kmmawb.u:
 kmmawt:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmawt: 0
     rs1:
       <<: *all_regs
@@ -2499,7 +2499,7 @@ kmmawt:
 kmmawt.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmawt.u: 0
     rs1:
       <<: *all_regs
@@ -2518,7 +2518,7 @@ kmmawt.u:
 kmmwb2:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmwb2: 0
     rs1:
       <<: *all_regs
@@ -2536,7 +2536,7 @@ kmmwb2:
 kmmwb2.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmwb2.u: 0
     rs1:
       <<: *all_regs
@@ -2554,7 +2554,7 @@ kmmwb2.u:
 kmmwt2:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmwt2: 0
     rs1:
       <<: *all_regs
@@ -2572,7 +2572,7 @@ kmmwt2:
 kmmwt2.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmwt2.u: 0
     rs1:
       <<: *all_regs
@@ -2591,7 +2591,7 @@ kmmwt2.u:
 kmmawb2:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmawb2: 0
     rs1:
       <<: *all_regs
@@ -2609,7 +2609,7 @@ kmmawb2:
 kmmawb2.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmawb2.u: 0
     rs1:
       <<: *all_regs
@@ -2627,7 +2627,7 @@ kmmawb2.u:
 kmmawt2:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmawt2: 0
     rs1:
       <<: *all_regs
@@ -2645,7 +2645,7 @@ kmmawt2:
 kmmawt2.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmmawt2.u: 0
     rs1:
       <<: *all_regs
@@ -2665,7 +2665,7 @@ kmmawt2.u:
 smbb16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smbb16: 0
     rs1:
       <<: *all_regs
@@ -2684,7 +2684,7 @@ smbb16:
 smbt16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smbt16: 0
     rs1:
       <<: *all_regs
@@ -2703,7 +2703,7 @@ smbt16:
 smtt16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smtt16: 0
     rs1:
       <<: *all_regs
@@ -2722,7 +2722,7 @@ smtt16:
 kmda:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmda: 0
     rs1:
       <<: *all_regs
@@ -2741,7 +2741,7 @@ kmda:
 kmxda:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmxda: 0
     rs1:
       <<: *all_regs
@@ -2759,7 +2759,7 @@ kmxda:
 smds:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smds: 0
     rs1:
       <<: *all_regs
@@ -2778,7 +2778,7 @@ smds:
 smdrs:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smdrs: 0
     rs1:
       <<: *all_regs
@@ -2797,7 +2797,7 @@ smdrs:
 smxds:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smxds: 0
     rs1:
       <<: *all_regs
@@ -2816,7 +2816,7 @@ smxds:
 kmabb:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmabb: 0
     rs1:
       <<: *all_regs
@@ -2835,7 +2835,7 @@ kmabb:
 kmabt:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmabt: 0
     rs1:
       <<: *all_regs
@@ -2854,7 +2854,7 @@ kmabt:
 kmatt:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmatt: 0
     rs1:
       <<: *all_regs
@@ -2873,7 +2873,7 @@ kmatt:
 kmada:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmada: 0
     rs1:
       <<: *all_regs
@@ -2892,7 +2892,7 @@ kmada:
 kmaxda:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmaxda: 0
     rs1:
       <<: *all_regs
@@ -2911,7 +2911,7 @@ kmaxda:
 kmads:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmads: 0
     rs1:
       <<: *all_regs
@@ -2930,7 +2930,7 @@ kmads:
 kmadrs:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmadrs: 0
     rs1:
       <<: *all_regs
@@ -2949,7 +2949,7 @@ kmadrs:
 kmaxds:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmaxds: 0
     rs1:
       <<: *all_regs
@@ -2968,7 +2968,7 @@ kmaxds:
 kmsda:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmsda: 0
     rs1:
       <<: *all_regs
@@ -2987,7 +2987,7 @@ kmsda:
 kmsxda:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmsxda: 0
     rs1:
       <<: *all_regs
@@ -3007,7 +3007,7 @@ kmsxda:
 smal:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smal: 0
     rs1:
       <<: *pair_regs
@@ -3027,7 +3027,7 @@ smal:
 sclip32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sclip32: 0
     rs1:
       <<: *all_regs
@@ -3043,7 +3043,7 @@ sclip32:
 uclip32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uclip32: 0
     rs1:
       <<: *all_regs
@@ -3059,7 +3059,7 @@ uclip32:
 clrs32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       clrs32: 0
     rs1:
       <<: *all_regs
@@ -3073,7 +3073,7 @@ clrs32:
 # clz32:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       clz32: 0
 #     rs1:
 #       <<: *all_regs
@@ -3086,7 +3086,7 @@ clrs32:
 pbsad:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       pbsad: 0
     rs1:
       <<: *all_regs
@@ -3105,7 +3105,7 @@ pbsad:
 pbsada:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       pbsada: 0
     rs1:
       <<: *all_regs
@@ -3124,7 +3124,7 @@ pbsada:
 smaqa:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smaqa: 0
     rs1:
       <<: *all_regs
@@ -3143,7 +3143,7 @@ smaqa:
 umaqa:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       umaqa: 0
     rs1:
       <<: *all_regs
@@ -3162,7 +3162,7 @@ umaqa:
 smaqa.su:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smaqa.su: 0
     rs1:
       <<: *all_regs
@@ -3182,7 +3182,7 @@ smaqa.su:
 add64:
     config:
       - check ISA:=regex(.*32.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       add64: 0
     rs1:
       <<: *pair_regs
@@ -3200,7 +3200,7 @@ add64:
 radd64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       radd64: 0
     rs1:
       <<: *pair_regs
@@ -3218,7 +3218,7 @@ radd64:
 uradd64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uradd64: 0
     rs1:
       <<: *pair_regs
@@ -3236,7 +3236,7 @@ uradd64:
 kadd64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kadd64: 0
     rs1:
       <<: *pair_regs
@@ -3254,7 +3254,7 @@ kadd64:
 ukadd64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukadd64: 0
     rs1:
       <<: *pair_regs
@@ -3272,7 +3272,7 @@ ukadd64:
 sub64:
     config:
       - check ISA:=regex(.*32.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sub64: 0
     rs1:
       <<: *pair_regs
@@ -3290,7 +3290,7 @@ sub64:
 rsub64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rsub64: 0
     rs1:
       <<: *pair_regs
@@ -3308,7 +3308,7 @@ rsub64:
 ursub64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ursub64: 0
     rs1:
       <<: *pair_regs
@@ -3326,7 +3326,7 @@ ursub64:
 ksub64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ksub64: 0
     rs1:
       <<: *pair_regs
@@ -3344,7 +3344,7 @@ ksub64:
 uksub64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uksub64: 0
     rs1:
       <<: *pair_regs
@@ -3363,7 +3363,7 @@ uksub64:
 smar64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smar64: 0
     rs1:
       <<: *all_regs
@@ -3382,7 +3382,7 @@ smar64:
 smsr64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smsr64: 0
     rs1:
       <<: *all_regs
@@ -3401,7 +3401,7 @@ smsr64:
 umar64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       umar64: 0
     rs1:
       <<: *all_regs
@@ -3420,7 +3420,7 @@ umar64:
 umsr64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       umsr64: 0
     rs1:
       <<: *all_regs
@@ -3439,7 +3439,7 @@ umsr64:
 kmar64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmar64: 0
     rs1:
       <<: *all_regs
@@ -3458,7 +3458,7 @@ kmar64:
 kmsr64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmsr64: 0
     rs1:
       <<: *all_regs
@@ -3477,7 +3477,7 @@ kmsr64:
 ukmar64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukmar64: 0
     rs1:
       <<: *all_regs
@@ -3496,7 +3496,7 @@ ukmar64:
 ukmsr64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukmsr64: 0
     rs1:
       <<: *all_regs
@@ -3516,7 +3516,7 @@ ukmsr64:
 smalbb:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smalbb: 0
     rs1:
       <<: *all_regs
@@ -3535,7 +3535,7 @@ smalbb:
 smalbt:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smalbt: 0
     rs1:
       <<: *all_regs
@@ -3554,7 +3554,7 @@ smalbt:
 smaltt:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smaltt: 0
     rs1:
       <<: *all_regs
@@ -3573,7 +3573,7 @@ smaltt:
 smalda:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smalda: 0
     rs1:
       <<: *all_regs
@@ -3592,7 +3592,7 @@ smalda:
 smalxda:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smalxda: 0
     rs1:
       <<: *all_regs
@@ -3611,7 +3611,7 @@ smalxda:
 smalds:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smalds: 0
     rs1:
       <<: *all_regs
@@ -3630,7 +3630,7 @@ smalds:
 smaldrs:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smaldrs: 0
     rs1:
       <<: *all_regs
@@ -3649,7 +3649,7 @@ smaldrs:
 smalxds:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smalxds: 0
     rs1:
       <<: *all_regs
@@ -3668,7 +3668,7 @@ smalxds:
 smslda:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smslda: 0
     rs1:
       <<: *all_regs
@@ -3687,7 +3687,7 @@ smslda:
 smslxda:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smslxda: 0
     rs1:
       <<: *all_regs
@@ -3708,7 +3708,7 @@ smslxda:
 kaddh:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kaddh: 0
     rs1:
       <<: *all_regs
@@ -3727,7 +3727,7 @@ kaddh:
 ksubh:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ksubh: 0
     rs1:
       <<: *all_regs
@@ -3746,7 +3746,7 @@ ksubh:
 khmbb:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       khmbb: 0
     rs1:
       <<: *all_regs
@@ -3765,7 +3765,7 @@ khmbb:
 khmbt:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       khmbt: 0
     rs1:
       <<: *all_regs
@@ -3784,7 +3784,7 @@ khmbt:
 khmtt:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       khmtt: 0
     rs1:
       <<: *all_regs
@@ -3803,7 +3803,7 @@ khmtt:
 ukaddh:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukaddh: 0
     rs1:
       <<: *all_regs
@@ -3822,7 +3822,7 @@ ukaddh:
 uksubh:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uksubh: 0
     rs1:
       <<: *all_regs
@@ -3841,7 +3841,7 @@ uksubh:
 kaddw:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kaddw: 0
     rs1:
       <<: *all_regs
@@ -3860,7 +3860,7 @@ kaddw:
 ukaddw:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukaddw: 0
     rs1:
       <<: *all_regs
@@ -3879,7 +3879,7 @@ ukaddw:
 ksubw:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ksubw: 0
     rs1:
       <<: *all_regs
@@ -3898,7 +3898,7 @@ ksubw:
 uksubw:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uksubw: 0
     rs1:
       <<: *all_regs
@@ -3917,7 +3917,7 @@ uksubw:
 kdmbb:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kdmbb: 0
     rs1:
       <<: *all_regs
@@ -3936,7 +3936,7 @@ kdmbb:
 kdmbt:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kdmbt: 0
     rs1:
       <<: *all_regs
@@ -3955,7 +3955,7 @@ kdmbt:
 kdmtt:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kdmtt: 0
     rs1:
       <<: *all_regs
@@ -3974,7 +3974,7 @@ kdmtt:
 kslraw:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kslraw: 0
     rs1:
       <<: *all_regs
@@ -3993,7 +3993,7 @@ kslraw:
 kslraw.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kslraw.u: 0
     rs1:
       <<: *all_regs
@@ -4013,7 +4013,7 @@ kslraw.u:
 ksllw:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ksllw: 0
     rs1:
       <<: *all_regs
@@ -4033,7 +4033,7 @@ ksllw:
 kslliw:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kslliw: 0
     rs1:
       <<: *all_regs
@@ -4049,7 +4049,7 @@ kslliw:
 kdmabb:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kdmabb: 0
     rs1:
       <<: *all_regs
@@ -4068,7 +4068,7 @@ kdmabb:
 kdmabt:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kdmabt: 0
     rs1:
       <<: *all_regs
@@ -4087,7 +4087,7 @@ kdmabt:
 kdmatt:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kdmatt: 0
     rs1:
       <<: *all_regs
@@ -4106,7 +4106,7 @@ kdmatt:
 kabsw:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kabsw: 0
     rs1:
       <<: *all_regs
@@ -4120,7 +4120,7 @@ kabsw:
 raddw:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       raddw: 0
     rs1:
       <<: *all_regs
@@ -4138,7 +4138,7 @@ raddw:
 uraddw:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uraddw: 0
     rs1:
       <<: *all_regs
@@ -4156,7 +4156,7 @@ uraddw:
 rsubw:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rsubw: 0
     rs1:
       <<: *all_regs
@@ -4174,7 +4174,7 @@ rsubw:
 ursubw:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ursubw: 0
     rs1:
       <<: *all_regs
@@ -4192,7 +4192,7 @@ ursubw:
 mulr64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       mulr64: 0
     rs1:
       <<: *all_regs
@@ -4209,7 +4209,7 @@ mulr64:
 mulsr64:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       mulsr64: 0
     rs1:
       <<: *all_regs
@@ -4227,7 +4227,7 @@ mulsr64:
 maddr32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       maddr32: 0
     rs1:
       <<: *all_regs
@@ -4245,7 +4245,7 @@ maddr32:
 msubr32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       msubr32: 0
     rs1:
       <<: *all_regs
@@ -4265,7 +4265,7 @@ msubr32:
 # rdov:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       rdov: 0
 #     rd:
 #       <<: *all_regs
@@ -4274,7 +4274,7 @@ msubr32:
 # clrov:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       clrov: 0
 #     rd:
 #       <<: *all_regs
@@ -4283,7 +4283,7 @@ msubr32:
 ave:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ave: 0
     rs1:
       <<: *all_regs
@@ -4301,7 +4301,7 @@ ave:
 sra.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sra.u: 0
     rs1:
       <<: *all_regs
@@ -4319,7 +4319,7 @@ sra.u:
 srai.u:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       srai.u: 0
     rs1:
       <<: *all_regs
@@ -4336,7 +4336,7 @@ srai.u:
 # bitrev:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       bitrev: 0
 #     rs1:
 #       <<: *all_regs
@@ -4355,7 +4355,7 @@ srai.u:
 # bitrevi:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       bitrevi: 0
 #     rs1:
 #       <<: *all_regs
@@ -4371,7 +4371,7 @@ srai.u:
 # wext:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       wext: 0
 #     rs1:
 #       <<: *pair_regs
@@ -4389,7 +4389,7 @@ srai.u:
 # wexti:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       wexti: 0
 #     rs1:
 #       <<: *pair_regs
@@ -4405,7 +4405,7 @@ srai.u:
 insb:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       insb: 0
     rs1:
       <<: *all_regs

--- a/sample_cgfs/rv32zabha.cgf
+++ b/sample_cgfs/rv32zabha.cgf
@@ -163,7 +163,7 @@ amomaxu.b:
 amocas.b:
     config:
       - check ISA:=regex(.*I.*A.*Zabha.*Zacas.*)
-    opcode:
+    mnemonics:
       amocas.b: 0
     rs1:
       <<: *all_regs_mx0
@@ -344,7 +344,7 @@ amomaxu.h:
 amocas.h:
     config:
       - check ISA:=regex(.*I.*A.*Zabha.*Zacas.*)
-    opcode:
+    mnemonics:
       amocas.h: 0
     rs1:
       <<: *all_regs_mx0

--- a/sample_cgfs/rv32zacas.cgf
+++ b/sample_cgfs/rv32zacas.cgf
@@ -2,7 +2,7 @@
 amocas.w:
     config: 
       - check ISA:=regex(.*Zacas.*)
-    opcode: 
+    mnemonics: 
       amocas.w: 0
     rs1: 
       <<: *all_regs_mx0
@@ -20,7 +20,7 @@ amocas.w:
 amocas.d_32:
     config:
       - check ISA:=regex(.*Zacas.*)
-    opcode:
+    mnemonics:
       amocas.d_32: 0
     rs1:
       <<: *all_regs_mx0

--- a/sample_cgfs/rv64i.cgf
+++ b/sample_cgfs/rv64i.cgf
@@ -3,13 +3,13 @@
 fence:
   config: 
     - check ISA:=regex(.*I.*)
-  opcode: 
+  mnemonics: 
     fence: 0
 
 addi:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       addi: 0
     rs1: 
       <<: *all_regs
@@ -26,7 +26,7 @@ addi:
 slti:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       slti: 0
     rs1: 
       <<: *all_regs
@@ -43,7 +43,7 @@ slti:
 sltiu:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sltiu: 0
     rs1: 
       <<: *all_regs
@@ -60,7 +60,7 @@ sltiu:
 andi:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       andi: 0
     rs1: 
       <<: *all_regs
@@ -77,7 +77,7 @@ andi:
 ori:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       ori: 0
     rs1: 
       <<: *all_regs
@@ -94,7 +94,7 @@ ori:
 xori:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       xori: 0
     rs1: 
       <<: *all_regs
@@ -111,7 +111,7 @@ xori:
 slli:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       slli: 0
     rs1: 
       <<: *all_regs
@@ -131,7 +131,7 @@ slli:
 srai:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       srai: 0
     rs1: 
       <<: *all_regs
@@ -151,7 +151,7 @@ srai:
 srli:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       srli: 0
     rs1: 
       <<: *all_regs
@@ -171,7 +171,7 @@ srli:
 add:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       add: 0
     rs1: 
       <<: *all_regs
@@ -190,7 +190,7 @@ add:
 sub:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sub: 0
     rs1: 
       <<: *all_regs
@@ -209,7 +209,7 @@ sub:
 slt:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       slt: 0
     rs1: 
       <<: *all_regs
@@ -228,7 +228,7 @@ slt:
 sltu:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sltu: 0
     rs1: 
       <<: *all_regs
@@ -247,7 +247,7 @@ sltu:
 and:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       and: 0
     rs1: 
       <<: *all_regs
@@ -266,7 +266,7 @@ and:
 or:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       or: 0
     rs1: 
       <<: *all_regs
@@ -285,7 +285,7 @@ or:
 xor:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       xor: 0
     rs1: 
       <<: *all_regs
@@ -304,7 +304,7 @@ xor:
 sll:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sll: 0
     rs1: 
       <<: *all_regs
@@ -326,7 +326,7 @@ sll:
 srl:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       srl: 0
     rs1: 
       <<: *all_regs
@@ -348,7 +348,7 @@ srl:
 sra:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sra: 0
     rs1: 
       <<: *all_regs
@@ -370,7 +370,7 @@ sra:
 beq:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       beq: 0
     rs1: 
       <<: *all_regs
@@ -387,7 +387,7 @@ beq:
 bge:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       bge: 0
     rs1: 
       <<: *all_regs
@@ -404,7 +404,7 @@ bge:
 bgeu:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       bgeu: 0
     rs1: 
       <<: *all_regs
@@ -421,7 +421,7 @@ bgeu:
 blt:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       blt: 0
     rs1: 
       <<: *all_regs
@@ -438,7 +438,7 @@ blt:
 bltu:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       bltu: 0
     rs1: 
       <<: *all_regs
@@ -455,7 +455,7 @@ bltu:
 bne:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       bne: 0
     rs1: 
       <<: *all_regs
@@ -472,7 +472,7 @@ bne:
 lhu-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       lhu: 0
     rs1: 
       <<: *all_regs_mx0
@@ -496,7 +496,7 @@ lhu-align:
 lh-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       lh: 0
     rs1: 
       <<: *all_regs_mx0
@@ -520,7 +520,7 @@ lh-align:
 lbu-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       lbu: 0
     rs1: 
       <<: *all_regs_mx0
@@ -552,7 +552,7 @@ lbu-align:
 lb-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       lb: 0
     rs1: 
       <<: *all_regs_mx0
@@ -584,7 +584,7 @@ lb-align:
 lw-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       lw: 0
     rs1: 
       <<: *all_regs_mx0
@@ -605,7 +605,7 @@ lw-align:
 sh-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sh: 0
     rs1: 
       <<: *all_regs_mx0
@@ -632,7 +632,7 @@ sh-align:
 sb-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sb: 0
     rs1: 
       <<: *all_regs_mx0
@@ -667,7 +667,7 @@ sb-align:
 sw-align:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       sw: 0
     rs1: 
       <<: *all_regs_mx0
@@ -690,7 +690,7 @@ sw-align:
 auipc:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       auipc: 0
     rd: 
       <<: *all_regs
@@ -707,7 +707,7 @@ auipc:
 lui:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       lui: 0
     rd: 
       <<: *all_regs
@@ -724,7 +724,7 @@ lui:
 jal:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       jal: 0
     rd: 
       <<: *all_regs
@@ -737,7 +737,7 @@ jal:
 jalr:
     config: 
       - check ISA:=regex(.*I.*)
-    opcode: 
+    mnemonics: 
       jalr: 0
     rs1:
       <<: *all_regs_mx0
@@ -754,7 +754,7 @@ jalr:
 lwu-align:
     config: 
       - check ISA:=regex(.*RV64.*I.*)
-    opcode: 
+    mnemonics: 
       lwu: 0
     rs1: 
       <<: *all_regs_mx0
@@ -774,7 +774,7 @@ lwu-align:
 ld-align:
     config: 
       - check ISA:=regex(.*RV64.*I.*)
-    opcode: 
+    mnemonics: 
       ld: 0
     rs1: 
       <<: *all_regs_mx0
@@ -798,7 +798,7 @@ ld-align:
 sd-align:
     config: 
       - check ISA:=regex(.*RV64.*I.*)
-    opcode: 
+    mnemonics: 
       sd: 0
     rs1: 
       <<: *all_regs_mx0
@@ -825,7 +825,7 @@ sd-align:
 addiw:
     config: 
       - check ISA:=regex(.*RV64.*I.*)
-    opcode: 
+    mnemonics: 
       addiw: 0
     rs1: 
       <<: *all_regs
@@ -842,7 +842,7 @@ addiw:
 slliw:
     config: 
       - check ISA:=regex(.*RV64.*I.*)
-    opcode: 
+    mnemonics: 
       slliw: 0
     rs1: 
       <<: *all_regs
@@ -862,7 +862,7 @@ slliw:
 srliw:
     config: 
       - check ISA:=regex(.*RV64.*I.*)
-    opcode: 
+    mnemonics: 
       srliw: 0
     rs1: 
       <<: *all_regs
@@ -882,7 +882,7 @@ srliw:
 sraiw:
     config: 
       - check ISA:=regex(.*RV64.*I.*)
-    opcode: 
+    mnemonics: 
       sraiw: 0
     rs1: 
       <<: *all_regs
@@ -902,7 +902,7 @@ sraiw:
 addw:
     config: 
       - check ISA:=regex(.*RV64.*I.*)
-    opcode: 
+    mnemonics: 
       addw: 0
     rs1: 
       <<: *all_regs
@@ -921,7 +921,7 @@ addw:
 subw:
     config: 
       - check ISA:=regex(.*RV64.*I.*)
-    opcode: 
+    mnemonics: 
       subw: 0
     rs1: 
       <<: *all_regs
@@ -940,7 +940,7 @@ subw:
 sllw:
     config: 
       - check ISA:=regex(.*RV64.*I.*)
-    opcode: 
+    mnemonics: 
       sllw: 0
     rs1: 
       <<: *all_regs
@@ -962,7 +962,7 @@ sllw:
 srlw:
     config: 
       - check ISA:=regex(.*RV64.*I.*)
-    opcode: 
+    mnemonics: 
       srlw: 0
     rs1: 
       <<: *all_regs
@@ -983,7 +983,7 @@ srlw:
 sraw:
     config: 
       - check ISA:=regex(.*RV64.*I.*)
-    opcode: 
+    mnemonics: 
       sraw: 0
     rs1: 
       <<: *all_regs

--- a/sample_cgfs/rv64i_fencei.cgf
+++ b/sample_cgfs/rv64i_fencei.cgf
@@ -2,7 +2,7 @@
 fencei:
   config: 
     - check ISA:=regex(.*I.*Zifencei.*)
-  opcode: 
+  mnemonics: 
     fence.i: 0
 
 

--- a/sample_cgfs/rv64i_priv.cgf
+++ b/sample_cgfs/rv64i_priv.cgf
@@ -1,13 +1,13 @@
 ecall:
   config: 
     - check ISA:=regex(.*I.*); def rvtest_mtrap_routine=True 
-  opcode: 
+  mnemonics: 
     ecall: 0
 
 ebreak:
   config: 
     - check ISA:=regex(.*I.*); def rvtest_mtrap_routine=True 
-  opcode: 
+  mnemonics: 
     ebreak: 0
 
 misalign-lh:
@@ -15,7 +15,7 @@ misalign-lh:
   config:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
-  opcode:
+  mnemonics:
     lh: 0
   val_comb:
     'ea_align == 1': 0
@@ -25,7 +25,7 @@ misalign-lhu:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
   cond: check ISA:=regex(.*I.*Zicsr.*)
-  opcode:
+  mnemonics:
     lhu: 0
   val_comb:
     'ea_align == 1': 0
@@ -35,7 +35,7 @@ misalign-lwu:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
   cond: check ISA:=regex(.*64.*I.*Zicsr.*)
-  opcode:
+  mnemonics:
     lwu: 0
   val_comb:
     'ea_align == 1': 0
@@ -47,7 +47,7 @@ misalign-sd:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
   cond: check ISA:=regex(.*64.*I.*Zicsr.*)
-  opcode:
+  mnemonics:
     sd: 0
   val_comb:
     'ea_align == 1': 0
@@ -63,7 +63,7 @@ misalign-ld:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
   cond: check ISA:=regex(.*64.*I.*)
-  opcode:
+  mnemonics:
     ld: 0
   val_comb:
     'ea_align == 1': 0
@@ -79,7 +79,7 @@ misalign-lw:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
   cond: check ISA:=regex(.*I.*Zicsr.*)
-  opcode:
+  mnemonics:
     lw: 0
   val_comb:
     'ea_align == 1': 0
@@ -91,7 +91,7 @@ misalign-sh:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
   cond: check ISA:=regex(.*I.*Zicsr.*)
-  opcode:
+  mnemonics:
     sh: 0
   val_comb:
     'ea_align == 1': 0
@@ -101,7 +101,7 @@ misalign-sw:
     - check ISA:=regex(.*I.*); check hw_data_misaligned_support:=True
     - check ISA:=regex(.*I.*Zicsr.*); check hw_data_misaligned_support:=False; def rvtest_mtrap_routine=True
   cond: check ISA:=regex(.*I.*Zicsr.*)
-  opcode:
+  mnemonics:
     sw: 0
   val_comb:
     'ea_align == 1': 0
@@ -113,7 +113,7 @@ misalign2-jalr:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     jalr: 0
   val_comb:
     'ea_align == 2': 0
@@ -121,7 +121,7 @@ misalign2-jalr:
 misalign1-jalr:
   config: 
     - check ISA:=regex(.*I.*); def rvtest_mtrap_routine=True
-  opcode:
+  mnemonics:
     jalr: 0
   val_comb:
     'ea_align == 1': 0
@@ -131,7 +131,7 @@ misalign-jal:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     jal: 0
   val_comb:
     'ea_align == 2': 0
@@ -141,7 +141,7 @@ misalign-bge:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     bge: 0
   val_comb:
     ' rs1_val>rs2_val and ea_align == 2': 0
@@ -151,7 +151,7 @@ misalign-bgeu:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     bgeu: 0
   val_comb:
     ' rs1_val>rs2_val and ea_align == 2': 0
@@ -161,7 +161,7 @@ misalign-blt:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     blt: 0
   val_comb:
     ' rs1_val<rs2_val and ea_align == 2': 0
@@ -171,7 +171,7 @@ misalign-bltu:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     bltu: 0
   val_comb:
     ' rs1_val<rs2_val and ea_align == 2': 0
@@ -181,7 +181,7 @@ misalign-bne:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     bne: 0
   val_comb:
     ' rs1_val!=rs2_val and ea_align == 2': 0
@@ -191,7 +191,7 @@ misalign-beq:
     - check ISA:=regex(.*I.*C.*)
     - check ISA:=regex(.*I.*Zicsr.*); check ISA:=regex(^[^C]+$); def rvtest_mtrap_routine=True 
   cond: check ISA:=regex(.*I.*)
-  opcode:
+  mnemonics:
     beq: 0
   val_comb:
     ' rs1_val==rs2_val and ea_align == 2': 0

--- a/sample_cgfs/rv64ic.cgf
+++ b/sample_cgfs/rv64ic.cgf
@@ -3,13 +3,13 @@
 cebreak:
   config: 
     - check ISA:=regex(.*I.*C.*)
-  opcode: 
+  mnemonics: 
     c.ebreak: 0
 
 caddi4spn:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.addi4spn: 0
     rd:
       <<: *c_regs
@@ -24,7 +24,7 @@ caddi4spn:
 clw:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.lw: 0
     rs1: 
       <<: *c_regs
@@ -44,7 +44,7 @@ clw:
 cld:
     config: 
       - check ISA:=regex(.*RV64.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.ld: 0
     rs1: 
       <<: *c_regs
@@ -64,7 +64,7 @@ cld:
 csw:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.sw: 0
     rs1: 
       <<: *c_regs
@@ -85,7 +85,7 @@ csw:
 csd:
     config: 
       - check ISA:=regex(.*RV64.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.sd: 0
     rs1: 
       <<: *c_regs
@@ -106,7 +106,7 @@ csd:
 cnop:
     config: 
       - check ISA:=regex(.*I.*C.*) 
-    opcode: 
+    mnemonics: 
       c.nop: 0
     val_comb:
       abstract_comb:
@@ -115,7 +115,7 @@ cnop:
 caddi:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.addi: 0
     rd:
       <<: *all_regs_mx0
@@ -128,7 +128,7 @@ caddi:
 caddiw:
     config: 
       - check ISA:=regex(.*RV64.*I.*C.*) 
-    opcode: 
+    mnemonics: 
       c.addiw: 0
     rd: 
       <<: *all_regs_mx0
@@ -148,7 +148,7 @@ caddiw:
 cli:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.li: 0
   rd:
     <<: *all_regs
@@ -162,7 +162,7 @@ cli:
 caddi16sp:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.addi16sp: 0
     rd:
       x2: 0
@@ -179,7 +179,7 @@ caddi16sp:
 clui:
   config: 
     - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.lui: 0
   rd:
     x0: 0
@@ -227,7 +227,7 @@ clui:
 csrli:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.srli: 0
   rs1:
     <<: *c_regs
@@ -249,7 +249,7 @@ csrli:
 csrai:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.srai: 0
   rs1:
     <<: *c_regs
@@ -271,7 +271,7 @@ csrai:
 candi:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.andi: 0
     rs1:
       <<: *c_regs
@@ -284,7 +284,7 @@ candi:
 csub:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.sub: 0
     rs1:
       <<: *c_regs
@@ -301,7 +301,7 @@ csub:
 cxor:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.xor: 0
     rs1:
       <<: *c_regs
@@ -318,7 +318,7 @@ cxor:
 cor:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.or: 0
     rs1:
       <<: *c_regs
@@ -335,7 +335,7 @@ cor:
 cand:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.and: 0
     rs1:
       <<: *c_regs
@@ -352,7 +352,7 @@ cand:
 csubw:
     config: 
       - check ISA:=regex(.*RV64.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.subw: 0
     rs1:
       <<: *c_regs
@@ -369,7 +369,7 @@ csubw:
 caddw:
     config: 
       - check ISA:=regex(.*RV64.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.addw: 0
     rs1:
       <<: *c_regs
@@ -386,7 +386,7 @@ caddw:
 cj:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.j: 0
   val_comb:
     'imm_val > 0': 0
@@ -399,7 +399,7 @@ cj:
 cbeqz:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.beqz: 0
   rs1:
     <<: *c_regs
@@ -418,7 +418,7 @@ cbeqz:
 cbnez:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.bnez: 0
   rs1:
     <<: *c_regs
@@ -437,7 +437,7 @@ cbnez:
 cslli:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.slli: 0
   rd:
     <<: *c_regs
@@ -459,7 +459,7 @@ cslli:
 clwsp:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.lwsp: 0
     rd: 
       <<: *all_regs_mx0
@@ -474,7 +474,7 @@ clwsp:
 cldsp:
     config: 
       - check ISA:=regex(.*RV64.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.ldsp: 0
     rd: 
       <<: *all_regs_mx0
@@ -489,7 +489,7 @@ cldsp:
 cjr:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.jr: 0
   rs1:
     <<: *all_regs_mx0
@@ -504,7 +504,7 @@ cjr:
 cmv:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.mv: 0
     rs2:
       <<: *all_regs_mx0
@@ -522,7 +522,7 @@ cmv:
 cadd:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.add: 0
     rs1:
       <<: *all_regs
@@ -539,7 +539,7 @@ cadd:
 cjalr:
   config: 
       - check ISA:=regex(.*I.*C.*) 
-  opcode: 
+  mnemonics: 
     c.jalr: 0
   rs1:
     <<: *all_regs_mx0
@@ -554,7 +554,7 @@ cjalr:
 cswsp:
     config: 
       - check ISA:=regex(.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.swsp: 0
     rs2: 
       <<: *all_regs_mx2
@@ -571,7 +571,7 @@ cswsp:
 csdsp:
     config: 
       - check ISA:=regex(.*RV64.*I.*C.*)
-    opcode: 
+    mnemonics: 
       c.sdsp: 0
     rs2: 
       <<: *all_regs_mx2

--- a/sample_cgfs/rv64im.cgf
+++ b/sample_cgfs/rv64im.cgf
@@ -3,7 +3,7 @@
 mul:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       mul: 0
     rs1: 
       <<: *all_regs
@@ -22,7 +22,7 @@ mul:
 mulh:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       mulh: 0
     rs1: 
       <<: *all_regs
@@ -41,7 +41,7 @@ mulh:
 mulhu:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       mulhu: 0
     rs1: 
       <<: *all_regs
@@ -60,7 +60,7 @@ mulhu:
 mulhsu:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       mulhsu: 0
     rs1: 
       <<: *all_regs
@@ -80,7 +80,7 @@ mulhsu:
 div:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       div: 0
     rs1: 
       <<: *all_regs
@@ -99,7 +99,7 @@ div:
 divu:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       divu: 0
     rs1: 
       <<: *all_regs
@@ -118,7 +118,7 @@ divu:
 rem:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       rem: 0
     rs1: 
       <<: *all_regs
@@ -137,7 +137,7 @@ rem:
 remu:
     config: 
       - check ISA:=regex(.*I.*M.*)
-    opcode: 
+    mnemonics: 
       remu: 0
     rs1: 
       <<: *all_regs
@@ -156,7 +156,7 @@ remu:
 mulw:
     config: 
       - check ISA:=regex(.*RV64.*I.*M.*)
-    opcode: 
+    mnemonics: 
       mulw: 0
     rs1: 
       <<: *all_regs
@@ -175,7 +175,7 @@ mulw:
 divw:
     config: 
       - check ISA:=regex(.*RV64.*I.*M.*)
-    opcode: 
+    mnemonics: 
       divw: 0
     rs1: 
       <<: *all_regs
@@ -194,7 +194,7 @@ divw:
 divuw:
     config: 
       - check ISA:=regex(.*RV64.*I.*M.*)
-    opcode: 
+    mnemonics: 
       divuw: 0
     rs1: 
       <<: *all_regs
@@ -213,7 +213,7 @@ divuw:
 remw:
     config: 
       - check ISA:=regex(.*RV64.*I.*M.*)
-    opcode: 
+    mnemonics: 
       remw: 0
     rs1: 
       <<: *all_regs
@@ -232,7 +232,7 @@ remw:
 remuw:
     config: 
       - check ISA:=regex(.*RV64.*I.*M.*)
-    opcode: 
+    mnemonics: 
       remuw: 0
     rs1: 
       <<: *all_regs

--- a/sample_cgfs/rv64ip.cgf
+++ b/sample_cgfs/rv64ip.cgf
@@ -3,7 +3,7 @@
 add32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       add32: 0
     rs1: 
       <<: *all_regs
@@ -22,7 +22,7 @@ add32:
 radd32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       radd32: 0
     rs1:
       <<: *all_regs
@@ -41,7 +41,7 @@ radd32:
 uradd32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uradd32: 0
     rs1:
       <<: *all_regs
@@ -60,7 +60,7 @@ uradd32:
 kadd32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kadd32: 0
     rs1:
       <<: *all_regs
@@ -79,7 +79,7 @@ kadd32:
 ukadd32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukadd32: 0
     rs1:
       <<: *all_regs
@@ -98,7 +98,7 @@ ukadd32:
 sub32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       sub32: 0
     rs1:
       <<: *all_regs
@@ -117,7 +117,7 @@ sub32:
 rsub32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rsub32: 0
     rs1:
       <<: *all_regs
@@ -137,7 +137,7 @@ rsub32:
 ursub32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ursub32: 0
     rs1:
       <<: *all_regs
@@ -156,7 +156,7 @@ ursub32:
 ksub32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ksub32: 0
     rs1:
       <<: *all_regs
@@ -175,7 +175,7 @@ ksub32:
 uksub32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       uksub32: 0
     rs1:
       <<: *all_regs
@@ -194,7 +194,7 @@ uksub32:
 cras32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       cras32: 0
     rs1:
       <<: *all_regs
@@ -213,7 +213,7 @@ cras32:
 rcras32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rcras32: 0
     rs1:
       <<: *all_regs
@@ -232,7 +232,7 @@ rcras32:
 urcras32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       urcras32: 0
     rs1:
       <<: *all_regs
@@ -251,7 +251,7 @@ urcras32:
 kcras32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kcras32: 0
     rs1:
       <<: *all_regs
@@ -270,7 +270,7 @@ kcras32:
 ukcras32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukcras32: 0
     rs1:
       <<: *all_regs
@@ -289,7 +289,7 @@ ukcras32:
 crsa32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       crsa32: 0
     rs1:
       <<: *all_regs
@@ -308,7 +308,7 @@ crsa32:
 rcrsa32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rcrsa32: 0
     rs1:
       <<: *all_regs
@@ -327,7 +327,7 @@ rcrsa32:
 urcrsa32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       urcrsa32: 0
     rs1:
       <<: *all_regs
@@ -346,7 +346,7 @@ urcrsa32:
 kcrsa32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kcrsa32: 0
     rs1:
       <<: *all_regs
@@ -365,7 +365,7 @@ kcrsa32:
 ukcrsa32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukcrsa32: 0
     rs1:
       <<: *all_regs
@@ -384,7 +384,7 @@ ukcrsa32:
 stas32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       stas32: 0
     rs1:
       <<: *all_regs
@@ -403,7 +403,7 @@ stas32:
 rstas32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rstas32: 0
     rs1:
       <<: *all_regs
@@ -422,7 +422,7 @@ rstas32:
 urstas32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       urstas32: 0
     rs1:
       <<: *all_regs
@@ -441,7 +441,7 @@ urstas32:
 kstas32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kstas32: 0
     rs1:
       <<: *all_regs
@@ -460,7 +460,7 @@ kstas32:
 ukstas32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukstas32: 0
     rs1:
       <<: *all_regs
@@ -479,7 +479,7 @@ ukstas32:
 stsa32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       stsa32: 0
     rs1:
       <<: *all_regs
@@ -498,7 +498,7 @@ stsa32:
 rstsa32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       rstsa32: 0
     rs1:
       <<: *all_regs
@@ -517,7 +517,7 @@ rstsa32:
 urstsa32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       urstsa32: 0
     rs1:
       <<: *all_regs
@@ -536,7 +536,7 @@ urstsa32:
 kstsa32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kstsa32: 0
     rs1:
       <<: *all_regs
@@ -555,7 +555,7 @@ kstsa32:
 ukstsa32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       ukstsa32: 0
     rs1:
       <<: *all_regs
@@ -574,7 +574,7 @@ ukstsa32:
 sra32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       sra32: 0
     rs1: 
       <<: *all_regs
@@ -594,7 +594,7 @@ sra32:
 srai32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       srai32: 0
     rs1: 
       <<: *all_regs
@@ -610,7 +610,7 @@ srai32:
 sra32.u:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       sra32.u: 0
     rs1: 
       <<: *all_regs
@@ -630,7 +630,7 @@ sra32.u:
 srai32.u:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       srai32.u: 0
     rs1: 
       <<: *all_regs
@@ -646,7 +646,7 @@ srai32.u:
 srl32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       srl32: 0
     rs1: 
       <<: *all_regs
@@ -666,7 +666,7 @@ srl32:
 srli32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       srli32: 0
     rs1: 
       <<: *all_regs
@@ -682,7 +682,7 @@ srli32:
 srl32.u:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       srl32.u: 0
     rs1: 
       <<: *all_regs
@@ -702,7 +702,7 @@ srl32.u:
 srli32.u:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       srli32.u: 0
     rs1: 
       <<: *all_regs
@@ -718,7 +718,7 @@ srli32.u:
 sll32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       sll32: 0
     rs1: 
       <<: *all_regs
@@ -738,7 +738,7 @@ sll32:
 slli32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       slli32: 0
     rs1: 
       <<: *all_regs
@@ -754,7 +754,7 @@ slli32:
 ksll32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       ksll32: 0
     rs1: 
       <<: *all_regs
@@ -774,7 +774,7 @@ ksll32:
 kslli32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       kslli32: 0
     rs1: 
       <<: *all_regs
@@ -790,7 +790,7 @@ kslli32:
 kslra32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       kslra32: 0
     rs1: 
       <<: *all_regs
@@ -810,7 +810,7 @@ kslra32:
 kslra32.u:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       kslra32.u: 0
     rs1: 
       <<: *all_regs
@@ -830,7 +830,7 @@ kslra32.u:
 smin32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       smin32: 0
     rs1: 
       <<: *all_regs
@@ -849,7 +849,7 @@ smin32:
 umin32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       umin32: 0
     rs1: 
       <<: *all_regs
@@ -868,7 +868,7 @@ umin32:
 smax32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       smax32: 0
     rs1: 
       <<: *all_regs
@@ -887,7 +887,7 @@ smax32:
 umax32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       umax32: 0
     rs1: 
       <<: *all_regs
@@ -906,7 +906,7 @@ umax32:
 kabs32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       kabs32: 0
     rs1: 
       <<: *all_regs
@@ -919,7 +919,7 @@ kabs32:
 khmbb16:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       khmbb16: 0
     rs1: 
       <<: *all_regs
@@ -938,7 +938,7 @@ khmbb16:
 khmbt16:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       khmbt16: 0
     rs1: 
       <<: *all_regs
@@ -957,7 +957,7 @@ khmbt16:
 khmtt16:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       khmtt16: 0
     rs1: 
       <<: *all_regs
@@ -976,7 +976,7 @@ khmtt16:
 kdmbb16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kdmbb16: 0
     rs1:
       <<: *all_regs
@@ -995,7 +995,7 @@ kdmbb16:
 kdmbt16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kdmbt16: 0
     rs1:
       <<: *all_regs
@@ -1014,7 +1014,7 @@ kdmbt16:
 kdmtt16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kdmtt16: 0
     rs1:
       <<: *all_regs
@@ -1033,7 +1033,7 @@ kdmtt16:
 kdmabb16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kdmabb16: 0
     rs1:
       <<: *all_regs
@@ -1052,7 +1052,7 @@ kdmabb16:
 kdmabt16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kdmabt16: 0
     rs1:
       <<: *all_regs
@@ -1071,7 +1071,7 @@ kdmabt16:
 kdmatt16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kdmatt16: 0
     rs1:
       <<: *all_regs
@@ -1091,7 +1091,7 @@ kdmatt16:
 # smbb32:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       smbb32: 0
 #     rs1:
 #       <<: *all_regs
@@ -1110,7 +1110,7 @@ kdmatt16:
 smbt32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smbt32: 0
     rs1:
       <<: *all_regs
@@ -1129,7 +1129,7 @@ smbt32:
 smtt32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smtt32: 0
     rs1:
       <<: *all_regs
@@ -1148,7 +1148,7 @@ smtt32:
 kmabb32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmabb32: 0
     rs1:
       <<: *all_regs
@@ -1167,7 +1167,7 @@ kmabb32:
 kmabt32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmabt32: 0
     rs1:
       <<: *all_regs
@@ -1186,7 +1186,7 @@ kmabt32:
 kmatt32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmatt32: 0
     rs1:
       <<: *all_regs
@@ -1205,7 +1205,7 @@ kmatt32:
 kmda32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmda32: 0
     rs1:
       <<: *all_regs
@@ -1224,7 +1224,7 @@ kmda32:
 kmxda32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmxda32: 0
     rs1:
       <<: *all_regs
@@ -1244,7 +1244,7 @@ kmxda32:
 # kmada32:
 #     config:
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode:
+#     mnemonics:
 #       kmada32: 0
 #     rs1:
 #       <<: *all_regs
@@ -1263,7 +1263,7 @@ kmxda32:
 kmaxda32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmaxda32: 0
     rs1:
       <<: *all_regs
@@ -1282,7 +1282,7 @@ kmaxda32:
 kmads32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmads32: 0
     rs1:
       <<: *all_regs
@@ -1301,7 +1301,7 @@ kmads32:
 kmadrs32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmadrs32: 0
     rs1:
       <<: *all_regs
@@ -1320,7 +1320,7 @@ kmadrs32:
 kmaxds32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmaxds32: 0
     rs1:
       <<: *all_regs
@@ -1339,7 +1339,7 @@ kmaxds32:
 kmsda32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmsda32: 0
     rs1:
       <<: *all_regs
@@ -1358,7 +1358,7 @@ kmsda32:
 kmsxda32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       kmsxda32: 0
     rs1:
       <<: *all_regs
@@ -1377,7 +1377,7 @@ kmsxda32:
 smds32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smds32: 0
     rs1:
       <<: *all_regs
@@ -1396,7 +1396,7 @@ smds32:
 smdrs32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smdrs32: 0
     rs1:
       <<: *all_regs
@@ -1415,7 +1415,7 @@ smdrs32:
 smxds32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       smxds32: 0
     rs1:
       <<: *all_regs
@@ -1434,7 +1434,7 @@ smxds32:
 sraiw.u:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       sraiw.u: 0
     rs1: 
       <<: *all_regs
@@ -1451,7 +1451,7 @@ sraiw.u:
 # pkbb32:
 #     config: 
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode: 
+#     mnemonics: 
 #       pkbb32: 0
 #     rs1: 
 #       <<: *all_regs
@@ -1470,7 +1470,7 @@ sraiw.u:
 pkbt32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       pkbt32: 0
     rs1: 
       <<: *all_regs
@@ -1489,7 +1489,7 @@ pkbt32:
 pktb32:
     config: 
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode: 
+    mnemonics: 
       pktb32: 0
     rs1: 
       <<: *all_regs
@@ -1509,7 +1509,7 @@ pktb32:
 # pktt32:
 #     config: 
 #       - check ISA:=regex(.*I.*P.*Zicsr.*)
-#     opcode: 
+#     mnemonics: 
 #       pktt32: 0
 #     rs1: 
 #       <<: *all_regs
@@ -1529,7 +1529,7 @@ pktb32:
 clz32:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       clz32: 0
     rs1:
       <<: *all_regs
@@ -1542,7 +1542,7 @@ clz32:
 pkbb16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       pkbb16: 0
     rs1:
       <<: *all_regs
@@ -1561,7 +1561,7 @@ pkbb16:
 pktt16:
     config:
       - check ISA:=regex(.*I.*P.*Zicsr.*)
-    opcode:
+    mnemonics:
       pktt16: 0
     rs1:
       <<: *all_regs

--- a/sample_cgfs/rv64zacas.cgf
+++ b/sample_cgfs/rv64zacas.cgf
@@ -2,7 +2,7 @@
 amocas.w:
     config: 
       - check ISA:=regex(.*Zacas.*)
-    opcode: 
+    mnemonics: 
       amocas.w: 0
     rs1: 
       <<: *all_regs_mx0
@@ -20,7 +20,7 @@ amocas.w:
 amocas.d_64:
     config: 
       - check ISA:=regex(.*Zacas.*)
-    opcode: 
+    mnemonics: 
       amocas.d_64: 0
     rs1: 
       <<: *all_regs_mx0
@@ -38,7 +38,7 @@ amocas.d_64:
 amocas.q:
     config:
       - check ISA:=regex(.*Zacas.*)
-    opcode:
+    mnemonics:
       amocas.q: 0
     rs1:
       <<: *all_regs_mx0

--- a/sample_cgfs/zcmop.cgf
+++ b/sample_cgfs/zcmop.cgf
@@ -10,7 +10,7 @@ c.mop.1:
 c.mop.3:
   config: 
       - check ISA:=regex(.*C.*Zcmop.*) 
-  opcode: 
+  mnemonics: 
     c.mop.3:
   val_comb:
     abstract_comb:
@@ -19,7 +19,7 @@ c.mop.3:
 c.mop.5:
   config: 
       - check ISA:=regex(.*C.*Zcmop.*) 
-  opcode: 
+  mnemonics: 
     c.mop.5:
   val_comb:
     abstract_comb:
@@ -28,7 +28,7 @@ c.mop.5:
 c.mop.7:
   config: 
       - check ISA:=regex(.*C.*Zcmop.*) 
-  opcode: 
+  mnemonics: 
     c.mop.7:
   val_comb:
     abstract_comb:
@@ -37,7 +37,7 @@ c.mop.7:
 c.mop.9:
   config: 
       - check ISA:=regex(.*C.*Zcmop.*) 
-  opcode: 
+  mnemonics: 
     c.mop.9:
   val_comb:
     abstract_comb:
@@ -46,7 +46,7 @@ c.mop.9:
 c.mop.11:
   config: 
       - check ISA:=regex(.*C.*Zcmop.*) 
-  opcode: 
+  mnemonics: 
     c.mop.11:
   val_comb:
     abstract_comb:
@@ -55,7 +55,7 @@ c.mop.11:
 c.mop.13:
   config: 
       - check ISA:=regex(.*C.*Zcmop.*) 
-  opcode: 
+  mnemonics: 
     c.mop.13:
   val_comb:
     abstract_comb:
@@ -64,7 +64,7 @@ c.mop.13:
 c.mop.15:
   config: 
       - check ISA:=regex(.*C.*Zcmop.*) 
-  opcode: 
+  mnemonics: 
     c.mop.15:
   val_comb:
     abstract_comb:

--- a/sample_cgfs/zicfilp.cgf
+++ b/sample_cgfs/zicfilp.cgf
@@ -1,7 +1,7 @@
 lpad-m:
   config:
     - check ISA:=regex(.*I.*Zicsr.*Zicfilp.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True
-  opcode:
+  mnemonics:
     lpad-m: 0
   val_comb:
     'imm_val == 0': 0
@@ -16,7 +16,7 @@ lpad-m:
 lpad-s:
   config:
     - check ISA:=regex(.*I.*Zicsr.*Zicfilp.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True
-  opcode:
+  mnemonics:
     lpad-s: 0
   val_comb:
     'imm_val == 0': 0
@@ -31,7 +31,7 @@ lpad-s:
 lpad-u:
   config:
     - check ISA:=regex(.*I.*Zicsr.*Zicfilp.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True
-  opcode:
+  mnemonics:
     lpad-u: 0
   val_comb:
     'imm_val == 0': 0

--- a/sample_cgfs/zicfiss.cgf
+++ b/sample_cgfs/zicfiss.cgf
@@ -1,7 +1,7 @@
 sspush_popchk_u:
     config: 
       - check ISA:=regex(.*I.*Zicsr.*Zicfiss.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True
-    opcode: 
+    mnemonics: 
       sspushpopchk_u: 0
     val_comb:
       <<: [*base_rs2val_sgn]
@@ -11,7 +11,7 @@ sspush_popchk_u:
 sspush_popchk_s:
     config:
       - check ISA:=regex(.*I.*Zicsr.*Zicfiss.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True
-    opcode:
+    mnemonics:
       sspushpopchk_s: 0
     val_comb:
       <<: [*base_rs2val_sgn]
@@ -21,7 +21,7 @@ sspush_popchk_s:
 csspush_popchk_u:
     config: 
       - check ISA:=regex(.*I.*C.*Zicsr.*Zicfiss.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True
-    opcode: 
+    mnemonics: 
       c.sspushpopchk_u: 0
     val_comb:
       <<: [*base_rs2val_sgn]
@@ -31,7 +31,7 @@ csspush_popchk_u:
 csspush_popchk_s:
     config:
       - check ISA:=regex(.*I.*C.*Zicsr.*Zicfiss.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True
-    opcode:
+    mnemonics:
       c.sspushpopchk_s: 0
     val_comb:
       <<: [*base_rs2val_sgn]

--- a/sample_cgfs/zicond.cgf
+++ b/sample_cgfs/zicond.cgf
@@ -1,7 +1,7 @@
 czero.eqz:
     config: 
       - check ISA:=regex(.*Zicond.*)
-    opcode: 
+    mnemonics: 
       czero.eqz: 0
     rs1: 
       <<: *all_regs
@@ -20,7 +20,7 @@ czero.eqz:
 czero.nez:
     config: 
       - check ISA:=regex(.*Zicond.*)
-    opcode: 
+    mnemonics: 
       czero.nez: 0
     rs1: 
       <<: *all_regs

--- a/sample_cgfs/zimop.cgf
+++ b/sample_cgfs/zimop.cgf
@@ -3,7 +3,7 @@
 mop.rr.0:
     config: 
       - check ISA:=regex(.*Zimop.*)
-    opcode: 
+    mnemonics: 
       mop.rr.0: 0
     rs1: 
       <<: *all_regs
@@ -22,7 +22,7 @@ mop.rr.0:
 mop.rr.1:
     config: 
       - check ISA:=regex(.*Zimop.*)
-    opcode: 
+    mnemonics: 
       mop.rr.1: 0
     rs1: 
       <<: *all_regs
@@ -41,7 +41,7 @@ mop.rr.1:
 mop.rr.2:
     config: 
       - check ISA:=regex(.*Zimop.*)
-    opcode: 
+    mnemonics: 
       mop.rr.2: 0
     rs1: 
       <<: *all_regs
@@ -60,7 +60,7 @@ mop.rr.2:
 mop.rr.3:
     config: 
       - check ISA:=regex(.*Zimop.*)
-    opcode: 
+    mnemonics: 
       mop.rr.3: 0
     rs1: 
       <<: *all_regs
@@ -79,7 +79,7 @@ mop.rr.3:
 mop.rr.4:
     config: 
       - check ISA:=regex(.*Zimop.*)
-    opcode: 
+    mnemonics: 
       mop.rr.4: 0
     rs1: 
       <<: *all_regs
@@ -98,7 +98,7 @@ mop.rr.4:
 mop.rr.5:
     config: 
       - check ISA:=regex(.*Zimop.*)
-    opcode: 
+    mnemonics: 
       mop.rr.5: 0
     rs1: 
       <<: *all_regs
@@ -117,7 +117,7 @@ mop.rr.5:
 mop.rr.6:
     config: 
       - check ISA:=regex(.*Zimop.*)
-    opcode: 
+    mnemonics: 
       mop.rr.6: 0
     rs1: 
       <<: *all_regs
@@ -136,7 +136,7 @@ mop.rr.6:
 mop.rr.7:
     config: 
       - check ISA:=regex(.*Zimop.*)
-    opcode: 
+    mnemonics: 
       mop.rr.7: 0
     rs1: 
       <<: *all_regs
@@ -155,7 +155,7 @@ mop.rr.7:
 mop.r.0:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.0: 0
     rs1:
       <<: *all_regs
@@ -172,7 +172,7 @@ mop.r.0:
 mop.r.1:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.1: 0
     rs1:
       <<: *all_regs
@@ -189,7 +189,7 @@ mop.r.1:
 mop.r.2:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.2: 0
     rs1:
       <<: *all_regs
@@ -206,7 +206,7 @@ mop.r.2:
 mop.r.3:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.3: 0
     rs1:
       <<: *all_regs
@@ -223,7 +223,7 @@ mop.r.3:
 mop.r.4:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.4: 0
     rs1:
       <<: *all_regs
@@ -240,7 +240,7 @@ mop.r.4:
 mop.r.5:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.5: 0
     rs1:
       <<: *all_regs
@@ -257,7 +257,7 @@ mop.r.5:
 mop.r.6:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.6: 0
     rs1:
       <<: *all_regs
@@ -274,7 +274,7 @@ mop.r.6:
 mop.r.7:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.7: 0
     rs1:
       <<: *all_regs
@@ -291,7 +291,7 @@ mop.r.7:
 mop.r.8:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.8: 0
     rs1:
       <<: *all_regs
@@ -308,7 +308,7 @@ mop.r.8:
 mop.r.9:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.9: 0
     rs1:
       <<: *all_regs
@@ -325,7 +325,7 @@ mop.r.9:
 mop.r.10:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.10: 0
     rs1:
       <<: *all_regs
@@ -342,7 +342,7 @@ mop.r.10:
 mop.r.11:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.11: 0
     rs1:
       <<: *all_regs
@@ -359,7 +359,7 @@ mop.r.11:
 mop.r.12:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.12: 0
     rs1:
       <<: *all_regs
@@ -376,7 +376,7 @@ mop.r.12:
 mop.r.13:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.13: 0
     rs1:
       <<: *all_regs
@@ -393,7 +393,7 @@ mop.r.13:
 mop.r.14:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.14: 0
     rs1:
       <<: *all_regs
@@ -410,7 +410,7 @@ mop.r.14:
 mop.r.15:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.15: 0
     rs1:
       <<: *all_regs
@@ -427,7 +427,7 @@ mop.r.15:
 mop.r.16:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.16: 0
     rs1:
       <<: *all_regs
@@ -444,7 +444,7 @@ mop.r.16:
 mop.r.17:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.17: 0
     rs1:
       <<: *all_regs
@@ -461,7 +461,7 @@ mop.r.17:
 mop.r.18:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.18: 0
     rs1:
       <<: *all_regs
@@ -478,7 +478,7 @@ mop.r.18:
 mop.r.19:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.19: 0
     rs1:
       <<: *all_regs
@@ -495,7 +495,7 @@ mop.r.19:
 mop.r.20:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.20: 0
     rs1:
       <<: *all_regs
@@ -512,7 +512,7 @@ mop.r.20:
 mop.r.21:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.21: 0
     rs1:
       <<: *all_regs
@@ -529,7 +529,7 @@ mop.r.21:
 mop.r.22:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.22: 0
     rs1:
       <<: *all_regs
@@ -546,7 +546,7 @@ mop.r.22:
 mop.r.23:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.23: 0
     rs1:
       <<: *all_regs
@@ -563,7 +563,7 @@ mop.r.23:
 mop.r.24:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.24: 0
     rs1:
       <<: *all_regs
@@ -580,7 +580,7 @@ mop.r.24:
 mop.r.25:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.25: 0
     rs1:
       <<: *all_regs
@@ -597,7 +597,7 @@ mop.r.25:
 mop.r.26:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.26: 0
     rs1:
       <<: *all_regs
@@ -614,7 +614,7 @@ mop.r.26:
 mop.r.27:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.27: 0
     rs1:
       <<: *all_regs
@@ -631,7 +631,7 @@ mop.r.27:
 mop.r.28:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.28: 0
     rs1:
       <<: *all_regs
@@ -648,7 +648,7 @@ mop.r.28:
 mop.r.29:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.29: 0
     rs1:
       <<: *all_regs
@@ -665,7 +665,7 @@ mop.r.29:
 mop.r.30:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.30: 0
     rs1:
       <<: *all_regs
@@ -682,7 +682,7 @@ mop.r.30:
 mop.r.31:
     config:
       - check ISA:=regex(.*Zimop.*)
-    opcode:
+    mnemonics:
       mop.r.31: 0
     rs1:
       <<: *all_regs


### PR DESCRIPTION
-Add test-1.yml for CI
-Add hardcoded register testcases to dataset.cgf and rv32im.cgf (missing coverage in the division testcases https://github.com/riscv-non-isa/riscv-arch-test/issues/306)
-Update in generator.py- The missing coverage of hard coded register testcases will be taken care of only if a hard coded register is assigned in the op_comb node of a coverpoint of an instruction.
-Add 'warning' as a verbose level in main.py
-Update 'opcode' to 'mnemonics' in the cgf files
-Define rs1_val_data for c.ldsp in imc.yaml
-Define rs1_val_data and rs2_val_data for instructions from zicfiss.cgf in template.yaml