### PR TITLE
Add support for Zdinx extension

### DIFF
--- a/riscv_ctg/generator.py
+++ b/riscv_ctg/generator.py
@@ -260,7 +260,7 @@ class Generator():
 
 
         is_nan_box = False
-        is_fext = any(['F' in x or 'D' in x or 'Zfh' in x or 'Zfinx' in x for x in opnode['isa']])
+        is_fext = any(['F' in x or 'D' in x or 'Zfh' in x or 'Zfinx' in x or 'Zdinx' in x for x in opnode['isa']])
         is_sgn_extd = True if (inxFlag and iflen <xlen) else False
 
         if is_fext:

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fadd.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fadd.d.cgf
@@ -1,0 +1,188 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fadd.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fadd.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fadd.d", 2, True)': 0
+        
+fadd.d_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fadd.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,64, "fadd.d", 2, True)': 0
+        
+fadd.d_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fadd.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,64, "fadd.d", 2, True)': 0
+        
+fadd.d_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fadd.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,64, "fadd.d", 2, True)': 0
+        
+fadd.d_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fadd.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,64, "fadd.d", 2, True)': 0
+        
+fadd.d_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fadd.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,64, "fadd.d", 2, True)': 0
+        
+fadd.d_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fadd.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,64, "fadd.d", 2, True)': 0
+        
+fadd.d_b10:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fadd.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b10(flen,64, "fadd.d", 2, True)': 0
+        
+fadd.d_b11:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fadd.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b11(flen,64, "fadd.d", 2, True)': 0
+        
+fadd.d_b12:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fadd.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b12(flen,64, "fadd.d", 2, True)': 0
+        
+fadd.d_b13:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fadd.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b13(flen,64, "fadd.d", 2, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fclass.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fclass.d.cgf
@@ -1,0 +1,14 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fclass.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fclass.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fclass.d", 1, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.d.l.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.d.l.cgf
@@ -1,0 +1,14 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+      
+fcvt.d.l_b25:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.d.l: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b25(flen,64, "fcvt.d.l", 1, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.d.lu.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.d.lu.cgf
@@ -1,0 +1,17 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+      
+fcvt.d.lu_b25:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.d.lu: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b25(flen,64, "fcvt.d.lu", 1, True)': 0
+        
+
+

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.d.w.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.d.w.cgf
@@ -1,0 +1,28 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+      
+fcvt.d.w_b25:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.d.w: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b25(flen,32, "fcvt.d.w", 1, True)': 0
+        
+fcvt.d.w_b26:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.d.w: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b26(32, "fcvt.d.w", 1, True)': 0
+

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.d.wu.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.d.wu.cgf
@@ -1,0 +1,28 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+      
+fcvt.d.wu_b25:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx)
+    mnemonics: 
+      fcvt.d.wu: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b25(flen,32, "fcvt.d.wu", 1, True)': 0
+        
+fcvt.d.wu_b26:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx)
+    mnemonics: 
+      fcvt.d.wu: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b26(32, "fcvt.d.wu", 1, True)': 0
+

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.s.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.s.d.cgf
@@ -1,0 +1,106 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fcvt.s.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.s.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fcvt.s.d", 1, True)': 0
+        
+fcvt.s.d_b22:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.s.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b22(flen,64, "fcvt.s.d", 1, True)': 0
+        
+fcvt.s.d_b23:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.s.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b23(flen,64, "fcvt.s.d", 1, True)': 0
+        
+fcvt.s.d_b24:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.s.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b24(flen,64, "fcvt.s.d", 1, True)': 0
+        
+fcvt.s.d_b27:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.s.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b27(flen,64, "fcvt.s.d", 1, True)': 0
+        
+fcvt.s.d_b28:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.s.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b28(flen,64, "fcvt.s.d", 1, True)': 0
+        
+fcvt.s.d_b29:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.s.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b29(flen,64, "fcvt.s.d", 1, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.w.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.w.d.cgf
@@ -1,0 +1,92 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fcvt.w.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.w.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fcvt.w.d", 1,True)': 0
+        
+fcvt.w.d_b22:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.w.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b22(flen,64, "fcvt.w.d", 1,True)': 0
+        
+fcvt.w.d_b23:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.w.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b23(flen,64, "fcvt.w.d", 1,True)': 0
+        
+fcvt.w.d_b24:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.w.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b24(flen,64, "fcvt.w.d", 1,True)': 0
+        
+fcvt.w.d_b27:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.w.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b27(flen,64, "fcvt.w.d", 1, True)': 0
+        
+fcvt.w.d_b28:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.w.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b28(flen,64, "fcvt.w.d", 1, True)': 0
+        
+fcvt.w.d_b29:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.w.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b29(flen,64, "fcvt.w.d", 1,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.wu.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fcvt.wu.d.cgf
@@ -1,0 +1,92 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fcvt.wu.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.wu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fcvt.wu.d", 1, True)': 0
+        
+fcvt.wu.d_b22:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.wu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b22(flen,64, "fcvt.wu.d", 1, True)': 0
+        
+fcvt.wu.d_b23:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.wu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b23(flen,64, "fcvt.wu.d", 1, True)': 0
+        
+fcvt.wu.d_b24:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.wu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b24(flen,64, "fcvt.wu.d", 1, True)': 0
+        
+fcvt.wu.d_b27:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.wu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b27(flen,64, "fcvt.wu.d", 1, True)': 0
+        
+fcvt.wu.d_b28:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.wu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b28(flen,64, "fcvt.wu.d", 1, True)': 0
+        
+fcvt.wu.d_b29:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.wu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b29(flen,64, "fcvt.wu.d", 1,True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fdiv.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fdiv.d.cgf
@@ -1,0 +1,188 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fdiv.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fdiv.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fdiv.d", 2, True)': 0
+        
+fdiv.d_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fdiv.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,64, "fdiv.d", 2, True)': 0
+        
+fdiv.d_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fdiv.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,64, "fdiv.d", 2, True)': 0
+        
+fdiv.d_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fdiv.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,64, "fdiv.d", 2, True)': 0
+        
+fdiv.d_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fdiv.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,64, "fdiv.d", 2, True)': 0
+
+fdiv.d_b6:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fdiv.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b6(flen,64, "fdiv.d", 2, True)': 0
+        
+fdiv.d_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fdiv.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,64, "fdiv.d", 2, True)': 0
+        
+fdiv.d_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fdiv.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,64, "fdiv.d", 2, True)': 0
+        
+fdiv.d_b9:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fdiv.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b9(flen,64, "fdiv.d", 2, True)': 0
+
+fdiv.d_b20:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fdiv.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b20(flen,64, "fdiv.d", 2, True)': 0
+        
+fdiv.d_b21:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fdiv.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b21(flen,64, "fdiv.d", 2, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/feq.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/feq.d.cgf
@@ -1,0 +1,35 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+feq.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      feq.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "feq.d", 2, True)': 0
+        
+feq.d_b19:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      feq.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen,64, "feq.d", 2, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fle.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fle.d.cgf
@@ -1,0 +1,35 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fle.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fle.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fle.d", 2, True)': 0
+        
+fle.d_b19:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fle.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen,64, "fle.d", 2, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/flt.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/flt.d.cgf
@@ -1,0 +1,35 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+flt.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      flt.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "flt.d", 2, True)': 0
+        
+flt.d_b19:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      flt.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *sfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen, 64, "flt.d", 2, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fmax.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fmax.d.cgf
@@ -1,0 +1,35 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fmax.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmax.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fmax.d", 2, True)': 0
+        
+fmax.d_b19:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmax.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen,64, "fmax.d", 2, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fmin.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fmin.d.cgf
@@ -1,0 +1,35 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fmin.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmin.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fmin.d", 2, True)': 0
+        
+fmin.d_b19:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmin.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b19(flen,64, "fmin.d", 2, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fmul.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fmul.d.cgf
@@ -1,0 +1,154 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fmul.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmul.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fmul.d", 2, True)': 0
+        
+fmul.d_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmul.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,64, "fmul.d", 2, True)': 0
+        
+fmul.d_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmul.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,64, "fmul.d", 2, True)': 0
+        
+fmul.d_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmul.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,64, "fmul.d", 2, True)': 0
+        
+fmul.d_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmul.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,64, "fmul.d", 2, True)': 0
+
+fmul.d_b6:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmul.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b6(flen,64, "fmul.d", 2, True)': 0
+        
+fmul.d_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmul.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,64, "fmul.d", 2, True)': 0
+        
+fmul.d_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmul.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,64, "fmul.d", 2, True)': 0
+        
+fmul.d_b9:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fmul.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b9(flen,64, "fmul.d", 2, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fsgnj.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fsgnj.d.cgf
@@ -1,0 +1,19 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fsgnj.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsgnj.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fsgnj.d", 2, True)': 0
+        

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fsgnjn.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fsgnjn.d.cgf
@@ -1,0 +1,17 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+fsgnjn.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsgnjn.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fsgnjn.d", 2, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fsgnjx.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fsgnjx.d.cgf
@@ -1,0 +1,19 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fsgnjx.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsgnjx.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fsgnjx.d", 2, True)': 0
+        

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fsqrt.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fsqrt.d.cgf
@@ -1,0 +1,136 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fsqrt.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsqrt.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fsqrt.d", 1, True)': 0
+
+fsqrt.d_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsqrt.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,64, "fsqrt.d", 1, True)': 0
+        
+fsqrt.d_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsqrt.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,64, "fsqrt.d", 1, True)': 0
+
+fsqrt.d_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsqrt.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,64, "fsqrt.d", 1, True)': 0
+
+fsqrt.d_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsqrt.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,64, "fsqrt.d", 1, True)': 0
+
+fsqrt.d_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsqrt.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,64, "fsqrt.d", 1, True)': 0
+
+fsqrt.d_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsqrt.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,64, "fsqrt.d", 1, True)': 0
+
+fsqrt.d_b9:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsqrt.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b9(flen,64, "fsqrt.d", 1, True)': 0
+
+fsqrt.d_b20:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsqrt.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *ifmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b20(flen,64, "fsqrt.d", 1, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fsub.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV32Zdinx/fsub.d.cgf
@@ -1,0 +1,188 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fsub.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsub.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fsub.d", 2, True)': 0
+        
+fsub.d_b2:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsub.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b2(flen,64, "fsub.d", 2, True)': 0
+        
+fsub.d_b3:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsub.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b3(flen,64, "fsub.d", 2, True)': 0
+        
+fsub.d_b4:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsub.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b4(flen,64, "fsub.d", 2, True)': 0
+        
+fsub.d_b5:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsub.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b5(flen,64, "fsub.d", 2, True)': 0
+        
+fsub.d_b7:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsub.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b7(flen,64, "fsub.d", 2, True)': 0
+        
+fsub.d_b8:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsub.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b8(flen,64, "fsub.d", 2, True)': 0
+        
+fsub.d_b10:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsub.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b10(flen,64, "fsub.d", 2, True)': 0
+        
+fsub.d_b11:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsub.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b11(flen,64, "fsub.d", 2, True)': 0
+        
+fsub.d_b12:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsub.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b12(flen,64, "fsub.d", 2, True)': 0
+        
+fsub.d_b13:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fsub.d: 0
+    rs1: 
+      <<: *pair_regs
+    rs2:
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    op_comb: 
+      <<: *rfmt_op_comb
+    val_comb:
+      abstract_comb:
+        'ibm_b13(flen,64, "fsub.d", 2, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV64Zdinx/fcvt.d.l.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV64Zdinx/fcvt.d.l.cgf
@@ -1,0 +1,14 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+      
+fcvt.d.l_b25:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.d.l: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b25(flen,64, "fcvt.d.l", 1, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV64Zdinx/fcvt.d.lu.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV64Zdinx/fcvt.d.lu.cgf
@@ -1,0 +1,17 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+      
+fcvt.d.lu_b25:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.d.lu: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b25(flen,64, "fcvt.d.lu", 1, True)': 0
+        
+
+

--- a/sample_cgfs/sample_cgfs_fext/RV64Zdinx/fcvt.l.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV64Zdinx/fcvt.l.d.cgf
@@ -1,0 +1,92 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fcvt.l.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.l.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fcvt.l.d", 1, True)': 0
+        
+fcvt.l.d_b22:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.l.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b22(flen,64, "fcvt.l.d", 1, True)': 0
+        
+fcvt.l.d_b23:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.l.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b23(flen,64, "fcvt.l.d", 1, True)': 0
+        
+fcvt.l.d_b24:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.l.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b24(flen,64, "fcvt.l.d", 1, True)': 0
+        
+fcvt.l.d_b27:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.l.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b27(flen,64, "fcvt.l.d", 1, True)': 0
+        
+fcvt.l.d_b28:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.l.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b28(flen,64, "fcvt.l.d", 1, True)': 0
+        
+fcvt.l.d_b29:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.l.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b29(flen,64, "fcvt.l.d", 1, True)': 0

--- a/sample_cgfs/sample_cgfs_fext/RV64Zdinx/fcvt.lu.d.cgf
+++ b/sample_cgfs/sample_cgfs_fext/RV64Zdinx/fcvt.lu.d.cgf
@@ -1,0 +1,92 @@
+# For Licence details look at https://gitlab.com/incoresemi/riscv-compliance/riscv_ctg/-/blob/master/LICENSE.incore
+
+fcvt.lu.d_b1:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.lu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b1(flen,64, "fcvt.lu.d", 1, True)': 0
+        
+fcvt.lu.d_b22:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.lu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b22(flen,64, "fcvt.lu.d", 1, True)': 0
+        
+fcvt.lu.d_b23:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.lu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b23(flen,64, "fcvt.lu.d", 1, True)': 0
+        
+fcvt.lu.d_b24:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.lu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b24(flen,64, "fcvt.lu.d", 1, True)': 0
+        
+fcvt.lu.d_b27:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.lu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b27(flen,64, "fcvt.lu.d", 1, True)': 0
+        
+fcvt.lu.d_b28:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.lu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b28(flen,64, "fcvt.lu.d", 1, True)': 0
+        
+fcvt.lu.d_b29:
+    config: 
+      - check ISA:=regex(.*I.*Zfinx.*Zdinx.*)
+    mnemonics: 
+      fcvt.lu.d: 0
+    rs1: 
+      <<: *pair_regs
+    rd: 
+      <<: *pair_regs
+    val_comb:
+      abstract_comb:
+        'ibm_b29(flen,64, "fcvt.lu.d", 1, True)': 0


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

#DEVELOPMENT PRs SHOULD BE TO DEV BRANCH ONLY

## Description

-  Added cover group format for RV32Zdinx instructions.
-  Added cover group format for RV64Zdinx instructions.
-  Introduced ZDINX flag to aid the compilation of double  precision floating ops into integer regs.
-  For RV32Zdinx, we use the pair register to accommodate 64 bit value. 


Related Issues

    NA

Update to/for Ratified/Unratified Extensions or to framework

   - Ratified

List Extensions

    - Zdinx


