### PR TITLE
Add support for Zhinx extension

### DIFF
--- a/riscv_ctg/data/inx.yaml
+++ b/riscv_ctg/data/inx.yaml
@@ -1528,3 +1528,742 @@ fcvt.s.lu:
     /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
     val_offset:$val_offset; rmval:$rm_val; correctval:$correctval; testreg:$testreg;
     fcsr_val: $fcsr*/
+    
+fadd.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32]
+  std_op:
+  formattype: 'rformat'
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val; 
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset; rmval:$rm_val; fcsr: $fcsr;
+       correctval:??; testreg:$testreg 
+    */
+    TEST_FPRR_OP($inst, $rd, $rs1, $rs2, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fclass.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; correctval:??; testreg:$testreg;
+    fcsr_val:$fcsr*/
+    TEST_FPID_OP_NRM($inst, $rd, $rs1, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fmax.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset; fcsr: $fcsr;
+       correctval:??; testreg:$testreg
+    */
+    TEST_FPRR_OP_NRM($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fmin.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset; fcsr: $fcsr;
+       correctval:??; testreg:$testreg
+    */
+    TEST_FPRR_OP_NRM($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+feq.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+    valaddr_reg:$valaddr_reg; val_offset:$val_offset; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr*/
+    TEST_FCMP_OP($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fle.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+    valaddr_reg:$valaddr_reg; val_offset:$val_offset; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr*/
+    TEST_FCMP_OP($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+flt.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+    valaddr_reg:$valaddr_reg; val_offset:$val_offset; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr*/
+    TEST_FCMP_OP($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+  
+fsgnj.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset; fcsr: $fcsr;
+       correctval:??; testreg:$testreg
+    */
+    TEST_FPRR_OP_NRM($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fsgnjn.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset;  fcsr: $fcsr;
+       correctval:??; testreg:$testreg
+    */
+    TEST_FPRR_OP_NRM($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fsgnjx.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset; fcsr: $fcsr;
+       correctval:??; testreg:$testreg
+    */
+    TEST_FPRR_OP_NRM($inst, $rd, $rs1, $rs2, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+  
+fsqrt.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr */
+    TEST_FPSR_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fdiv.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset; rmval:$rm_val; fcsr: $fcsr;
+       correctval:??; testreg:$testreg
+    */
+    TEST_FPRR_OP($inst, $rd, $rs1, $rs2, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fmul.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset; rmval:$rm_val; fcsr: $fcsr;
+       correctval:??; testreg:$testreg
+    */
+    TEST_FPRR_OP($inst, $rd, $rs1, $rs2, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+
+fsub.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 2
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'rformat'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+       valaddr_reg:$valaddr_reg; val_offset:$val_offset; rmval:$rm_val; fcsr: $fcsr;
+       correctval:??; testreg:$testreg*/
+    TEST_FPRR_OP($inst, $rd, $rs1, $rs2, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+
+fcvt.h.w:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: '4'
+    val_template: "'.word $val;'"
+    load_instr: "lw"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr*/
+    TEST_FPIO_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
+
+fcvt.h.wu:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: '4'
+    val_template: "'.word $val;'"
+    load_instr: "LREGWU"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr*/
+    TEST_FPIO_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
+
+fcvt.w.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val:$fcsr*/
+    TEST_FPID_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
+
+fcvt.wu.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val:$fcsr*/
+    TEST_FPID_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
+
+fcvt.s.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr */
+    TEST_FPSR_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+    
+fcvt.h.l:
+  sig:
+    stride: 1
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: '8'
+    val_template: "'.dword $val;'"
+    load_instr: "ld"
+  xlen: [64]
+  isa: 
+    - I_Zfinx_Zhinx
+  std_op:
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  formattype: 'fsrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr*/
+    TEST_FPIO_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
+
+fcvt.l.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [64]
+  std_op:
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[0,1,2,3,4,7]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  formattype: 'fsrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val:$fcsr*/
+    TEST_FPID_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
+
+fcvt.lu.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[0,1,2,3,4,7]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val:$fcsr*/
+    TEST_FPID_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
+
+fcvt.h.lu:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 1
+    sz: '8'
+    val_template: "'.dword $val;'"
+    load_instr: "ld"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'fsrformat'
+  rs1_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+    // $comment
+    /* opcode: $inst ; op1:$rs1; dest:$rd; op1val:$rs1_val; valaddr_reg:$valaddr_reg;
+    val_offset:$val_offset; rmval:$rm_val; correctval:??; testreg:$testreg;
+    fcsr_val: $fcsr*/
+    TEST_FPIO_OP($inst, $rd, $rs1, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg,$load_instr)
+    
+fmadd.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 3
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'r4format'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rs3_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; op3:$rs3; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+    op3val:$rs3_val; valaddr_reg:$valaddr_reg; val_offset:$val_offset; rmval:$rm_val;
+    testreg:$testreg; fcsr_val:$fcsr */
+    TEST_FPR4_OP($inst, $rd, $rs1, $rs2, $rs3, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+
+fmsub.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 3
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'r4format'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rs3_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; op3:$rs3; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+    op3val:$rs3_val; valaddr_reg:$valaddr_reg; val_offset:$val_offset; rmval:$rm_val;
+    testreg:$testreg; fcsr_val:$fcsr */
+    TEST_FPR4_OP($inst, $rd, $rs1, $rs2, $rs3, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fnmadd.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 3
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'r4format'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rs3_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; op3:$rs3; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+    op3val:$rs3_val; valaddr_reg:$valaddr_reg; val_offset:$val_offset; rmval:$rm_val;
+    testreg:$testreg; fcsr_val:$fcsr */
+    TEST_FPR4_OP($inst, $rd, $rs1, $rs2, $rs3, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)
+
+fnmsub.h:
+  sig:
+    stride: 2
+    sz: 'SIGALIGN'
+  val:
+    stride: 3
+    sz: 'FLEN/8'
+    val_template: "'NAN_BOXED($val,$width,FLEN)'"
+    load_instr: "FLREG"
+  xlen: [32,64]
+  isa: 
+    - I_Zfinx_Zhinx
+  flen: [16,32,64]
+  rm_val_data: '[7,0,1,2,3,4]'
+  fcsr_data: '[x<<5|y for x,y in itertools.product([0,1,2,3,4],range(0,2**5))]'
+  std_op:
+  formattype: 'r4format'
+  rs1_op_data: *all_regs
+  rs2_op_data: *all_regs
+  rs3_op_data: *all_regs
+  rd_op_data: *all_regs
+  template: |-
+
+    // $comment
+    /* opcode: $inst ; op1:$rs1; op2:$rs2; op3:$rs3; dest:$rd; op1val:$rs1_val; op2val:$rs2_val;
+    op3val:$rs3_val; valaddr_reg:$valaddr_reg; val_offset:$val_offset; rmval:$rm_val;
+    testreg:$testreg; fcsr_val:$fcsr */
+    TEST_FPR4_OP($inst, $rd, $rs1, $rs2, $rs3, $rm_val, $fcsr, $correctval, $valaddr_reg, $val_offset, $flagreg, $swreg, $testreg)

--- a/riscv_ctg/env/arch_test.h
+++ b/riscv_ctg/env/arch_test.h
@@ -111,6 +111,11 @@
   #define FSREG SREG
   #define FREGWIDTH 8
   #define FLEN 64
+#elif ZHINX==1
+  #define FLREG lw
+  #define FSREG sw
+  #define FREGWIDTH 4
+  #define FLEN 32
 #endif
 
 #if FLEN>XLEN

--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -260,7 +260,7 @@ class Generator():
 
 
         is_nan_box = False
-        is_fext = any(['F' in x or 'D' in x or 'Zfh' in x or 'Zfinx' in x for x in opnode['isa']])
+        is_fext = any(['F' in x or 'D' in x or 'Zfh' in x or 'Zfinx' in x or 'Zhinx' in x for x in opnode['isa']])
         is_sgn_extd = True if (inxFlag and iflen <xlen) else False
 
         if is_fext:
@@ -812,6 +812,7 @@ class Generator():
                     for y in op_inds[i:]:
                         if op[y] == op[x]:
                             val[ind_dict[y]] = val[ind_dict[x]]
+
             if self.is_fext:
                 instr_dict.append(self.__fext_instr__(op,val))
             elif self.opcode == 'c.lui':
@@ -888,7 +889,7 @@ class Generator():
             if (is_fp_instruction(insn)):
                 insn = "fadd.s"
             instr_obj = instructionObject(None, insn, None)
-            ext_specific_vars = instr_obj.evaluate_instr_var("ext_specific_vars", {**var_dict, 'flen': self.flen, 'iflen': self.iflen}, None, {'fcsr': hex(var_dict.get('fcsr', 0))})
+            ext_specific_vars = instr_obj.evaluate_instr_var("ext_specific_vars", {**var_dict, 'flen': self.flen, 'iflen': self.iflen,'inxFlag': self.inxFlag, 'xlen': self.xlen}, None, {'fcsr': hex(var_dict.get('fcsr', 0))})
 
             if ext_specific_vars is not None:
                 var_dict.update(ext_specific_vars)

--- a/riscv_ctg/helpers.py
+++ b/riscv_ctg/helpers.py
@@ -78,7 +78,7 @@ def merge_fields_f(val_vars,cvp,flen,iflen,merge,inxFlag=False):
                     fdict[nan_var] = eval(match_obj.group(nan_var))
                 else:
                     fdict[nan_var] = (2**(flen-iflen))-1
-        elif sgn_extd:
+            elif sgn_extd:
                 sgn_var = 'rs{0}_sgn_prefix'.format(num_dict[var])
                 regex = val_regex.format(sgn_var.replace("_","\\_"),sgn_var)
                 match_obj = re.search(regex,cvp)

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fadd.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fadd.cgf
@@ -1,0 +1,188 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fadd_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fadd.h", 2,True)': 0
+       
+fadd_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,16, "fadd.h", 2,True)': 0
+        
+fadd_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,16, "fadd.h", 2,True)': 0
+        
+fadd_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,16, "fadd.h", 2,True)': 0
+        
+fadd_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,16, "fadd.h", 2,True)': 0
+        
+fadd_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,16, "fadd.h", 2,True)': 0
+        
+fadd_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,16, "fadd.h", 2,True)': 0
+        
+fadd_b10:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b10(flen,16, "fadd.h", 2,True)': 0
+        
+fadd_b11:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b11(flen,16, "fadd.h", 2,True)': 0
+        
+fadd_b12:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b12(flen,16, "fadd.h", 2,True)': 0
+        
+fadd_b13:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b13(flen,16, "fadd.h", 2,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fcvt.w.h.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fcvt.w.h.cgf
@@ -1,0 +1,92 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fcvt.w.h_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.w.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fcvt.w.h", 1,True)': 0
+        
+fcvt.w.h_b22:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.w.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b22(flen,16, "fcvt.w.h", 1,True)': 0
+        
+fcvt.w.h_b23:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.w.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b23(flen,16, "fcvt.w.h", 1,True)': 0
+        
+fcvt.w.h_b24:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.w.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b24(flen,16, "fcvt.w.h", 1,True)': 0
+        
+fcvt.w.h_b27:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.w.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b27(flen,16, "fcvt.w.h", 1,True)': 0
+        
+fcvt.w.h_b28:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.w.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b28(flen,16, "fcvt.w.h", 1,True)': 0
+        
+fcvt.w.h_b29:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.w.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b29(flen,16, "fcvt.w.h", 1,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fcvt.wu.h.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fcvt.wu.h.cgf
@@ -1,0 +1,92 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fcvt.wu.h_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.wu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fcvt.wu.h", 1,True)': 0
+        
+fcvt.wu.h_b22:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.wu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b22(flen,16, "fcvt.wu.h", 1,True)': 0
+        
+fcvt.wu.h_b23:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.wu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b23(flen,16, "fcvt.wu.h", 1,True)': 0
+        
+fcvt.wu.h_b24:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.wu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b24(flen,16, "fcvt.wu.h", 1,True)': 0
+        
+fcvt.wu.h_b27:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.wu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b27(flen,16, "fcvt.wu.h", 1,True)': 0
+        
+fcvt.wu.h_b28:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.wu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b28(flen,16, "fcvt.wu.h", 1,True)': 0
+        
+fcvt.wu.h_b29:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fcvt.wu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b29(flen,16, "fcvt.wu.h", 1,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fdiv.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fdiv.cgf
@@ -1,0 +1,188 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fdiv_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fdiv.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fdiv.h", 2,True)': 0
+        
+fdiv_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fdiv.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,16, "fdiv.h", 2,True)': 0
+        
+fdiv_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fdiv.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,16, "fdiv.h", 2,True)': 0
+        
+fdiv_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fdiv.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,16, "fdiv.h", 2,True)': 0
+        
+fdiv_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fdiv.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,16, "fdiv.h", 2,True)': 0
+
+fdiv_b6:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fdiv.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b6(flen,16, "fdiv.h", 2,True)': 0
+        
+fdiv_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fdiv.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,16, "fdiv.h", 2,True)': 0
+        
+fdiv_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fdiv.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,16, "fdiv.h", 2,True)': 0
+        
+fdiv_b9:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fdiv.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b9(flen,16, "fdiv.h", 2,True)': 0
+
+fdiv_b20:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fdiv.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b20(flen,16, "fdiv.h", 2,True)': 0
+        
+fdiv_b21:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fdiv.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b21(flen,16, "fdiv.h", 2,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_feq.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_feq.cgf
@@ -1,0 +1,35 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+feq_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      feq.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "feq.h", 2,True)': 0
+        
+feq_b19:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      feq.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen,16, "feq.h", 2,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fle.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fle.cgf
@@ -1,0 +1,35 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fle_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fle.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fle.h", 2,True)': 0
+        
+fle_b19:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fle.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen,16, "fle.h", 2,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_flt.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_flt.cgf
@@ -1,0 +1,35 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+flt_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      flt.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen, 16, "flt.h", 2,True)': 0
+        
+flt_b19:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      flt.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen,16, "flt.h", 2,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fmadd.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fmadd.cgf
@@ -1,0 +1,229 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fmadd_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fmadd.h", 3,True)': 0
+        
+fmadd_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,16, "fmadd.h", 3,True)': 0
+        
+fmadd_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,16, "fmadd.h", 3,True)': 0
+        
+fmadd_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,16, "fmadd.h", 3,True)': 0
+        
+fmadd_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,16, "fmadd.h", 3,True)': 0
+        
+fmadd_b6:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b6(flen,16, "fmadd.h", 3,True)': 0
+        
+fmadd_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,16, "fmadd.h", 3,True)': 0
+        
+fmadd_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,16, "fmadd.h", 3,True)': 0
+        
+fmadd_b14:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b14(flen,16, "fmadd.h", 3,True)': 0
+        
+fmadd_b16:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b16(flen,16, "fmadd.h", 3,True)': 0
+        
+fmadd_b17:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b17(flen,16, "fmadd.h", 3,True)': 0
+        
+fmadd_b18:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b18(flen,16, "fmadd.h", 3,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fmax.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fmax.cgf
@@ -1,0 +1,35 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fmax_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmax.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fmax.h", 2,True)': 0
+        
+fmax_b19:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmax.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen,16, "fmax.h", 2,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fmin.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fmin.cgf
@@ -1,0 +1,35 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fmin_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmin.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fmin.h", 2,True)': 0
+       
+fmin_b19:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmin.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen,16, "fmin.h", 2,True)': 0        

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fmsub.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fmsub.cgf
@@ -1,0 +1,229 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fmsub_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fmsub.h", 3,True)': 0
+        
+fmsub_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,16, "fmsub.h", 3,True)': 0
+        
+fmsub_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,16, "fmsub.h", 3,True)': 0
+        
+fmsub_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,16, "fmsub.h", 3,True)': 0
+        
+fmsub_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,16, "fmsub.h", 3,True)': 0
+        
+fmsub_b6:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b6(flen,16, "fmsub.h", 3,True)': 0
+        
+fmsub_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,16, "fmsub.h", 3,True)': 0
+        
+fmsub_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,16, "fmsub.h", 3,True)': 0
+        
+fmsub_b14:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b14(flen,16, "fmsub.h", 3,True)': 0
+        
+fmsub_b16:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b16(flen,16, "fmsub.h", 3,True)': 0
+        
+fmsub_b17:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b17(flen,16, "fmsub.h", 3,True)': 0
+        
+fmsub_b18:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b18(flen,16, "fmsub.h", 3,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fmul.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fmul.cgf
@@ -1,0 +1,155 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fmul_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmul.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fmul.h", 2,True)': 0
+        
+fmul_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmul.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,16, "fmul.h", 2,True)': 0
+        
+fmul_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmul.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,16, "fmul.h", 2,True)': 0
+        
+fmul_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmul.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,16, "fmul.h", 2,True)': 0
+        
+fmul_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmul.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,16, "fmul.h", 2,True)': 0
+
+fmul_b6:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmul.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b6(flen,16, "fmul.h", 2,True)': 0
+        
+fmul_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmul.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,16, "fmul.h", 2,True)': 0
+        
+fmul_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmul.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,16, "fmul.h", 2,True)': 0
+        
+fmul_b9:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fmul.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b9(flen,16, "fmul.h", 2,True)': 0
+

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fnmadd.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fnmadd.cgf
@@ -1,0 +1,229 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fnmadd_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fnmadd.h", 3,True)': 0
+        
+fnmadd_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,16, "fnmadd.h", 3,True)': 0
+        
+fnmadd_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,16, "fnmadd.h", 3,True)': 0
+        
+fnmadd_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,16, "fnmadd.h", 3,True)': 0
+        
+fnmadd_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,16, "fnmadd.h", 3,True)': 0
+        
+fnmadd_b6:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b6(flen,16, "fnmadd.h", 3,True)': 0
+        
+fnmadd_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,16, "fnmadd.h", 3,True)': 0
+        
+fnmadd_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,16, "fnmadd.h", 3,True)': 0
+        
+fnmadd_b14:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b14(flen,16, "fnmadd.h", 3,True)': 0
+                
+fnmadd_b16:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b16(flen,16, "fnmadd.h", 3,True)': 0
+        
+fnmadd_b17:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b17(flen,16, "fnmadd.h", 3,True)': 0
+        
+fnmadd_b18:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmadd.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b18(flen,16, "fnmadd.h", 3,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fnmsub.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fnmsub.cgf
@@ -1,0 +1,229 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fnmsub_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fnmsub.h", 3,True)': 0
+        
+fnmsub_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,16, "fnmsub.h", 3,True)': 0
+        
+fnmsub_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,16, "fnmsub.h", 3,True)': 0
+        
+fnmsub_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,16, "fnmsub.h", 3,True)': 0
+        
+fnmsub_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,16, "fnmsub.h", 3,True)': 0
+        
+fnmsub_b6:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b6(flen,16, "fnmsub.h", 3,True)': 0
+        
+fnmsub_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,16, "fnmsub.h", 3,True)': 0
+        
+fnmsub_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,16, "fnmsub.h", 3,True)': 0
+        
+fnmsub_b14:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b14(flen,16, "fnmsub.h", 3,True)': 0
+        
+fnmsub_b16:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b16(flen,16, "fnmsub.h", 3,True)': 0
+        
+fnmsub_b17:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b17(flen,16, "fnmsub.h", 3,True)': 0
+        
+fnmsub_b18:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fnmsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rs3:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *r4fmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b18(flen,16, "fnmsub.h", 3,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fsgnj.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fsgnj.cgf
@@ -1,0 +1,19 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fsgnj_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsgnj.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fsgnj.h", 2,True)': 0
+        

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fsgnjn.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fsgnjn.cgf
@@ -1,0 +1,19 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fsgnjn_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsgnjn.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fsgnjn.h", 2,True)': 0
+        

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fsgnjx.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fsgnjx.cgf
@@ -1,0 +1,19 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fsgnjx_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsgnjx.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fsgnjx.h", 2,True)': 0
+        

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fsqrt.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fsqrt.cgf
@@ -1,0 +1,136 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fsqrt_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsqrt.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fsqrt.h", 1,True)': 0
+
+fsqrt_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsqrt.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,16, "fsqrt.h", 1,True)': 0
+        
+fsqrt_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsqrt.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,16, "fsqrt.h", 1,True)': 0
+
+fsqrt_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsqrt.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,16, "fsqrt.h", 1,True)': 0
+
+fsqrt_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsqrt.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,16, "fsqrt.h", 1,True)': 0
+
+fsqrt_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsqrt.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,16, "fsqrt.h", 1,True)': 0
+
+fsqrt_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsqrt.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,16, "fsqrt.h", 1,True)': 0
+
+fsqrt_b9:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsqrt.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b9(flen,16, "fsqrt.h", 1,True)': 0
+
+fsqrt_b20:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsqrt.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b20(flen,16, "fsqrt.h", 1,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fsub.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zhinx/rv32h_fsub.cgf
@@ -1,0 +1,188 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fsub_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fsub.h", 2,True)': 0
+        
+fsub_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,16, "fsub.h", 2,True)': 0
+        
+fsub_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,16, "fsub.h", 2,True)': 0
+        
+fsub_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,16, "fsub.h", 2,True)': 0
+        
+fsub_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,16, "fsub.h", 2,True)': 0
+        
+fsub_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,16, "fsub.h", 2,True)': 0
+        
+fsub_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,16, "fsub.h", 2,True)': 0
+        
+fsub_b10:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b10(flen,16, "fsub.h", 2,True)': 0
+        
+fsub_b11:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b11(flen,16, "fsub.h", 2,True)': 0
+        
+fsub_b12:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b12(flen,16, "fsub.h", 2,True)': 0
+        
+fsub_b13:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    opcode: 
+      fsub.h: 0
+    rs1: 
+      <<: *all_regs
+    rs2:
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b13(flen,16, "fsub.h", 2,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV64Zhinx/rv64h_fcvt.l.h.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV64Zhinx/rv64h_fcvt.l.h.cgf
@@ -1,0 +1,106 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+      
+fcvt.l.h_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.l.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fcvt.l.h", 1, True)': 0
+        
+fcvt.l.h_b22:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.l.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b22(flen,16, "fcvt.l.h", 1, True)': 0
+        
+fcvt.l.h_b23:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.l.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b23(flen,16, "fcvt.l.h", 1, True)': 0
+        
+fcvt.l.h_b24:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.l.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b24(flen,16, "fcvt.l.h", 1, True)': 0
+        
+fcvt.l.h_b27:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.l.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b27(flen,16, "fcvt.l.h", 1, True)': 0
+        
+fcvt.l.h_b28:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.l.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b28(flen,16, "fcvt.l.h", 1, True)': 0
+        
+fcvt.l.h_b29:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.l.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b29(flen,16, "fcvt.l.h", 1, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV64Zhinx/rv64h_fcvt.lu.h.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV64Zhinx/rv64h_fcvt.lu.h.cgf
@@ -1,0 +1,106 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+      
+fcvt.lu.h_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.lu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,16, "fcvt.lu.h", 1, True)': 0
+        
+fcvt.lu.h_b22:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.lu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b22(flen,16, "fcvt.lu.h", 1, True)': 0
+        
+fcvt.lu.h_b23:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.lu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b23(flen,16, "fcvt.lu.h", 1, True)': 0
+        
+fcvt.lu.h_b24:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.lu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b24(flen,16, "fcvt.lu.h", 1, True)': 0
+        
+fcvt.lu.h_b27:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.lu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b27(flen,16, "fcvt.lu.h", 1, True)': 0
+        
+fcvt.lu.h_b28:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.lu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b28(flen,16, "fcvt.lu.h", 1, True)': 0
+        
+fcvt.lu.h_b29:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zhinx.*)
+    mnemonics: 
+      fcvt.lu.h: 0
+    rs1: 
+      <<: *all_regs
+    rd: 
+      <<: *all_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b29(flen,16, "fcvt.lu.h", 1, True)': 0


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

#DEVELOPMENT PRs SHOULD BE TO DEV BRANCH ONLY

## Description

- Added cover group format for RV32Zhinx instructions.
- Added cover group format for RV64Zhinx instructions.
- Introduced ZHINX flag to aid the compilation of Half precision floating ops into integer regs.

### Related Issues

> NA

### Update to/for Ratified/Unratified Extensions or to framework

- [ ] Ratified

### List Extensions

- Zhinx

